### PR TITLE
Add validation for invalid audit ratings (Issue #156)

### DIFF
--- a/analyzer/src/main.py
+++ b/analyzer/src/main.py
@@ -317,6 +317,20 @@ def cmd_plan(args: argparse.Namespace) -> int:
             quality_threshold=args.quality_threshold
         )
 
+        # Display warning if invalid ratings were found
+        if plan.invalid_ratings_count > 0:
+            if args.verbose:
+                # Show detailed warnings for each invalid rating
+                for inv in plan.invalid_ratings:
+                    print(f"Warning: Invalid audit rating {inv['rating']} for {inv['name']} "
+                          f"in {inv['filepath']} (expected 1-4), skipped",
+                          file=sys.stderr)
+            else:
+                # Show summary warning
+                print(f"Warning: {plan.invalid_ratings_count} invalid audit rating(s) skipped. "
+                      f"Run with --verbose for details.",
+                      file=sys.stderr)
+
         # Save plan to file
         plan_file = Path(args.plan_file)
         save_plan(plan, plan_file)


### PR DESCRIPTION
## Summary
Adds validation to prevent invalid audit ratings from being silently accepted and applied. Users are notified via warnings when invalid ratings are encountered.

## Problem
The `generate_plan()` function accepted audit ratings without validating they're in the expected 1-4 range. Corrupted audit data (e.g., rating=999) would be silently accepted, leading to incorrect prioritization and making debugging difficult.

## Changes

### PlanResult Dataclass
- Added `invalid_ratings_count` field to track number of skipped invalid ratings
- Added `invalid_ratings` field to store details for debugging (filepath, name, rating)

### Validation Logic in generate_plan()
- Validate ratings are in range 1-4 before applying
- Skip invalid ratings (don't apply them to items)
- Collect invalid rating details for reporting

### User Notification in cmd_plan()
- Summary warning by default: "Warning: N invalid audit rating(s) skipped. Run with --verbose for details."
- Detailed warnings with --verbose: Shows each invalid rating with filepath, name, and value
- Warnings go to stderr (standard for CLI tools)

## Testing
Added 4 comprehensive test cases:
- `test_generate_plan_skips_invalid_ratings`: Verifies only valid ratings are applied
- `test_generate_plan_tracks_invalid_ratings_count`: Verifies count accuracy
- `test_generate_plan_tracks_invalid_ratings_details`: Verifies details list contains correct info
- `test_generate_plan_invalid_rating_boundaries`: Tests edge cases (0, -1, 5, 999)

All 167 tests pass (no regressions).

## Benefits
- User is informed when audit data is corrupted
- Invalid ratings don't silently affect prioritization
- Debugging is easier with detailed warning output
- Clean separation: data processing in generate_plan(), presentation in cmd_plan()

## Fixes
Closes #156

Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>