### PR TITLE
docs: update documentation for state directory architecture (TASKS 6-7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Interactive workflow:
   - S = Skip (saves null for later review)
   - Q = Quit (stops audit)
 - Calculates weighted coverage score
-- Saves results to `.docimp-audit.json`
+- Saves results to `.docimp/session-reports/audit.json`
 
 ### Plan
 
@@ -256,6 +256,54 @@ docimp improve ./src
 - JSDoc types are incorrect or missing
 - Style guide violations (preferred tags, punctuation)
 - Missing examples for public APIs
+
+---
+
+## Workflows
+
+DocImp supports two monodirectional workflows in MVP:
+
+### Workflow A: analyze → plan → improve
+**Complexity-only** impact scoring (no audit)
+
+```bash
+docimp analyze ./src
+docimp plan ./src
+docimp improve ./src
+```
+
+Best for: Quick start, small codebases, first-time users
+
+### Workflow B: analyze → audit → plan → improve
+**Quality-weighted** impact scoring (with audit)
+
+```bash
+docimp analyze ./src
+docimp audit ./src      # Rate existing documentation quality
+docimp plan ./src       # Generates plan with quality-adjusted priorities
+docimp improve ./src
+```
+
+Best for: Large codebases, teams prioritizing documentation quality
+
+### State Directory (.docimp/)
+
+DocImp stores session data in `.docimp/` (similar to `.git/`):
+
+```
+.docimp/
+├── session-reports/
+│   ├── audit.json          # Latest audit ratings
+│   ├── plan.json           # Latest improvement plan
+│   └── analyze-latest.json # Latest analysis
+└── history/                # Future: audit history
+```
+
+**Auto-clean behavior**: `docimp analyze` clears old session reports by default
+- Prevents stale audit/plan data
+- Use `--keep-old-reports` flag to preserve existing reports
+
+**Note**: `.docimp/` is gitignored automatically. Restore clean state with `rm -rf .docimp/`
 
 ---
 

--- a/cli/src/python-bridge/IPythonBridge.ts
+++ b/cli/src/python-bridge/IPythonBridge.ts
@@ -30,7 +30,7 @@ export interface AuditOptions {
   /** Path to audit */
   path: string;
 
-  /** Path to audit file (default: .docimp-audit.json) */
+  /** Path to audit file (default: .docimp/session-reports/audit.json) */
   auditFile?: string;
 
   /** Enable verbose output */
@@ -44,10 +44,10 @@ export interface PlanOptions {
   /** Path to analyze */
   path: string;
 
-  /** Path to audit file (default: .docimp-audit.json) */
+  /** Path to audit file (default: .docimp/session-reports/audit.json) */
   auditFile?: string;
 
-  /** Path to save plan file (default: .docimp-plan.json) */
+  /** Path to save plan file (default: .docimp/session-reports/plan.json) */
   planFile?: string;
 
   /** Quality threshold for including audited items (default: 2) */
@@ -126,7 +126,7 @@ export interface IPythonBridge {
    * Save audit ratings to file.
    *
    * @param ratings - Audit ratings to persist
-   * @param auditFile - Path to audit file (default: .docimp-audit.json)
+   * @param auditFile - Path to audit file (default: .docimp/session-reports/audit.json)
    * @returns Promise resolving when ratings are saved
    * @throws Error if Python process fails
    */

--- a/cli/src/python-bridge/PythonBridge.ts
+++ b/cli/src/python-bridge/PythonBridge.ts
@@ -180,7 +180,7 @@ export class PythonBridge implements IPythonBridge {
    * Save audit ratings to file.
    *
    * @param ratings - Audit ratings to persist
-   * @param auditFile - Path to audit file (default: .docimp-audit.json)
+   * @param auditFile - Path to audit file (default: .docimp/session-reports/audit.json)
    * @returns Promise resolving when ratings are saved
    * @throws Error if Python process fails
    */


### PR DESCRIPTION
## Summary

Completes TASKS 6-7 from `PLAN_INTERRUPTION.md`, finalizing the state directory refactoring documentation work.

## Changes

### TASK 6: GitHub Issues for Future Enhancements
- **Issue #215**: Feature: Report ignored files in `docimp analyze` output
- **Issue #216**: Feature: Support bidirectional and iterative workflows
- Created new labels: `post-mvp`, `needs-design`

### TASK 7: Documentation Updates

**README.md**:
- Added new "Workflows" section explaining two monodirectional workflows:
  - Workflow A: `analyze → plan → improve` (complexity-only)
  - Workflow B: `analyze → audit → plan → improve` (with quality ratings)
- Documented `.docimp/` state directory structure
- Updated audit path reference: `.docimp-audit.json` → `.docimp/session-reports/audit.json`

**TypeScript Interface Comments**:
- Updated `IPythonBridge.ts` default path comments
- Updated `PythonBridge.ts` JSDoc comments
- All references now use `.docimp/session-reports/` structure

**Local Documentation** (gitignored, not in PR):
- `CLAUDE.md`: Added comprehensive state directory section, StateManager examples, workflow clarifications
- `.planning/PLAN.md`: Added note in Step 18 referencing PLAN_INTERRUPTION work

## Test Results

All tests passing:
- Python: 181 tests passed
- Workflow integration: 27 tests passed

## Related Work

This completes the documentation portion of the state directory refactoring initiated in PLAN_INTERRUPTION.md. Previous implementation work completed via:
- PR #147: State directory structure (TASK 1)
- PR #149: Auto-clean on analyze (TASK 2)
- PR #154: Apply audit ratings in plan (TASK 3)
- PR #168: Audit summary report (TASK 4)
- PR #170: Test sample codebase (TASK 5)

## Checklist

- [x] README.md updated with workflows and state directory info
- [x] TypeScript interface comments updated
- [x] GitHub issues created (#215, #216)
- [x] Local documentation updated (CLAUDE.md, .planning/PLAN.md)
- [x] All tests passing
- [x] No old path references remain in user-facing docs