### PR TITLE
Fix default export detection in TypeScript parser (Issue #48)

### DIFF
--- a/cli/src/parsers/ts-js-parser-helper.ts
+++ b/cli/src/parsers/ts-js-parser-helper.ts
@@ -124,14 +124,14 @@ function getExportType(node: ts.Node): 'named' | 'default' | 'internal' {
     if (ts.canHaveModifiers(node)) {
         const modifiers = ts.getModifiers(node);
         if (modifiers) {
-            for (const modifier of modifiers) {
-                if (modifier.kind === ts.SyntaxKind.ExportKeyword) {
-                    // Check if it's a default export
-                    if (node.parent && ts.isExportAssignment(node.parent)) {
-                        return 'default';
-                    }
-                    return 'named';
-                }
+            const hasExport = modifiers.some(m => m.kind === ts.SyntaxKind.ExportKeyword);
+            const hasDefault = modifiers.some(m => m.kind === ts.SyntaxKind.DefaultKeyword);
+
+            if (hasExport && hasDefault) {
+                return 'default';
+            }
+            if (hasExport) {
+                return 'named';
             }
         }
     }


### PR DESCRIPTION
## Summary

Fixes #48 by correcting the `getExportType()` function in the TypeScript parser helper to properly detect default exports.

## Problem

The parser was incorrectly identifying all `export default` statements as named exports because it only checked for the `ExportKeyword` modifier and didn't check for the `DefaultKeyword` modifier.

## Solution

Modified `getExportType()` to check for both modifiers using `Array.some()`:
- `export` + `default` keywords → return `'default'`
- `export` keyword only → return `'named'`  
- no export keyword → return `'internal'`

## Test Results

- **Before**: Test "should detect default export" was FAILING (expected 'default', got 'named')
- **After**: Test "should detect default export" is PASSING ✓

All previously passing tests remain passing (no regressions).

## Changes

- `cli/src/parsers/ts-js-parser-helper.ts`: Updated `getExportType()` function (lines 122-145)

## Verification

```bash
cd cli
npm run build
npm test -- ts-js-parser.test.ts
```

Test "should detect default export" now passes.

---

Generated with Claude Code