### PR TITLE
feat: add TypeScript CLI foundation with Commander.js

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -17,7 +17,8 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "typescript": "^5.7.3"
+    "typescript": "^5.7.3",
+    "commander": "^13.0.0"
   },
   "devDependencies": {
     "@types/node": "^22.10.5",

--- a/cli/src/commands/analyze.ts
+++ b/cli/src/commands/analyze.ts
@@ -1,0 +1,33 @@
+/**
+ * Analyze command implementation.
+ *
+ * This command analyzes documentation coverage in a codebase by calling
+ * the Python analyzer via subprocess.
+ */
+
+/**
+ * Execute the analyze command.
+ *
+ * @param path - Path to file or directory to analyze
+ * @param options - Command options
+ */
+export async function analyzeCommand(
+  path: string,
+  options: {
+    format?: string;
+    config?: string;
+    verbose?: boolean;
+  }
+): Promise<void> {
+  console.log(`Analyzing: ${path}`);
+  console.log(`Format: ${options.format || 'summary'}`);
+  if (options.config) {
+    console.log(`Config: ${options.config}`);
+  }
+  if (options.verbose) {
+    console.log('Verbose mode enabled');
+  }
+
+  console.log('\nThis command will be fully implemented in Step 11 (TypeScript-Python Bridge).');
+  console.log('Current status: Stub implementation');
+}

--- a/cli/src/commands/audit.ts
+++ b/cli/src/commands/audit.ts
@@ -1,0 +1,31 @@
+/**
+ * Audit command implementation.
+ *
+ * This command audits existing documentation quality by presenting
+ * documented items to the user for rating.
+ */
+
+/**
+ * Execute the audit command.
+ *
+ * @param path - Path to file or directory to audit
+ * @param options - Command options
+ */
+export async function auditCommand(
+  path: string,
+  options: {
+    config?: string;
+    resume?: boolean;
+  }
+): Promise<void> {
+  console.log(`Auditing: ${path}`);
+  if (options.config) {
+    console.log(`Config: ${options.config}`);
+  }
+  if (options.resume) {
+    console.log('Resuming interrupted audit session');
+  }
+
+  console.log('\nThis command will be fully implemented in Step 15 (Audit Command).');
+  console.log('Current status: Stub implementation');
+}

--- a/cli/src/commands/improve.ts
+++ b/cli/src/commands/improve.ts
@@ -1,0 +1,34 @@
+/**
+ * Improve command implementation.
+ *
+ * This command provides an interactive workflow for improving documentation
+ * with Claude AI assistance and plugin validation.
+ */
+
+/**
+ * Execute the improve command.
+ *
+ * @param path - Path to file or directory to improve
+ * @param options - Command options
+ */
+export async function improveCommand(
+  path: string,
+  options: {
+    config?: string;
+    plan?: string;
+  }
+): Promise<void> {
+  console.log(`Improving documentation for: ${path}`);
+  if (options.config) {
+    console.log(`Config: ${options.config}`);
+  }
+  if (options.plan) {
+    console.log(`Plan file: ${options.plan}`);
+  } else {
+    console.log('Plan file: .docimp-plan.json');
+  }
+
+  console.log('\nThis command will be fully implemented in Step 17 (Interactive Improve Workflow).');
+  console.log('Current status: Stub implementation');
+  console.log('\nNote: Requires ANTHROPIC_API_KEY environment variable.');
+}

--- a/cli/src/commands/plan.ts
+++ b/cli/src/commands/plan.ts
@@ -1,0 +1,33 @@
+/**
+ * Plan command implementation.
+ *
+ * This command generates a prioritized documentation improvement plan
+ * by combining missing and poor-quality documentation items.
+ */
+
+/**
+ * Execute the plan command.
+ *
+ * @param path - Path to file or directory to plan
+ * @param options - Command options
+ */
+export async function planCommand(
+  path: string,
+  options: {
+    config?: string;
+    output?: string;
+  }
+): Promise<void> {
+  console.log(`Planning improvements for: ${path}`);
+  if (options.config) {
+    console.log(`Config: ${options.config}`);
+  }
+  if (options.output) {
+    console.log(`Output file: ${options.output}`);
+  } else {
+    console.log('Output file: .docimp-plan.json');
+  }
+
+  console.log('\nThis command will be fully implemented in Step 16 (Plan Command).');
+  console.log('Current status: Stub implementation');
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+
+/**
+ * Main entry point for the DocImp CLI.
+ *
+ * This module sets up Commander.js with subcommands for analyzing,
+ * auditing, planning, and improving documentation coverage.
+ */
+
+import { Command } from 'commander';
+import { analyzeCommand } from './commands/analyze.js';
+import { auditCommand } from './commands/audit.js';
+import { planCommand } from './commands/plan.js';
+import { improveCommand } from './commands/improve.js';
+
+const program = new Command();
+
+program
+  .name('docimp')
+  .description('Impact-driven documentation coverage tool')
+  .version('0.1.0');
+
+// Analyze command
+program
+  .command('analyze')
+  .description('Analyze documentation coverage in a codebase')
+  .argument('<path>', 'Path to file or directory to analyze')
+  .option('--format <format>', 'Output format (json or summary)', 'summary')
+  .option('--config <path>', 'Path to configuration file')
+  .option('--verbose', 'Enable verbose output')
+  .action(analyzeCommand);
+
+// Audit command
+program
+  .command('audit')
+  .description('Audit existing documentation quality')
+  .argument('<path>', 'Path to file or directory to audit')
+  .option('--config <path>', 'Path to configuration file')
+  .option('--resume', 'Resume interrupted audit session')
+  .action(auditCommand);
+
+// Plan command
+program
+  .command('plan')
+  .description('Generate prioritized documentation improvement plan')
+  .argument('<path>', 'Path to file or directory to plan')
+  .option('--config <path>', 'Path to configuration file')
+  .option('--output <file>', 'Output file for plan (default: .docimp-plan.json)')
+  .action(planCommand);
+
+// Improve command
+program
+  .command('improve')
+  .description('Interactively improve documentation with Claude AI')
+  .argument('<path>', 'Path to file or directory to improve')
+  .option('--config <path>', 'Path to configuration file')
+  .option('--plan <file>', 'Plan file to load (default: .docimp-plan.json)')
+  .action(improveCommand);
+
+program.parse(process.argv);


### PR DESCRIPTION
Add TypeScript CLI skeleton with Commander.js for all subcommands.

## Summary

- Add Commander.js dependency to package.json
- Create main CLI entry point (cli/src/index.ts)
- Create stub command files: analyze, audit, plan, improve
- Configure all commands with proper arguments and options
- Add help text for each command
- Verify build process and all commands work

## Testing

Manual smoke testing performed for this skeleton implementation:
- `docimp --help` - Shows main help
- `docimp --version` - Shows version 0.1.0
- `docimp analyze --help` - Shows analyze command help
- `docimp analyze ../examples` - Runs stub implementation
- All other subcommands (audit, plan, improve) work similarly

Note: This is a skeleton implementation with stub commands. Comprehensive unit and integration tests will be added in Step 18 (Testing & CI/CD) once the commands have real implementations to test.

## Implementation Notes

All commands show stub implementations with notes about when they will be fully implemented:
- analyze: Step 11 (TypeScript-Python Bridge)
- audit: Step 15 (Audit Command)
- plan: Step 16 (Plan Command)
- improve: Step 17 (Interactive Improve Workflow)

Generated with Claude Code (https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>