### PR TITLE
feat: add Python CLI entry point with analyze command

### DIFF
--- a/analyzer/src/__main__.py
+++ b/analyzer/src/__main__.py
@@ -1,0 +1,7 @@
+"""Enable running the analyzer as a module via python -m analyzer."""
+
+import sys
+from .main import main
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/analyzer/src/main.py
+++ b/analyzer/src/main.py
@@ -1,0 +1,226 @@
+"""Command-line interface for the documentation analyzer.
+
+This module provides the main entry point for running the analyzer from the
+command line. It uses argparse to handle subcommands and configuration.
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+from .analysis.analyzer import DocumentationAnalyzer
+from .parsers.python_parser import PythonParser
+from .parsers.typescript_parser import TypeScriptParser
+from .scoring.impact_scorer import ImpactScorer
+
+
+def create_analyzer() -> DocumentationAnalyzer:
+    """Create a DocumentationAnalyzer with all available parsers.
+
+    Returns:
+        DocumentationAnalyzer: Configured analyzer instance.
+    """
+    return DocumentationAnalyzer(
+        parsers={
+            'python': PythonParser(),
+            'typescript': TypeScriptParser(),
+            'javascript': TypeScriptParser()
+        },
+        scorer=ImpactScorer()
+    )
+
+
+def format_json(result) -> str:
+    """Format analysis result as JSON.
+
+    Args:
+        result: AnalysisResult object to format.
+
+    Returns:
+        JSON string representation.
+    """
+    # Convert to dictionary for JSON serialization
+    data = {
+        'coverage_percent': result.coverage_percent,
+        'total_items': result.total_items,
+        'documented_items': result.documented_items,
+        'by_language': {
+            lang: {
+                'language': metrics.language,
+                'total_items': metrics.total_items,
+                'documented_items': metrics.documented_items,
+                'coverage_percent': metrics.coverage_percent,
+                'avg_complexity': metrics.avg_complexity,
+                'avg_impact_score': metrics.avg_impact_score
+            }
+            for lang, metrics in result.by_language.items()
+        },
+        'items': [
+            {
+                'name': item.name,
+                'type': item.type,
+                'filepath': item.filepath,
+                'line_number': item.line_number,
+                'language': item.language,
+                'complexity': item.complexity,
+                'impact_score': item.impact_score,
+                'has_docs': item.has_docs,
+                'export_type': item.export_type,
+                'module_system': item.module_system
+            }
+            for item in result.items
+        ]
+    }
+    return json.dumps(data, indent=2)
+
+
+def format_summary(result) -> str:
+    """Format analysis result as human-readable summary.
+
+    Args:
+        result: AnalysisResult object to format.
+
+    Returns:
+        Formatted summary string.
+    """
+    lines = []
+    lines.append("=" * 60)
+    lines.append("Documentation Coverage Analysis")
+    lines.append("=" * 60)
+    lines.append("")
+    lines.append(f"Overall Coverage: {result.coverage_percent:.1f}% "
+                 f"({result.documented_items}/{result.total_items} items)")
+    lines.append("")
+
+    if result.by_language:
+        lines.append("By Language:")
+        lines.append("-" * 60)
+        for lang, metrics in sorted(result.by_language.items()):
+            lines.append(f"  {lang.capitalize()}:")
+            lines.append(f"    Coverage: {metrics.coverage_percent:.1f}% "
+                        f"({metrics.documented_items}/{metrics.total_items})")
+            lines.append(f"    Avg Complexity: {metrics.avg_complexity:.1f}")
+            lines.append(f"    Avg Impact Score: {metrics.avg_impact_score:.1f}")
+            lines.append("")
+
+    # Show undocumented items by priority
+    undocumented = [item for item in result.items if not item.has_docs]
+    if undocumented:
+        lines.append("Top Undocumented Items (by impact):")
+        lines.append("-" * 60)
+        sorted_items = sorted(undocumented, key=lambda x: x.impact_score, reverse=True)
+        for item in sorted_items[:10]:  # Show top 10
+            lines.append(f"  [{item.impact_score:5.1f}] {item.type:8s} "
+                        f"{item.name:30s} ({item.filepath}:{item.line_number})")
+
+        if len(undocumented) > 10:
+            lines.append(f"  ... and {len(undocumented) - 10} more")
+
+    lines.append("")
+    lines.append("=" * 60)
+    return "\n".join(lines)
+
+
+def cmd_analyze(args: argparse.Namespace) -> int:
+    """Handle the analyze subcommand.
+
+    Args:
+        args: Parsed command-line arguments.
+
+    Returns:
+        Exit code (0 for success, 1 for error).
+    """
+    try:
+        # Create analyzer
+        analyzer = create_analyzer()
+
+        # Run analysis
+        if args.verbose:
+            print(f"Analyzing: {args.path}", file=sys.stderr)
+
+        result = analyzer.analyze(args.path, verbose=args.verbose)
+
+        # Format output
+        if args.format == 'json':
+            output = format_json(result)
+        else:  # summary
+            output = format_summary(result)
+
+        # Write to stdout
+        print(output)
+
+        return 0
+
+    except FileNotFoundError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        if args.verbose:
+            import traceback
+            traceback.print_exc(file=sys.stderr)
+        return 1
+
+
+def main(argv: Optional[list] = None) -> int:
+    """Main entry point for the CLI.
+
+    Args:
+        argv: Command-line arguments (defaults to sys.argv).
+
+    Returns:
+        Exit code (0 for success, 1 for error).
+    """
+    parser = argparse.ArgumentParser(
+        prog='analyzer',
+        description='Analyze documentation coverage in Python, TypeScript, and JavaScript codebases'
+    )
+
+    parser.add_argument(
+        '--version',
+        action='version',
+        version='%(prog)s 0.1.0'
+    )
+
+    subparsers = parser.add_subparsers(dest='command', help='Available commands')
+
+    # Analyze command
+    analyze_parser = subparsers.add_parser(
+        'analyze',
+        help='Analyze documentation coverage'
+    )
+    analyze_parser.add_argument(
+        'path',
+        help='Path to file or directory to analyze'
+    )
+    analyze_parser.add_argument(
+        '--format',
+        choices=['json', 'summary'],
+        default='summary',
+        help='Output format (default: summary)'
+    )
+    analyze_parser.add_argument(
+        '--verbose',
+        action='store_true',
+        help='Enable verbose output'
+    )
+
+    # Parse arguments
+    args = parser.parse_args(argv)
+
+    # Handle no command
+    if not args.command:
+        parser.print_help()
+        return 1
+
+    # Dispatch to command handler
+    if args.command == 'analyze':
+        return cmd_analyze(args)
+
+    return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/analyzer/tests/test_cli.py
+++ b/analyzer/tests/test_cli.py
@@ -1,0 +1,229 @@
+"""Tests for the command-line interface."""
+
+import json
+import sys
+from pathlib import Path
+import pytest
+
+# Add parent directory to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from src.main import main, format_json, format_summary, create_analyzer
+from src.analysis.analyzer import DocumentationAnalyzer
+from src.models.analysis_result import AnalysisResult, LanguageMetrics
+from src.models.code_item import CodeItem
+
+
+class TestCLI:
+    """Test suite for command-line interface."""
+
+    @pytest.fixture
+    def examples_dir(self):
+        """Return path to examples directory."""
+        project_root = Path(__file__).parent.parent.parent
+        return str(project_root / 'examples')
+
+    def test_main_no_command(self, capsys):
+        """Test that running without command shows help."""
+        exit_code = main([])
+        captured = capsys.readouterr()
+
+        assert exit_code == 1
+        assert 'usage:' in captured.out or 'usage:' in captured.err
+
+    def test_main_help(self, capsys):
+        """Test help flag."""
+        with pytest.raises(SystemExit) as exc:
+            main(['--help'])
+
+        assert exc.value.code == 0
+        captured = capsys.readouterr()
+        assert 'usage:' in captured.out
+        assert 'analyze' in captured.out
+
+    def test_main_version(self, capsys):
+        """Test version flag."""
+        with pytest.raises(SystemExit) as exc:
+            main(['--version'])
+
+        assert exc.value.code == 0
+        captured = capsys.readouterr()
+        assert 'analyzer' in captured.out
+        assert '0.1.0' in captured.out
+
+    def test_analyze_json_format(self, examples_dir, capsys):
+        """Test analyze command with JSON output."""
+        exit_code = main(['analyze', examples_dir, '--format', 'json'])
+        captured = capsys.readouterr()
+
+        assert exit_code == 0
+
+        # Parse JSON output
+        data = json.loads(captured.out)
+
+        assert 'coverage_percent' in data
+        assert 'total_items' in data
+        assert 'documented_items' in data
+        assert 'by_language' in data
+        assert 'items' in data
+
+        assert isinstance(data['coverage_percent'], (int, float))
+        assert isinstance(data['total_items'], int)
+        assert isinstance(data['documented_items'], int)
+        assert isinstance(data['items'], list)
+
+    def test_analyze_summary_format(self, examples_dir, capsys):
+        """Test analyze command with summary output."""
+        exit_code = main(['analyze', examples_dir, '--format', 'summary'])
+        captured = capsys.readouterr()
+
+        assert exit_code == 0
+        assert 'Documentation Coverage Analysis' in captured.out
+        assert 'Overall Coverage:' in captured.out
+        assert 'By Language:' in captured.out
+
+    def test_analyze_default_format(self, examples_dir, capsys):
+        """Test analyze command with default format (summary)."""
+        exit_code = main(['analyze', examples_dir])
+        captured = capsys.readouterr()
+
+        assert exit_code == 0
+        assert 'Documentation Coverage Analysis' in captured.out
+
+    def test_analyze_verbose(self, examples_dir, capsys):
+        """Test analyze command with verbose flag."""
+        exit_code = main(['analyze', examples_dir, '--verbose'])
+        captured = capsys.readouterr()
+
+        assert exit_code == 0
+        # Verbose messages go to stderr
+        assert 'Analyzing:' in captured.err or len(captured.err) > 0
+
+    def test_analyze_nonexistent_path(self, capsys):
+        """Test analyze command with nonexistent path."""
+        exit_code = main(['analyze', '/nonexistent/path/that/does/not/exist'])
+        captured = capsys.readouterr()
+
+        assert exit_code == 1
+        assert 'Error:' in captured.err
+
+    def test_analyze_single_file(self, capsys):
+        """Test analyzing a single file."""
+        project_root = Path(__file__).parent.parent.parent
+        test_file = project_root / 'examples' / 'test_simple.py'
+
+        exit_code = main(['analyze', str(test_file), '--format', 'json'])
+        captured = capsys.readouterr()
+
+        assert exit_code == 0
+
+        data = json.loads(captured.out)
+        assert data['total_items'] > 0
+        # All items should be Python
+        assert all(item['language'] == 'python' for item in data['items'])
+
+    def test_create_analyzer(self):
+        """Test analyzer factory function."""
+        analyzer = create_analyzer()
+
+        assert isinstance(analyzer, DocumentationAnalyzer)
+        assert 'python' in analyzer.parsers
+        assert 'typescript' in analyzer.parsers
+        assert 'javascript' in analyzer.parsers
+
+    def test_format_json_structure(self):
+        """Test JSON formatting with mock data."""
+        # Create mock result
+        item = CodeItem(
+            name='test_func',
+            type='function',
+            filepath='test.py',
+            line_number=10,
+            language='python',
+            complexity=5,
+            impact_score=25.0,
+            has_docs=True,
+            export_type='named',
+            module_system='esm'
+        )
+
+        metrics = LanguageMetrics(
+            language='python',
+            total_items=1,
+            documented_items=1,
+            coverage_percent=100.0,
+            avg_complexity=5.0,
+            avg_impact_score=25.0
+        )
+
+        result = AnalysisResult(
+            items=[item],
+            coverage_percent=100.0,
+            total_items=1,
+            documented_items=1,
+            by_language={'python': metrics}
+        )
+
+        json_str = format_json(result)
+        data = json.loads(json_str)
+
+        assert data['coverage_percent'] == 100.0
+        assert data['total_items'] == 1
+        assert data['documented_items'] == 1
+        assert 'python' in data['by_language']
+        assert len(data['items']) == 1
+        assert data['items'][0]['name'] == 'test_func'
+
+    def test_format_summary_structure(self):
+        """Test summary formatting with mock data."""
+        item1 = CodeItem(
+            name='documented_func',
+            type='function',
+            filepath='test.py',
+            line_number=10,
+            language='python',
+            complexity=5,
+            impact_score=25.0,
+            has_docs=True,
+            export_type='named',
+            module_system='esm'
+        )
+
+        item2 = CodeItem(
+            name='undocumented_func',
+            type='function',
+            filepath='test.py',
+            line_number=20,
+            language='python',
+            complexity=10,
+            impact_score=50.0,
+            has_docs=False,
+            export_type='named',
+            module_system='esm'
+        )
+
+        metrics = LanguageMetrics(
+            language='python',
+            total_items=2,
+            documented_items=1,
+            coverage_percent=50.0,
+            avg_complexity=7.5,
+            avg_impact_score=37.5
+        )
+
+        result = AnalysisResult(
+            items=[item1, item2],
+            coverage_percent=50.0,
+            total_items=2,
+            documented_items=1,
+            by_language={'python': metrics}
+        )
+
+        summary = format_summary(result)
+
+        assert 'Documentation Coverage Analysis' in summary
+        assert '50.0%' in summary
+        assert '(1/2 items)' in summary
+        assert 'By Language:' in summary
+        assert 'Top Undocumented Items' in summary
+        assert 'undocumented_func' in summary


### PR DESCRIPTION
Implements Step 8 from PLAN.md: Python CLI Entry Point

This PR adds a command-line interface for the Python analyzer with the following features:

## Changes

- Created analyzer/src/main.py with argparse-based CLI
- Created analyzer/src/__main__.py to enable python -m analyzer invocation
- Added analyze command that accepts file or directory path
- Implemented --format flag for json or summary output (default: summary)
- Implemented --verbose flag for detailed progress output
- Proper exit codes (0 for success, 1 for error)
- Error messages go to stderr, data goes to stdout
- JSON format includes all analysis data for machine consumption
- Summary format provides human-readable coverage report with language breakdown

## Testing

Created analyzer/tests/test_cli.py with 12 comprehensive tests:
- CLI argument parsing (help, version, no command)
- JSON and summary output formats
- Verbose mode
- Error handling for nonexistent paths
- Single file analysis
- Analyzer factory function
- Output formatting functions

All 12 tests pass successfully.

## Manual Testing

Verified CLI works correctly:
- python -m src analyze ../examples --format summary (displays readable report)
- python -m src analyze ../examples --format json (outputs valid JSON)
- python -m src analyze ../examples --verbose (shows progress messages)

Closes Step 8 of PLAN.md.