### PR TITLE
Document Git 2.28+ requirement and fix CI badge (Issue #330)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 DocImp analyzes your Python, TypeScript, and JavaScript codebases to identify undocumented code, prioritizes it by impact score, and uses Claude AI to generate high-quality documentation with validation gates.
 
-[![CI Status](https://github.com/USERNAME/docimp/workflows/CI/badge.svg)](https://github.com/USERNAME/docimp/actions)
+[![CI Status](https://github.com/nikblanchet/docimp/workflows/CI/badge.svg)](https://github.com/nikblanchet/docimp/actions)
 [![Python 3.13](https://img.shields.io/badge/python-3.13-blue.svg)](https://www.python.org/downloads/)
 [![Node.js 22](https://img.shields.io/badge/node-22-green.svg)](https://nodejs.org/)
 [![License: AGPL-3.0 or Commercial](https://img.shields.io/badge/License-AGPL%20v3%20%7C%20Commercial-blue.svg)](./LICENSE)
@@ -88,7 +88,7 @@ DocImp treats JavaScript as a **first-class language**, not just "TypeScript tha
 
 ```bash
 # Clone and install from source
-git clone https://github.com/USERNAME/docimp.git
+git clone https://github.com/nikblanchet/docimp.git
 cd docimp
 
 # Install Python dependencies
@@ -148,16 +148,16 @@ docimp improve ./src
 
 - **Python**: 3.13 (untested on other versions)
 - **Node.js**: 22 (untested on other versions)
-- **Git**: 2.x or higher (Git CLI is required for rollback/undo functionality)
+- **Git**: 2.28 or later (Git CLI is required for rollback/undo functionality)
 - **Claude API Key**: From [console.anthropic.com](https://console.anthropic.com)
 
-**Note on Git**: DocImp uses the Git CLI to track documentation changes for rollback capability. If Git is not installed, DocImp will run without rollback features (graceful degradation). Future versions will include Dulwich (Apache 2.0 license) as a pure-Python fallback.
+**Note on Git**: DocImp uses the Git CLI to track documentation changes for rollback capability. The transaction system requires Git 2.28+ (released July 2020) for improved working tree handling with `--git-dir` and `--work-tree` flags. Check your version with `git --version`. If Git is not installed or is older than 2.28, DocImp will run without rollback features (graceful degradation). See the [Git installation guide](https://git-scm.com/downloads) for installation instructions. Future versions will include Dulwich (Apache 2.0 license) as a pure-Python fallback.
 
 ### Install from Source
 
 ```bash
 # Clone repository
-git clone https://github.com/USERNAME/docimp.git
+git clone https://github.com/nikblanchet/docimp.git
 cd docimp
 
 # Install Python dependencies
@@ -1080,7 +1080,7 @@ Contributions welcome! See `CONTRIBUTING.md` for guidelines.
 
 ```bash
 # Clone repository
-git clone https://github.com/USERNAME/docimp.git
+git clone https://github.com/nikblanchet/docimp.git
 cd docimp
 
 # Python setup


### PR DESCRIPTION
## Summary

This PR addresses Issue #330 by documenting the Git 2.28+ requirement and also fixes the broken CI status badge.

Resolves #330

## Changes to README.md

### 1. Fixed CI Status Badge (Line 7)
- **Before**: `https://github.com/USERNAME/docimp/...`
- **After**: `https://github.com/nikblanchet/docimp/...`
- Badge now displays correctly on GitHub

### 2. Fixed Repository Clone URLs
Updated all 3 clone URL instances:
- Line 91: Quick Start section
- Line 160: Installation section
- Line 1083: Contributing section
- All changed from `USERNAME` to `nikblanchet`

### 3. Updated Git Version Requirement (Line 151)
- **Before**: `Git: 2.x or higher`
- **After**: `Git: 2.28 or later`
- Specifies exact minimum version required by transaction system

### 4. Enhanced Git Documentation (Line 154)
Comprehensive Git note now includes:
- Explicit version requirement (Git 2.28+)
- Technical reason: improved working tree handling with `--git-dir` and `--work-tree` flags
- Release date context (July 2020 - widely available)
- How to check version: `git --version`
- Link to [Git installation guide](https://git-scm.com/downloads)
- Clarified graceful degradation behavior (runs without rollback if Git unavailable)

## Testing

- [x] Verified CI badge displays correctly
- [x] Validated all links work
- [x] Checked markdown rendering
- [x] Confirmed no other USERNAME placeholders remain

## Impact

- **Priority**: Low (documentation-only)
- **Effort**: Small (<30 minutes)
- **Risk**: None - no code changes
- **Files**: 1 (README.md)
- **Lines**: 6 locations updated

Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>