### PR TITLE
Fix: Handle backup file path collisions with timestamps (Issue #246)

### DIFF
--- a/analyzer/src/writer/docstring_writer.py
+++ b/analyzer/src/writer/docstring_writer.py
@@ -4,6 +4,7 @@ This module handles writing documentation to Python, TypeScript, and JavaScript
 files while preserving formatting and ensuring idempotent operations.
 """
 
+import datetime
 import os
 import re
 import shutil
@@ -240,7 +241,17 @@ class DocstringWriter:
         self._check_disk_space(file_path, required_bytes)
 
         # Create backup and temp file paths
-        backup_path = file_path.with_suffix(file_path.suffix + '.bak')
+        # Use timestamp to avoid collisions with existing .bak files
+        timestamp = datetime.datetime.now().strftime('%Y%m%d_%H%M%S_%f')
+        backup_path = file_path.with_suffix(f'{file_path.suffix}.{timestamp}.bak')
+
+        # Safety check: verify backup path is unique (should always be true with microseconds)
+        if backup_path.exists():
+            raise IOError(
+                f"Backup path collision: '{backup_path}' already exists. "
+                f"This should not happen with timestamp-based naming."
+            )
+
         temp_path = None  # Initialize to avoid NameError if mkstemp fails
 
         try:


### PR DESCRIPTION
Fixes #246

## Summary

Use timestamp-based backup naming to avoid overwriting existing .bak files.

## Changes

- Add `datetime` import
- Backup path format: `{filename}.{extension}.{timestamp}.bak`
- Timestamp includes microseconds for uniqueness
- Safety check verifies no collision (should never happen)
- Test verifies pre-existing .bak files are preserved

## Benefits

- Never overwrites user's manual backups
- Timestamp in filename helps debugging
- Simple implementation (no loops)
- Still cleans up properly in finally block

## Testing

Added `test_backup_collision_handling()` to verify behavior when .bak file pre-exists.

All atomic write tests pass (7/7).

## Related Issues

- #61 - Backup Files Accumulate Without Cleanup (already fixed)
- #100 - Add atomic file writes with validation
- #197 - No testing for concurrent DocImp command execution

Found in PR #244 code review.

Generated with [Claude Code](https://claude.com/claude-code)