### PR TITLE
Fix: Track errors in improve workflow session summary (Issue #219)

### DIFF
--- a/cli/src/__tests__/session/InteractiveSession.test.ts
+++ b/cli/src/__tests__/session/InteractiveSession.test.ts
@@ -582,7 +582,7 @@ describe('InteractiveSession', () => {
 
       // Progress string for item 3 should include error count
       expect(consoleSpy).toHaveBeenCalledWith(
-        expect.stringMatching(/\[3\/3\].*1 errors/)
+        expect.stringMatching(/\[3\/3\].*1 error/)
       );
     });
   });

--- a/cli/src/__tests__/session/ProgressTracker.test.ts
+++ b/cli/src/__tests__/session/ProgressTracker.test.ts
@@ -199,7 +199,7 @@ describe('ProgressTracker', () => {
 
       const progressString = tracker.getProgressString();
 
-      expect(progressString).toBe('3/10 items (1 accepted, 1 skipped, 1 errors)');
+      expect(progressString).toBe('3/10 items (1 accepted, 1 skipped, 1 error)');
     });
 
     it('should not include errors in progress string when zero', () => {

--- a/cli/src/session/InteractiveSession.ts
+++ b/cli/src/session/InteractiveSession.ts
@@ -126,7 +126,7 @@ export class InteractiveSession {
     let docstring = await this.requestSuggestion(item);
 
     if (!docstring) {
-      console.log(chalk.red('Failed to generate suggestion. Skipping item.'));
+      console.log(chalk.red('Failed to generate suggestion.'));
       tracker.recordError();
       return true; // Continue to next item
     }

--- a/cli/src/session/ProgressTracker.ts
+++ b/cli/src/session/ProgressTracker.ts
@@ -107,7 +107,8 @@ export class ProgressTracker {
     const { completedItems, totalItems, acceptedItems, skippedItems, errorItems } = this.getProgress();
     const parts = [`${acceptedItems} accepted`, `${skippedItems} skipped`];
     if (errorItems > 0) {
-      parts.push(`${errorItems} errors`);
+      const errorText = errorItems === 1 ? 'error' : 'errors';
+      parts.push(`${errorItems} ${errorText}`);
     }
     return `${completedItems}/${totalItems} items (${parts.join(', ')})`;
   }


### PR DESCRIPTION
## Summary

Fixes #219 - Errors in the improve workflow are now properly counted and displayed in the session summary.

## Changes

### ProgressTracker Updates
- Add `errorItems` field to track error count separately
- Implement `recordError()` method to increment both completed and error counts
- Update `getProgressString()` to include errors in progress display (only when > 0)
- Update `SessionProgress` interface to include `errorItems`

### InteractiveSession Updates
- Call `tracker.recordError()` when initial suggestion fails
- Call `tracker.recordError()` when write to file fails
- Update `showSummary()` to conditionally display error count (only if > 0)

### Exhaustive Test Coverage

Following the `exhaustive-testing` skill requirements, comprehensive tests have been added:

**Integration Tests (5 new):**
- Track errors when initial suggestion fails
- Track errors when write to file fails
- Track multiple errors across items (5 item scenario: accept, error, error, skip, accept)
- Don't show errors in summary when count is zero
- Show errors in progress string during workflow

**Regression Test (1 new):**
- Reproduce exact Issue #219 scenario where items "disappeared" from summary
- Verify all 4 items accounted for (2 accepted + 2 errors)
- Prevents future regression of this specific bug

**Enhanced Existing Tests (2 modified):**
- Update suggestion failure test to verify error count in summary
- Update write failure test to verify error count in summary

**Unit Tests (6 from previous commit):**
- ProgressTracker initialization with errorItems
- recordError() single and multiple
- Mixed operations (accepts, skips, errors)
- getProgressString() with and without errors

**Test Summary:**
- Total new tests: 6 integration/regression tests
- Total enhanced tests: 2 existing tests
- Total unit tests: 6 (from previous commit)
- All 263 TypeScript tests pass
- All 279 Python tests pass

## Design Decisions

**Regeneration failures NOT counted as errors**: When regeneration fails, the user stays in the interactive loop and can still accept, edit, skip, or try again. Errors are only recorded when an item is actually abandoned due to failure.

**Conditional display**: Error count only appears in summary when > 0, avoiding the implication that errors are expected.

## Example Output

Before (items 2-3 had errors):
```
Session Summary
  Total items: 18
  Completed: 1
  Accepted: 1
  Skipped: 0
  (Quit at item 4)
```

After:
```
Session Summary
  Total items: 18
  Completed: 3
  Accepted: 1
  Skipped: 0
  Errors: 2
  (Quit at item 4)
```

## Testing

- TypeScript tests: 263 passed (6 new)
- Python tests: 279 passed
- Linter: No new warnings introduced
- All existing functionality preserved
- Exhaustive test coverage per skill requirements

## Commits

1. Add error tracking to ProgressTracker (Issue #219)
2. Track errors in InteractiveSession improve workflow (Issue #219)
3. Add comprehensive tests for error tracking (Issue #219)
4. Add exhaustive test coverage for error tracking (Issue #219)

Co-Authored-By: Claude <noreply@anthropic.com>