### PR TITLE
refactor: remove audit resume logic for MVP simplification

### DIFF
--- a/analyzer/src/main.py
+++ b/analyzer/src/main.py
@@ -192,15 +192,6 @@ def cmd_audit(args: argparse.Namespace) -> int:
         if args.verbose:
             print(f"Found {len(documented_items)} documented items", file=sys.stderr)
 
-        # Load existing audit results for resume capability
-        audit_results = load_audit_results(Path(args.audit_file))
-
-        # Mark items that have already been audited
-        for item in documented_items:
-            existing_rating = audit_results.get_rating(item.filepath, item.name)
-            if existing_rating is not None:
-                item.audit_rating = existing_rating
-
         # Format output as JSON for TypeScript to consume
         data = {
             'items': [

--- a/cli/src/commands/audit.ts
+++ b/cli/src/commands/audit.ts
@@ -62,33 +62,13 @@ export async function auditCore(
     // Initialize ratings structure
     const ratings: AuditRatings = { ratings: {} };
 
-    // Load existing ratings into ratings structure
-    for (const item of items) {
-      if (item.audit_rating !== undefined && item.audit_rating !== null) {
-        if (!ratings.ratings[item.filepath]) {
-          ratings.ratings[item.filepath] = {};
-        }
-        ratings.ratings[item.filepath][item.name] = item.audit_rating;
-      }
-    }
-
-    // Filter out already-rated items (for resume capability)
-    const unratedItems = items.filter(item => item.audit_rating === undefined || item.audit_rating === null);
-
-    if (unratedItems.length === 0) {
-      terminalDisplay.showMessage('All items have already been audited.');
-      return;
-    }
-
-    terminalDisplay.showMessage(`${unratedItems.length} items remaining to audit.\n`);
-
     // Interactive rating loop
     let audited = 0;
-    for (const item of unratedItems) {
+    for (const item of items) {
       audited++;
 
       // Show progress
-      terminalDisplay.showMessage(`\nAuditing: ${audited}/${unratedItems.length}`);
+      terminalDisplay.showMessage(`\nAuditing: ${audited}/${items.length}`);
       terminalDisplay.showMessage(`${item.type} ${item.name} (${item.language})`);
       terminalDisplay.showMessage(`Location: ${item.filepath}:${item.line_number}`);
       terminalDisplay.showMessage(`Complexity: ${item.complexity}\n`);


### PR DESCRIPTION
## Summary
Fixes #22 by removing resume functionality from the audit command for MVP simplification.

## Changes

### TypeScript (`cli/src/commands/audit.ts`)
- Removed: Loading existing ratings before interactive loop (lines 65-73)
- Removed: Filtering out already-rated items (lines 75-83)
- Removed: "X items remaining" messaging
- Simplified: Progress counter now shows "Auditing X/Y" with total item count

### Python (`analyzer/src/main.py`)
- Removed: Loading audit results and marking items with existing ratings (lines 195-202)
- Simplified: Returns all documented items directly

## Behavior
**Before**: Running `docimp audit` twice would skip already-rated items
**After**: Running `docimp audit` twice shows ALL documented items both times

This is the correct MVP behavior. Resume functionality will be added as a future enhancement with an `--resume` flag.

## What Still Works
- Ratings are saved to `.docimp-audit.json`
- Ratings are loaded by `analyze` command for weighted impact scores
- Simple progress counter "Auditing X/Y"
- All interactive rating options work (0-4, Skip, Quit)

## Testing
- TypeScript builds successfully
- All 75 Python tests pass
- Reduces complexity (removed 29 lines)
- Cleaner code path without resume logic edge cases

## Related
- Closes #22
- Part of PR #20 refinements

Generated with Claude Code.