### PR TITLE
Fix: Resolve paths to absolute before passing to Python subprocess

### DIFF
--- a/cli/src/python-bridge/PythonBridge.ts
+++ b/cli/src/python-bridge/PythonBridge.ts
@@ -76,11 +76,15 @@ export class PythonBridge implements IPythonBridge {
    * @throws Error if Python process fails or returns invalid JSON
    */
   async analyze(options: AnalyzeOptions): Promise<AnalysisResult> {
+    // Resolve path to absolute before passing to Python subprocess
+    // This is necessary because the subprocess runs with CWD set to analyzer/
+    const absolutePath = resolve(process.cwd(), options.path);
+
     const args = [
       '-m',
       'src.main',
       'analyze',
-      options.path,
+      absolutePath,
       '--format',
       'json',
     ];
@@ -100,11 +104,14 @@ export class PythonBridge implements IPythonBridge {
    * @throws Error if Python process fails or returns invalid JSON
    */
   async audit(options: AuditOptions): Promise<AuditListResult> {
+    // Resolve path to absolute before passing to Python subprocess
+    const absolutePath = resolve(process.cwd(), options.path);
+
     const args = [
       '-m',
       'src.main',
       'audit',
-      options.path,
+      absolutePath,
     ];
 
     if (options.auditFile) {
@@ -186,11 +193,14 @@ export class PythonBridge implements IPythonBridge {
    * @throws Error if Python process fails or returns invalid JSON
    */
   async plan(options: PlanOptions): Promise<PlanResult> {
+    // Resolve path to absolute before passing to Python subprocess
+    const absolutePath = resolve(process.cwd(), options.path);
+
     const args = [
       '-m',
       'src.main',
       'plan',
-      options.path,
+      absolutePath,
     ];
 
     if (options.auditFile) {


### PR DESCRIPTION
## Summary

Fixes a bug where running `docimp analyze .` from the project root only discovered Python files, missing TypeScript and JavaScript files entirely.

## Problem

When running `docimp analyze .` from the project root, the Python subprocess executes with its working directory set to `analyzer/`. This caused relative paths like `.` to be interpreted as the `analyzer/` directory instead of the project root, so only Python files within `analyzer/` were discovered.

**Before fix:**
```
By Language:
  Python        98.9%         368/372
```

**After fix:**
```
By Language:
  JavaScript    91.2%         31/34
  Python        98.1%         371/378
  TypeScript    91.2%         114/125
```

## Solution

Modified `PythonBridge.ts` to resolve all paths to absolute using `resolve(process.cwd(), path)` before passing them to the Python subprocess.

Applied the fix to three methods:
- `analyze()` - analyzes codebase documentation coverage
- `audit()` - finds documented items for quality rating
- `plan()` - generates improvement plans

## Changes

- **File:** `cli/src/python-bridge/PythonBridge.ts`
- **Lines changed:** +13 -3
- Added path resolution in 3 methods using `resolve(process.cwd(), options.path)`

## Testing

- All TypeScript tests pass (8 suites, 132 tests)
- Manual verification: `docimp analyze .` now correctly finds all 3 languages
- No regressions in existing functionality

## Test Plan

Run the following commands to verify:

```bash
# From project root
docimp analyze .

# Should show all 3 languages in "By Language" section:
# - JavaScript
# - Python  
# - TypeScript
```