### PR TITLE
Add WARP.md to shared files infrastructure (Issue #347)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ dist/
 .vscode/
 .idea/
 .warp/              # Warp terminal configuration
+WARP.md             # Warp terminal AI documentation (symlinked)
 
 # Editor temporary files
 *~


### PR DESCRIPTION
## Summary

Add WARP.md support to the shared files infrastructure, following the same pattern as CLAUDE.md and other symlinked files.

## Changes

- **Add WARP.md to .gitignore** in OS/IDE section (alongside .vscode, .idea, .warp)
- **Update create_worktree.py script** to automatically create WARP.md symlink in new worktrees
- **Create WARP.md symlinks** in existing worktrees (issue-80)
- **Point WARP.md to CLAUDE.md** (same target as CLAUDE.md symlink)

## Implementation Details

- WARP.md symlinks point directly to `../../.docimp-shared/CLAUDE.md` (same target as CLAUDE.md)
- Main repo keeps existing `WARP.md -> CLAUDE.md` symlink (symlink chain works fine)
- All new worktrees will automatically get WARP.md symlink via updated script

## Testing

- ✅ Verified WARP.md resolves to correct content in all worktrees
- ✅ Verified symlink chain (WARP.md -> CLAUDE.md -> shared file) works correctly
- ✅ Tested create_worktree.py creates proper symlinks

## Related

Closes #347

---

**Note**: This PR includes changes to the docimp repo only. The create_worktree.py script is maintained in a separate skills repository and has been committed there separately.