### PR TITLE
Fix WARP.md .gitignore pattern (Issue #347)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,8 @@ dist/
 .DS_Store
 .vscode/
 .idea/
-.warp/              # Warp terminal configuration
-WARP.md             # Warp terminal AI documentation (symlinked)
+.warp/
+WARP.md
 
 # Editor temporary files
 *~


### PR DESCRIPTION
## Problem

WARP.md was showing as untracked in git status despite being in .gitignore.

## Root Cause

The .gitignore pattern had trailing spaces before the comment:
```
WARP.md             # Warp terminal AI documentation (symlinked)
```

Gitignore treats everything before `#` as the pattern, so git was looking for `"WARP.md             "` (with 13 trailing spaces) instead of `"WARP.md"`.

## Fix

Remove comments from .warp/ and WARP.md entries for consistency:
```diff
-.warp/              # Warp terminal configuration
-WARP.md             # Warp terminal AI documentation (symlinked)
+.warp/
+WARP.md
```

## Verification

- `git check-ignore -v WARP.md` now correctly matches the pattern
- WARP.md no longer shows as untracked in git status

## Related

Issue #347

---

**Note**: This is a follow-up fix to PR #348 which added WARP.md infrastructure.