### PR TITLE
fix: add 'interface' as valid code element type

### DIFF
--- a/cli/src/types/analysis.ts
+++ b/cli/src/types/analysis.ts
@@ -7,14 +7,14 @@
  */
 
 /**
- * Represents a parsed code item (function, class, or method).
+ * Represents a parsed code item (function, class, method, or interface).
  */
 export interface CodeItem {
-  /** Function, class, or method name */
+  /** Function, class, method, or interface name */
   name: string;
 
   /** Type of code element */
-  type: 'function' | 'class' | 'method';
+  type: 'function' | 'class' | 'method' | 'interface';
 
   /** Absolute path to source file */
   filepath: string;
@@ -91,11 +91,11 @@ export interface AnalysisResult {
  * Audit item with documentation for quality rating.
  */
 export interface AuditItem {
-  /** Function, class, or method name */
+  /** Function, class, method, or interface name */
   name: string;
 
   /** Type of code element */
-  type: 'function' | 'class' | 'method';
+  type: 'function' | 'class' | 'method' | 'interface';
 
   /** Absolute path to source file */
   filepath: string;
@@ -136,11 +136,11 @@ export interface AuditRatings {
  * Plan item for documentation improvement.
  */
 export interface PlanItem {
-  /** Function, class, or method name */
+  /** Function, class, method, or interface name */
   name: string;
 
   /** Type of code element */
-  type: 'function' | 'class' | 'method';
+  type: 'function' | 'class' | 'method' | 'interface';
 
   /** Absolute path to source file */
   filepath: string;


### PR DESCRIPTION
## Summary

Fixes #35 

Updates TypeScript type definitions to include `'interface'` as a valid code element type.

## Problem

The Python TypeScript parser returns `'interface'` for TypeScript interfaces, but the TypeScript type definitions were restricted to:
```typescript
type: 'function' | 'class' | 'method';
```

This caused type mismatches when processing interface items.

## Changes

Updated three interface definitions in `cli/src/types/analysis.ts`:
- `CodeItem.type` (line 17)
- `AuditItem.type` (line 98)
- `PlanItem.type` (line 143)

Now includes `'interface'` in the union type:
```typescript
type: 'function' | 'class' | 'method' | 'interface';
```

Also updated JSDoc comments to reflect the inclusion of interfaces.

## Testing

- TypeScript build succeeds (`npm run build`)
- No type errors
- Verified with plan output that includes interface items

## Related

Part of Step 16 (Plan Command) cleanup before merging to main.