### PR TITLE
fix: add audit and plan JSON files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ dist/
 CLAUDE.md
 CLAUDE_CONTEXT.md
 PLAN.md
+.docimp-audit.json
+.docimp-plan.json


### PR DESCRIPTION
## Summary
Fixes #23 by adding local artifact files to `.gitignore`.

## Changes
- Added `.docimp-audit.json` to `.gitignore`
- Added `.docimp-plan.json` to `.gitignore`

These are local artifacts generated by the `audit` and `plan` commands respectively, and should not be committed to version control (similar to `__pycache__/` or `node_modules/`).

## Testing
- Verified files are in the appropriate "Project-specific" section
- Follows existing `.gitignore` conventions

## Related
- Closes #23
- Part of PR #20 fixes

Generated with Claude Code.