### PR TITLE
Fix interface JSDoc detection in TypeScript parser

### DIFF
--- a/cli/src/parsers/ts-js-parser-helper.ts
+++ b/cli/src/parsers/ts-js-parser-helper.ts
@@ -69,11 +69,6 @@ function calculateComplexity(node: ts.Node): number {
  * Extract JSDoc comment from a node
  */
 function getDocstring(node: ts.Node, sourceFile: ts.SourceFile): string | null {
-    const jsDocTags = ts.getJSDocTags(node);
-    if (jsDocTags.length === 0) {
-        return null;
-    }
-
     const fullText = sourceFile.getFullText();
     const jsDocComments = ts.getJSDocCommentsAndTags(node);
 
@@ -89,7 +84,7 @@ function getDocstring(node: ts.Node, sourceFile: ts.SourceFile): string | null {
  * Check if node has JSDoc documentation
  */
 function hasDocumentation(node: ts.Node): boolean {
-    return ts.getJSDocTags(node).length > 0;
+    return ts.getJSDocCommentsAndTags(node).length > 0;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #49 - TypeScript parser now correctly detects JSDoc comments on interfaces and other constructs with description-only JSDoc (no tags).

## Problem

The parser helper was using `ts.getJSDocTags()` which only detects JSDoc with tags (`@param`, `@returns`, etc.) and missed simple description comments:

```typescript
/**
 * User interface  ← This was not detected
 */
export interface User {
  id: string;
  name: string;
}
```

## Changes

Updated two functions in `cli/src/parsers/ts-js-parser-helper.ts`:

1. **`getDocstring()`** - Removed check for `getJSDocTags()`, directly use `getJSDocCommentsAndTags()`
2. **`hasDocumentation()`** - Changed from `getJSDocTags()` to `getJSDocCommentsAndTags()`

## Impact

This fix benefits **all** TypeScript/JavaScript constructs:
- Interfaces (primary issue)
- Functions with description-only JSDoc
- Classes with description-only JSDoc
- Methods with description-only JSDoc

## Testing

✓ All 20 parser tests passing (20/20)
✓ Interface test "should parse interfaces" now passes
✓ No regressions in existing tests

## Test Case

The failing test at `cli/src/__tests__/parsers/ts-js-parser.test.ts:421-443` now passes:

```typescript
it('should parse interfaces', async () => {
  const filepath = await createTestFile(
    'interface.ts',
    `
    /**
     * User interface
     */
    export interface User {
      id: string;
      name: string;
    }
    `
  );

  const items = parseFile(filepath);

  expect(items[0].has_docs).toBe(true); // ✓ Now passes
});
```

## Related Issues

- #49: Fix interface JSDoc detection in TypeScript parser (this PR)
- #45: Jest test suite improvements (parent issue)
- #44: Fix parser helper tests failing on import.meta (previously fixed)