### PR TITLE
test: add basic smoke tests for audit command

### DIFF
--- a/analyzer/tests/test_audit.py
+++ b/analyzer/tests/test_audit.py
@@ -1,0 +1,244 @@
+"""Basic smoke tests for audit functionality."""
+
+import sys
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+import pytest
+
+# Add parent directory to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from src.audit.quality_rater import (
+    AuditResult,
+    load_audit_results,
+    save_audit_results
+)
+from src.main import cmd_audit, cmd_apply_audit
+
+
+class TestAuditCommand:
+    """Tests for the audit command."""
+
+    @pytest.fixture
+    def mock_analyzer(self):
+        """Create a mock analyzer with documented and undocumented items."""
+        from src.models.code_item import CodeItem
+        from src.models.analysis_result import AnalysisResult
+
+        documented_item = CodeItem(
+            name='documented_func',
+            type='function',
+            filepath='test.py',
+            line_number=10,
+            language='python',
+            complexity=5,
+            impact_score=25.0,
+            has_docs=True,
+            parameters=['x', 'y'],
+            return_type='int',
+            docstring='This function has documentation.',
+            export_type='named',
+            module_system='esm',
+            audit_rating=None
+        )
+
+        undocumented_item = CodeItem(
+            name='undocumented_func',
+            type='function',
+            filepath='test.py',
+            line_number=20,
+            language='python',
+            complexity=3,
+            impact_score=15.0,
+            has_docs=False,
+            parameters=['a'],
+            return_type='str',
+            docstring=None,
+            export_type='named',
+            module_system='esm',
+            audit_rating=None
+        )
+
+        result = AnalysisResult(
+            items=[documented_item, undocumented_item],
+            coverage_percent=50.0,
+            total_items=2,
+            documented_items=1,
+            by_language={}
+        )
+        return result
+
+    def test_audit_finds_documented_items(self, mock_analyzer, capsys):
+        """Test audit command returns only items WITH docs."""
+        import argparse
+
+        with patch('src.main.create_analyzer') as mock_create:
+            mock_create.return_value.analyze.return_value = mock_analyzer
+
+            args = argparse.Namespace(
+                path='./test',
+                verbose=False,
+                audit_file='.docimp-audit.json'
+            )
+
+            exit_code = cmd_audit(args)
+
+            assert exit_code == 0
+
+            captured = capsys.readouterr()
+            output = json.loads(captured.out)
+
+            assert 'items' in output
+            assert len(output['items']) == 1
+            assert output['items'][0]['name'] == 'documented_func'
+
+    def test_audit_excludes_undocumented(self, mock_analyzer, capsys):
+        """Test audit command excludes items without docs."""
+        import argparse
+
+        with patch('src.main.create_analyzer') as mock_create:
+            mock_create.return_value.analyze.return_value = mock_analyzer
+
+            args = argparse.Namespace(
+                path='./test',
+                verbose=False,
+                audit_file='.docimp-audit.json'
+            )
+
+            exit_code = cmd_audit(args)
+
+            assert exit_code == 0
+
+            captured = capsys.readouterr()
+            output = json.loads(captured.out)
+
+            # Should NOT contain undocumented_func
+            item_names = [item['name'] for item in output['items']]
+            assert 'undocumented_func' not in item_names
+
+
+class TestApplyAuditCommand:
+    """Tests for the apply-audit command."""
+
+    def test_apply_audit_saves_ratings(self, tmp_path):
+        """Test apply-audit command persists ratings to JSON."""
+        import argparse
+        from io import StringIO
+
+        audit_file = tmp_path / '.docimp-audit.json'
+
+        audit_data = {
+            'ratings': {
+                'test.py': {
+                    'func1': 3,
+                    'func2': 2
+                }
+            }
+        }
+
+        args = argparse.Namespace(
+            audit_file=str(audit_file),
+            verbose=False
+        )
+
+        # Mock stdin with StringIO
+        mock_stdin = StringIO(json.dumps(audit_data))
+        with patch('sys.stdin', mock_stdin):
+            exit_code = cmd_apply_audit(args)
+
+        assert exit_code == 0
+        assert audit_file.exists()
+
+        # Verify contents
+        with open(audit_file, 'r') as f:
+            saved_data = json.load(f)
+
+        assert saved_data['ratings'] == audit_data['ratings']
+
+
+class TestAuditPersistence:
+    """Tests for audit result persistence."""
+
+    def test_load_audit_empty_file(self):
+        """Test loading when file doesn't exist returns empty."""
+        result = load_audit_results(Path('/nonexistent/path/.docimp-audit.json'))
+
+        assert isinstance(result, AuditResult)
+        assert result.ratings == {}
+
+    def test_load_audit_existing(self, tmp_path):
+        """Test loading existing ratings."""
+        audit_file = tmp_path / '.docimp-audit.json'
+
+        test_data = {
+            'ratings': {
+                'file1.py': {
+                    'func_a': 4,
+                    'func_b': 2
+                },
+                'file2.py': {
+                    'func_c': 3
+                }
+            }
+        }
+
+        with open(audit_file, 'w') as f:
+            json.dump(test_data, f)
+
+        result = load_audit_results(audit_file)
+
+        assert result.ratings == test_data['ratings']
+        assert result.get_rating('file1.py', 'func_a') == 4
+        assert result.get_rating('file2.py', 'func_c') == 3
+
+    def test_save_audit_creates_file(self, tmp_path):
+        """Test saving creates .docimp-audit.json."""
+        audit_file = tmp_path / '.docimp-audit.json'
+
+        audit_result = AuditResult(
+            ratings={
+                'test.py': {
+                    'my_func': 3
+                }
+            }
+        )
+
+        save_audit_results(audit_result, audit_file)
+
+        assert audit_file.exists()
+
+        # Verify contents
+        with open(audit_file, 'r') as f:
+            saved_data = json.load(f)
+
+        assert 'ratings' in saved_data
+        assert saved_data['ratings']['test.py']['my_func'] == 3
+
+    def test_skip_saved_as_none(self, tmp_path):
+        """Test that skipped items are saved as None, not a number."""
+        audit_file = tmp_path / '.docimp-audit.json'
+
+        audit_result = AuditResult(
+            ratings={
+                'test.py': {
+                    'rated_func': 3,
+                    'skipped_func': None
+                }
+            }
+        )
+
+        save_audit_results(audit_result, audit_file)
+
+        # Load and verify
+        with open(audit_file, 'r') as f:
+            saved_data = json.load(f)
+
+        assert saved_data['ratings']['test.py']['rated_func'] == 3
+        assert saved_data['ratings']['test.py']['skipped_func'] is None
+
+        # Also verify through load function
+        loaded = load_audit_results(audit_file)
+        assert loaded.get_rating('test.py', 'rated_func') == 3
+        assert loaded.get_rating('test.py', 'skipped_func') is None


