### PR TITLE
Fix: Add atomic file writes with validation in DocstringWriter (Issue #100)

### DIFF
--- a/analyzer/src/writer/docstring_writer.py
+++ b/analyzer/src/writer/docstring_writer.py
@@ -4,6 +4,7 @@ This module handles writing documentation to Python, TypeScript, and JavaScript
 files while preserving formatting and ensuring idempotent operations.
 """
 
+import datetime
 import os
 import re
 import shutil
@@ -263,7 +264,17 @@ class DocstringWriter:
         self._check_disk_space(file_path, required_bytes)
 
         # Create backup and temp file paths
-        backup_path = file_path.with_suffix(file_path.suffix + '.bak')
+        # Use timestamp to avoid collisions with existing .bak files
+        timestamp = datetime.datetime.now().strftime('%Y%m%d_%H%M%S_%f')
+        backup_path = file_path.with_suffix(f'{file_path.suffix}.{timestamp}.bak')
+
+        # Safety check: verify backup path is unique (should always be true with microseconds)
+        if backup_path.exists():
+            raise IOError(
+                f"Backup path collision: '{backup_path}' already exists. "
+                f"This should not happen with timestamp-based naming."
+            )
+
         temp_path = None  # Initialize to avoid NameError if mkstemp fails
 
         try:


### PR DESCRIPTION
Fixes #100

## Summary

Implement atomic write operations with comprehensive validation to prevent file corruption on write failures in DocstringWriter.

## Changes

### New Helper Methods
- `_check_disk_space()` - Verifies sufficient disk space before writing (with 10% buffer)
- `_validate_write()` - Reads back written content to verify it matches expected content
- `_safe_restore()` - Safely restores from backup with detailed error reporting

### Refactored `write_docstring()` Method
Uses atomic write pattern:
1. Write to temp file in same directory (enables atomic rename)
2. Validate temp file content before committing
3. Create backup of original only after temp file validated
4. Use `os.replace()` for atomic rename operation
5. Improved error handling and cleanup in all paths

## Test Coverage

Added 5 comprehensive tests in `TestAtomicWrites` class:
- `test_successful_atomic_write` - Verifies temp file creation and atomic rename flow
- `test_disk_full_scenario` - Simulates disk full and verifies original file untouched
- `test_write_validation_failure` - Verifies validation catches content mismatches
- `test_restore_failure_handling` - Verifies restore failures are properly reported
- `test_atomic_rename_behavior` - Verifies `os.replace()` is used for atomicity

All 23 writer tests pass.

## Testing

```bash
/Users/nik/miniconda3/envs/docimp/bin/python -m pytest analyzer/tests/test_writer.py -v
```

Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>