### PR TITLE
Fix #191: Add directory validation to test fixture generation

### DIFF
--- a/test-samples/test-workflows.sh
+++ b/test-samples/test-workflows.sh
@@ -151,6 +151,13 @@ import json
 import sys
 from pathlib import Path
 
+# Validate we're in the right directory
+base_dir = Path.cwd()
+if not (base_dir / 'src' / 'python' / 'calculator.py').exists():
+    print("ERROR: Script must be run from example-project/ directory", file=sys.stderr)
+    print(f"Current directory: {base_dir}", file=sys.stderr)
+    sys.exit(1)
+
 try:
     # Load expected audit ratings
     with open('../expected-results.json') as f:
@@ -166,7 +173,6 @@ try:
     # Convert to audit.json format with absolute paths
     # The plan_generator expects paths to be resolvable to match analysis results
     ratings = {}
-    base_dir = Path.cwd()  # Current directory (example-project/)
     for filepath, items in expected['sample_audit_ratings']['ratings'].items():
         # Resolve relative path to absolute path
         abs_path = str((base_dir / filepath).resolve())


### PR DESCRIPTION
## Summary

Adds directory validation to the Python fixture generation script in `test-workflows.sh` to ensure it's running from the correct directory before attempting path resolution.

## Changes

- Add validation check for `src/python/calculator.py` existence
- Fail fast with clear error message if not in correct directory
- Show current directory in error message for debugging
- Consolidate `base_dir` assignment (remove duplicate)

## Testing

- All tests in `test-workflows.sh` pass (24/24)
- Fixture generation works correctly when run from repository root
- Script would fail gracefully if somehow run from wrong directory

## Related

- Fixes #191
- Part of PR #170 Round 2 cleanup (PLAN_PR170_ROUND2.md)

Generated with [Claude Code](https://claude.com/claude-code)