### PR TITLE
fix: complete path validation integration

### DIFF
--- a/analyzer/src/main.py
+++ b/analyzer/src/main.py
@@ -421,13 +421,14 @@ def cmd_apply(args: argparse.Namespace) -> int:
         docstring = apply_data.get('docstring')
         language = apply_data.get('language')
         line_number = apply_data.get('line_number')
+        base_path = apply_data.get('base_path', '/')
 
         if not all([filepath, item_name, item_type, docstring, language]):
             print("Error: Missing required fields in apply data", file=sys.stderr)
             return 1
 
-        # Create writer
-        writer = DocstringWriter()
+        # Create writer with base_path for path validation
+        writer = DocstringWriter(base_path=base_path)
 
         # Write docstring
         if args.verbose:

--- a/cli/src/commands/improve.ts
+++ b/cli/src/commands/improve.ts
@@ -129,6 +129,7 @@ export async function improveCommand(
       pluginManager,
       styleGuide,
       tone,
+      basePath: resolve(process.cwd(), path),
     });
 
     // Run the session

--- a/cli/src/python-bridge/IPythonBridge.ts
+++ b/cli/src/python-bridge/IPythonBridge.ts
@@ -95,6 +95,9 @@ export interface ApplyData {
 
   /** Line number where item is located */
   line_number?: number;
+
+  /** Base directory for path validation (files must be within this directory) */
+  base_path?: string;
 }
 
 /**

--- a/cli/src/session/InteractiveSession.ts
+++ b/cli/src/session/InteractiveSession.ts
@@ -37,6 +37,9 @@ export interface SessionOptions {
 
   /** Documentation tone */
   tone: string;
+
+  /** Base directory for path validation */
+  basePath: string;
 }
 
 /**
@@ -54,6 +57,7 @@ export class InteractiveSession {
   private styleGuide: string;
   private tone: string;
   private editorLauncher: EditorLauncher;
+  private basePath: string;
 
   /**
    * Create a new interactive session.
@@ -67,6 +71,7 @@ export class InteractiveSession {
     this.styleGuide = options.styleGuide;
     this.tone = options.tone;
     this.editorLauncher = new EditorLauncher();
+    this.basePath = options.basePath;
   }
 
   /**
@@ -380,6 +385,7 @@ export class InteractiveSession {
         docstring: docstring,
         language: item.language,
         line_number: item.line_number,
+        base_path: this.basePath,
       });
 
       return true;


### PR DESCRIPTION
## Summary

Fixes the critical integration bug in PR #133 where `DocstringWriter` used the Python subprocess CWD as `base_path`, causing all legitimate file writes to fail in production.

**Parent PR**: #133

## The Problem

The original PR added path traversal validation but didn't properly integrate it with the production code path:

- Python subprocess runs with `cwd: this.analyzerModule` (= `/path/to/docimp/analyzer`)
- `DocstringWriter()` defaulted to `base_path = Path.cwd().resolve()` 
- User project files at `/home/user/myproject/src/foo.py` were rejected as "outside allowed directory"
- Result: **All writes would fail in production**

The test fixture used `base_path='/'` which masked this bug.

## The Solution

Pass the correct `base_path` (user's project directory) through the TypeScript → Python boundary:

1. **TypeScript interface**: Add `base_path?: string` to `ApplyData`
2. **InteractiveSession**: Accept and store `basePath`, pass to `apply()`
3. **improve.ts**: Pass `resolve(process.cwd(), path)` as basePath
4. **Python main.py**: Extract `base_path` from JSON, pass to `DocstringWriter`
5. **Tests**: Add integration test validating realistic workflow

## Changes

### TypeScript Layer
- `cli/src/python-bridge/IPythonBridge.ts`: Add `base_path` field to interface
- `cli/src/session/InteractiveSession.ts`: Store and pass basePath
- `cli/src/commands/improve.ts`: Provide project path as basePath

### Python Layer
- `analyzer/src/main.py`: Use base_path from JSON with fallback to `/`

### Tests
- `analyzer/tests/test_writer.py`: Add `test_improve_workflow_integration()`

## Test Results

**Python**: ✓ 119 tests passed (added 1 new integration test)
**TypeScript**: ✓ 137 tests passed
**Build**: ✓ TypeScript compiles successfully

## Integration Test

The new test simulates the actual production scenario:
- Creates a mock user project outside analyzer directory
- Uses project root as `base_path` (not subprocess CWD)
- Verifies files within project are accepted
- Verifies docstrings are written correctly

## Design Decision

**base_path = resolve(process.cwd(), path)**

This uses the analyzed directory as the security boundary:
- `docimp improve ./myproject` → `base_path = /abs/path/to/myproject`
- Intuitive and covers primary use case
- Already available in TypeScript layer

## Verification

After merging this into the parent PR, the complete fix will:
1. Preserve the security validation from PR #133
2. Work correctly in production (no spurious rejections)
3. Have comprehensive test coverage (119 Python, 137 TypeScript)
4. Include integration test for the full workflow