### PR DESCRIPTION
## Summary

Adds 7 basic smoke tests for the audit command functionality implemented in PR #20, as requested in issue #24.

## Tests Added

**TestAuditCommand (2 tests):**
- `test_audit_finds_documented_items` - Verifies audit command returns only items WITH docs
- `test_audit_excludes_undocumented` - Verifies undocumented items are excluded

**TestApplyAuditCommand (1 test):**
- `test_apply_audit_saves_ratings` - Verifies apply-audit command persists ratings to JSON

**TestAuditPersistence (4 tests):**
- `test_load_audit_empty_file` - Tests loading when file does not exist returns empty
- `test_load_audit_existing` - Tests loading existing ratings from file
- `test_save_audit_creates_file` - Tests saving creates .docimp-audit.json
- `test_skip_saved_as_none` - Tests that skipped items are saved as None, not a number

## Testing

All tests pass:
```bash
python -m pytest tests/test_audit.py -v
# 7 passed in 0.13s
```

All existing tests still pass:
```bash
python -m pytest tests/ -v
# 82 passed in 9.28s
```

## Notes

- These are basic smoke tests for MVP functionality
- Comprehensive testing will come in Step 18
- Tests follow existing patterns (pytest fixtures, tmp_path, mocking)
- All tests document expected behavior with clear docstrings

Resolves #24