### PR TITLE
Add update-expected-results.sh script for test maintenance (Issues #195, #201)

### DIFF
--- a/test-samples/README.md
+++ b/test-samples/README.md
@@ -336,9 +336,11 @@ When you make intentional changes to the example-project code or when parser imp
    - `sample_audit_ratings`
    - `expected_plan_items`
    - `notes`
-4. Add version field (`version: "1.0"`)
+4. Add version field (`version: "1.0"`) for backward compatibility tracking (Issue #201)
 5. Output to `expected-results-new.json` for review
 6. Show a diff of what changed
+
+**Version Field**: The `version` field indicates the schema version of `expected-results.json`. Currently at "1.0". This field should be incremented if the structure of expected-results.json changes in breaking ways (e.g., renaming fields, changing data types, or adding required fields).
 
 **Review workflow:**
 
@@ -373,12 +375,14 @@ git commit -m "Update expected results after [description of change]"
 
 The following sections in `expected-results.json` are **NOT** auto-generated and must be updated manually when needed:
 
+- **`description`**: Human-readable description of the file's purpose
+- **`note`**: Important context about how values are generated
 - **`high_priority_items`**: Representative sample of high-impact items for validation
 - **`sample_audit_ratings`**: Consistent audit ratings for workflow B testing
 - **`expected_plan_items`**: Expected plan counts for both workflows A and B
 - **`notes`**: Important context about exclusions, restoration, etc.
 
-If you modify these sections, the update script will preserve your changes.
+If you modify these sections, the update script will preserve your changes. The `description` and `note` fields have sensible defaults if missing.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

Creates automated script to regenerate `expected-results.json` from actual analysis results, addressing the maintenance burden of hardcoded test expectations.

## Changes

### New Files

- **`test-samples/scripts/update-expected-results.sh`**
  - Runs `docimp analyze` on example-project
  - Extracts `analysis` section from actual results
  - Preserves manually-maintained sections (high_priority_items, sample_audit_ratings, etc.)
  - Adds `version: "1.0"` field (addresses Issue #201)
  - Outputs to `expected-results-new.json` for review (safe, non-destructive)
  - Shows diff and provides clear next-step instructions
  - Includes color-coded output for clarity
  - Validates prerequisites (jq, docimp command)

### Updated Files

- **`test-samples/README.md`**
  - New "Maintenance" section with detailed usage instructions
  - Documents when to regenerate vs when to investigate unexpected changes
  - Explains manually-maintained sections that script preserves
  - Provides review workflow guidance

## Issues Addressed

- Closes #195: Hardcoded item counts in test expectations make maintenance harder
- Closes #201: Test samples should be versioned (adds version field)

## Testing

- [x] Script runs successfully from repository root
- [x] Script runs successfully from test-samples directory
- [x] Generated JSON is valid (verified with jq)
- [x] All top-level sections preserved (analysis, high_priority_items, sample_audit_ratings, expected_plan_items, notes)
- [x] Version field added to output
- [x] Diff output shows changes clearly
- [x] No emojis or unprofessional formatting

## Related

Part of PR #170 Round 2 cleanup (see `.planning/PLAN_PR170_ROUND2.md`).