### PR TITLE
Add JSDoc @param documentation for command options

### DIFF
--- a/cli/src/commands/analyze.ts
+++ b/cli/src/commands/analyze.ts
@@ -19,6 +19,10 @@ import type { IDisplay } from '../display/IDisplay.js';
  *
  * @param path - Path to file or directory to analyze
  * @param options - Command options
+ * @param options.format - Output format (json or summary)
+ * @param options.config - Path to configuration file
+ * @param options.verbose - Enable verbose output
+ * @param options.keepOldReports - Preserve existing audit and plan files
  * @param bridge - Python bridge instance (injected for testing)
  * @param display - Display instance (injected for testing)
  */
@@ -107,6 +111,10 @@ export async function analyzeCore(
  *
  * @param path - Path to file or directory to analyze
  * @param options - Command options
+ * @param options.format - Output format (json or summary)
+ * @param options.config - Path to configuration file
+ * @param options.verbose - Enable verbose output
+ * @param options.keepOldReports - Preserve existing audit and plan files
  */
 export async function analyzeCommand(
   path: string,

--- a/cli/src/commands/audit.ts
+++ b/cli/src/commands/audit.ts
@@ -74,6 +74,8 @@ export function calculateAuditSummary(
  *
  * @param path - Path to file or directory to audit
  * @param options - Command options
+ * @param options.auditFile - Path to audit file for storing ratings
+ * @param options.verbose - Enable verbose output
  * @param bridge - Python bridge instance (injected for testing)
  * @param display - Display instance (injected for testing)
  * @param config - Config instance (injected for testing)
@@ -358,6 +360,8 @@ export async function auditCore(
  *
  * @param path - Path to file or directory to audit
  * @param options - Command options
+ * @param options.auditFile - Path to audit file for storing ratings
+ * @param options.verbose - Enable verbose output
  */
 export async function auditCommand(
   path: string,

--- a/cli/src/commands/improve.ts
+++ b/cli/src/commands/improve.ts
@@ -29,6 +29,15 @@ import type { IConfig } from '../config/IConfig.js';
  *
  * @param path - Path to file or directory to improve
  * @param options - Command options
+ * @param options.config - Path to configuration file
+ * @param options.planFile - Path to plan file containing improvement items
+ * @param options.pythonStyle - Python documentation style guide
+ * @param options.javascriptStyle - JavaScript documentation style guide
+ * @param options.typescriptStyle - TypeScript documentation style guide
+ * @param options.tone - Documentation tone (concise, friendly, technical)
+ * @param options.nonInteractive - Run in non-interactive mode
+ * @param options.verbose - Enable verbose output
+ * @param options.listStyles - List available style guides and exit
  */
 export async function improveCommand(
   path: string,

--- a/cli/src/commands/plan.ts
+++ b/cli/src/commands/plan.ts
@@ -17,6 +17,10 @@ import type { IDisplay } from '../display/IDisplay.js';
  *
  * @param path - Path to file or directory to analyze
  * @param options - Command options
+ * @param options.auditFile - Path to audit file containing quality ratings
+ * @param options.planFile - Path to plan file for saving improvement plan
+ * @param options.qualityThreshold - Quality threshold for filtering items
+ * @param options.verbose - Enable verbose output
  * @param bridge - Python bridge instance (injected for testing)
  * @param display - Display instance (injected for testing)
  */
@@ -109,6 +113,10 @@ export async function planCore(
  *
  * @param path - Path to file or directory to analyze
  * @param options - Command options
+ * @param options.auditFile - Path to audit file containing quality ratings
+ * @param options.planFile - Path to plan file for saving improvement plan
+ * @param options.qualityThreshold - Quality threshold for filtering items
+ * @param options.verbose - Enable verbose output
  */
 export async function planCommand(
   path: string,


### PR DESCRIPTION
## Summary
Added missing JSDoc @param documentation for command options across all command files to improve IDE support and reduce linting warnings.

## Changes Made
Added detailed @param documentation for options parameters in the following files:

- **cli/src/commands/analyze.ts**
  - analyzeCore: Added @param docs for format, config, verbose, keepOldReports
  - analyzeCommand: Added @param docs for format, config, verbose, keepOldReports

- **cli/src/commands/audit.ts**
  - auditCore: Added @param docs for auditFile, verbose
  - auditCommand: Added @param docs for auditFile, verbose

- **cli/src/commands/plan.ts**
  - planCore: Added @param docs for auditFile, planFile, qualityThreshold, verbose
  - planCommand: Added @param docs for auditFile, planFile, qualityThreshold, verbose

- **cli/src/commands/improve.ts**
  - improveCommand: Added @param docs for config, planFile, pythonStyle, javascriptStyle, typescriptStyle, tone, nonInteractive, verbose, listStyles

## Benefits
- Better IDE autocomplete and hover documentation
- Reduced linting warnings in CI/CD
- Improved developer experience and code maintainability
- Consistent documentation across all command files

Fixes #262