### PR TITLE
Modernize datetime handling and add Black/Ruff enforcement (Issue #319)

### DIFF
--- a/analyzer/pyproject.toml
+++ b/analyzer/pyproject.toml
@@ -1,0 +1,35 @@
+[tool.ruff]
+# Exclude test directories and virtual environments
+exclude = [
+    ".venv",
+    "venv",
+    "__pycache__",
+    ".pytest_cache",
+]
+
+# Python 3.13+ required
+target-version = "py313"
+
+# Line length limit (88 chars is Black default)
+line-length = 88
+
+[tool.ruff.lint]
+# Enable pycodestyle (E), pyflakes (F), and flake8-datetimez (DTZ)
+# E: pycodestyle errors (including E501 line too long)
+# F: pyflakes (undefined names, unused imports, etc.)
+# DTZ: flake8-datetimez (timezone-naive datetime usage)
+#
+# DTZ rules prevent timezone-naive datetime usage:
+# DTZ001: datetime.datetime() without tzinfo
+# DTZ002: datetime.datetime.today()
+# DTZ003: datetime.datetime.utcnow() [deprecated in Python 3.12+]
+# DTZ004: datetime.datetime.utcfromtimestamp() [deprecated in Python 3.12+]
+# DTZ005: datetime.datetime.now() without tz parameter
+# DTZ006: datetime.datetime.fromtimestamp() without tz parameter
+# DTZ007: datetime.datetime.strptime() without %z
+# DTZ011: datetime.date.today()
+# DTZ012: datetime.date.fromtimestamp()
+select = ["E", "F", "DTZ"]
+
+# Don't ignore any rules - we want strict enforcement
+ignore = []

--- a/analyzer/src/__main__.py
+++ b/analyzer/src/__main__.py
@@ -3,5 +3,5 @@
 import sys
 from .main import main
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/analyzer/src/analysis/__init__.py
+++ b/analyzer/src/analysis/__init__.py
@@ -3,4 +3,4 @@
 from .analyzer import DocumentationAnalyzer
 from .coverage_calculator import CoverageCalculator
 
-__all__ = ['DocumentationAnalyzer', 'CoverageCalculator']
+__all__ = ["DocumentationAnalyzer", "CoverageCalculator"]

--- a/analyzer/src/analysis/analyzer.py
+++ b/analyzer/src/analysis/analyzer.py
@@ -27,32 +27,32 @@ class DocumentationAnalyzer:
 
     # Default file patterns to exclude during discovery
     DEFAULT_EXCLUDES = {
-        'node_modules',
-        'venv',
-        '__pycache__',
-        'dist',
-        'build',
-        '.git',
-        '.pytest_cache',
-        '.mypy_cache',
-        'coverage',
-        '.tox',
-        'eggs',
-        '.eggs',
-        'tests',  # Exclude test directories
-        'test',   # Common test directory name
-        '__tests__',  # Jest convention
+        "node_modules",
+        "venv",
+        "__pycache__",
+        "dist",
+        "build",
+        ".git",
+        ".pytest_cache",
+        ".mypy_cache",
+        "coverage",
+        ".tox",
+        "eggs",
+        ".eggs",
+        "tests",  # Exclude test directories
+        "test",  # Common test directory name
+        "__tests__",  # Jest convention
     }
 
     # File extension to language mapping
     EXTENSION_MAP = {
-        '.py': 'python',
-        '.ts': 'typescript',
-        '.tsx': 'typescript',
-        '.js': 'javascript',
-        '.jsx': 'javascript',
-        '.cjs': 'javascript',
-        '.mjs': 'javascript',
+        ".py": "python",
+        ".ts": "typescript",
+        ".tsx": "typescript",
+        ".js": "javascript",
+        ".jsx": "javascript",
+        ".cjs": "javascript",
+        ".mjs": "javascript",
     }
 
     def __init__(
@@ -60,7 +60,7 @@ class DocumentationAnalyzer:
         parsers: Dict[str, BaseParser],
         scorer: ImpactScorer,
         calculator: Optional[CoverageCalculator] = None,
-        exclude_patterns: Optional[Set[str]] = None
+        exclude_patterns: Optional[Set[str]] = None,
     ) -> None:
         """Initialize the analyzer with injected dependencies.
 
@@ -81,7 +81,9 @@ class DocumentationAnalyzer:
         if exclude_patterns:
             self.exclude_patterns.update(exclude_patterns)
 
-    def analyze(self, path: str, verbose: bool = False, strict: bool = False) -> AnalysisResult:
+    def analyze(
+        self, path: str, verbose: bool = False, strict: bool = False
+    ) -> AnalysisResult:
         """Analyze documentation coverage for a codebase.
 
         Args:
@@ -130,7 +132,8 @@ class DocumentationAnalyzer:
         if len(all_items) == 0 and len(parse_failures) > 0:
             raise ValueError(
                 f"Failed to parse all {len(parse_failures)} files. "
-                f"No code items could be analyzed. Check file syntax and parser compatibility."
+                f"No code items could be analyzed. Check file syntax and "
+                f"parser compatibility."
             )
 
         # Calculate impact scores for all items
@@ -148,7 +151,7 @@ class DocumentationAnalyzer:
             total_items=len(all_items),
             documented_items=documented_count,
             by_language=by_language,
-            parse_failures=parse_failures
+            parse_failures=parse_failures,
         )
 
     def _discover_files(self, path: Path) -> List[Path]:
@@ -191,7 +194,9 @@ class DocumentationAnalyzer:
         """
         return filepath.suffix in self.EXTENSION_MAP
 
-    def _parse_file(self, filepath: Path, strict: bool = False) -> tuple[List[CodeItem], Optional[ParseFailure]]:
+    def _parse_file(
+        self, filepath: Path, strict: bool = False
+    ) -> tuple[List[CodeItem], Optional[ParseFailure]]:
         """Parse a single file using the appropriate language parser.
 
         Args:
@@ -229,11 +234,14 @@ class DocumentationAnalyzer:
             if strict:
                 raise
             # Handle expected parsing errors gracefully - capture first line of error
-            error_msg = str(e).split('\n')[0] or "Unknown parse error"
+            error_msg = str(e).split("\n")[0] or "Unknown parse error"
             print(f"Warning: Failed to parse {filepath}: {error_msg}", file=sys.stderr)
             return [], ParseFailure(filepath=str(filepath), error=error_msg)
         except Exception as e:
             # Unexpected errors indicate programming errors - log and re-raise
-            error_msg = str(e).split('\n')[0] or "Unknown error"
-            print(f"Error: Unexpected exception parsing {filepath}: {error_msg}", file=sys.stderr)
+            error_msg = str(e).split("\n")[0] or "Unknown error"
+            print(
+                f"Error: Unexpected exception parsing {filepath}: {error_msg}",
+                file=sys.stderr,
+            )
             raise

--- a/analyzer/src/analysis/coverage_calculator.py
+++ b/analyzer/src/analysis/coverage_calculator.py
@@ -27,7 +27,9 @@ class CoverageCalculator:
         documented = sum(1 for item in items if item.has_docs)
         return (documented / len(items)) * 100.0
 
-    def calculate_by_language(self, items: List[CodeItem]) -> Dict[str, LanguageMetrics]:
+    def calculate_by_language(
+        self, items: List[CodeItem]
+    ) -> Dict[str, LanguageMetrics]:
         """Calculate coverage metrics broken down by programming language.
 
         Args:
@@ -53,11 +55,13 @@ class CoverageCalculator:
             # Calculate averages
             avg_complexity = (
                 sum(item.complexity for item in lang_items) / total
-                if total > 0 else 0.0
+                if total > 0
+                else 0.0
             )
             avg_impact = (
                 sum(item.impact_score for item in lang_items) / total
-                if total > 0 else 0.0
+                if total > 0
+                else 0.0
             )
 
             metrics[language] = LanguageMetrics(
@@ -66,7 +70,7 @@ class CoverageCalculator:
                 documented_items=documented,
                 coverage_percent=coverage,
                 avg_complexity=avg_complexity,
-                avg_impact_score=avg_impact
+                avg_impact_score=avg_impact,
             )
 
         return metrics

--- a/analyzer/src/audit/__init__.py
+++ b/analyzer/src/audit/__init__.py
@@ -2,4 +2,4 @@
 
 from .quality_rater import AuditResult, load_audit_results, save_audit_results
 
-__all__ = ['AuditResult', 'load_audit_results', 'save_audit_results']
+__all__ = ["AuditResult", "load_audit_results", "save_audit_results"]

--- a/analyzer/src/audit/quality_rater.py
+++ b/analyzer/src/audit/quality_rater.py
@@ -1,8 +1,8 @@
 """Quality rating system for existing documentation.
 
 This module handles persistence and management of documentation quality ratings
-collected during interactive audits. Ratings are stored in .docimp/session-reports/audit.json
-for use in impact scoring calculations.
+collected during interactive audits. Ratings are stored in
+.docimp/session-reports/audit.json for use in impact scoring calculations.
 """
 
 import json
@@ -64,7 +64,8 @@ def load_audit_results(audit_file: Optional[Path] = None) -> AuditResult:
     """Load audit results from JSON file.
 
     Args:
-        audit_file: Path to the audit results file. If None, uses StateManager.get_audit_file().
+        audit_file: Path to the audit results file. If None, uses
+            StateManager.get_audit_file().
 
     Returns:
         AuditResult with loaded ratings, or empty if file doesn't exist.
@@ -75,28 +76,28 @@ def load_audit_results(audit_file: Optional[Path] = None) -> AuditResult:
         return AuditResult(ratings={})
 
     try:
-        with open(audit_file, 'r') as f:
+        with open(audit_file, "r") as f:
             data = json.load(f)
-        return AuditResult(ratings=data.get('ratings', {}))
+        return AuditResult(ratings=data.get("ratings", {}))
     except (json.JSONDecodeError, IOError):
         # If file is corrupted, start fresh
         return AuditResult(ratings={})
 
 
 def save_audit_results(
-    audit_result: AuditResult,
-    audit_file: Optional[Path] = None
+    audit_result: AuditResult, audit_file: Optional[Path] = None
 ) -> None:
     """Save audit results to JSON file.
 
     Args:
         audit_result: AuditResult to save.
-        audit_file: Path to the audit results file. If None, uses StateManager.get_audit_file().
+        audit_file: Path to the audit results file. If None, uses
+            StateManager.get_audit_file().
     """
     if audit_file is None:
         audit_file = StateManager.get_audit_file()
 
     # Ensure state directory exists before writing
     StateManager.ensure_state_dir()
-    with open(audit_file, 'w') as f:
+    with open(audit_file, "w") as f:
         json.dump(audit_result.to_dict(), f, indent=2)

--- a/analyzer/src/claude/__init__.py
+++ b/analyzer/src/claude/__init__.py
@@ -3,4 +3,4 @@
 from .claude_client import ClaudeClient
 from .prompt_builder import PromptBuilder
 
-__all__ = ['ClaudeClient', 'PromptBuilder']
+__all__ = ["ClaudeClient", "PromptBuilder"]

--- a/analyzer/src/claude/claude_client.py
+++ b/analyzer/src/claude/claude_client.py
@@ -20,11 +20,13 @@ class ClaudeClient:
     Parameters
     ----------
     api_key : str, optional
-        Anthropic API key. If not provided, reads from ANTHROPIC_API_KEY environment variable.
+        Anthropic API key. If not provided, reads from ANTHROPIC_API_KEY
+        environment variable.
     model : str, optional
         Claude model to use. Defaults to claude-sonnet-4-20250514.
     max_retries : int, optional
-        Maximum number of retry attempts for rate-limited or timed-out requests. Defaults to 3.
+        Maximum number of retry attempts for rate-limited or timed-out
+        requests. Defaults to 3.
     retry_delay : float, optional
         Base delay in seconds between retries. Defaults to 1.0.
     timeout : float, optional
@@ -42,9 +44,9 @@ class ClaudeClient:
         model: str = "claude-sonnet-4-20250514",
         max_retries: int = 3,
         retry_delay: float = 1.0,
-        timeout: float = 30.0
+        timeout: float = 30.0,
     ):
-        self.api_key = api_key or os.environ.get('ANTHROPIC_API_KEY')
+        self.api_key = api_key or os.environ.get("ANTHROPIC_API_KEY")
         if not self.api_key:
             raise ValueError(
                 "API key must be provided either as parameter or via "
@@ -78,7 +80,7 @@ class ClaudeClient:
         Returns False if max retries would be exceeded.
         """
         if attempt < self.max_retries - 1:
-            delay = self.retry_delay * (2 ** attempt)
+            delay = self.retry_delay * (2**attempt)
             return (True, delay)
         return (False, 0.0)
 
@@ -119,12 +121,7 @@ class ClaudeClient:
                     model=self.model,
                     max_tokens=max_tokens,
                     timeout=self.timeout,
-                    messages=[
-                        {
-                            "role": "user",
-                            "content": prompt
-                        }
-                    ]
+                    messages=[{"role": "user", "content": prompt}],
                 )
 
                 # Extract text from response
@@ -133,7 +130,8 @@ class ClaudeClient:
                     return content_block.text
                 else:
                     raise RuntimeError(
-                        f"Unexpected content block type: {type(content_block).__name__}. "
+                        f"Unexpected content block type: "
+                        f"{type(content_block).__name__}. "
                         f"Expected TextBlock with text content."
                     )
 
@@ -144,7 +142,8 @@ class ClaudeClient:
                     continue
                 else:
                     raise RuntimeError(
-                        f"Claude API request timed out after {self.max_retries} attempts. "
+                        f"Claude API request timed out after "
+                        f"{self.max_retries} attempts. "
                         f"Each request has a {self.timeout} second timeout."
                     )
 

--- a/analyzer/src/claude/prompt_builder.py
+++ b/analyzer/src/claude/prompt_builder.py
@@ -30,11 +30,11 @@ class PromptBuilder:
 
     STYLE_GUIDES = {
         # Python style guides (4 variants)
-        'google': {
-            'name': 'Google',
-            'description': 'Google-style Python docstrings',
-            'language': 'python',
-            'example': '''"""
+        "google": {
+            "name": "Google",
+            "description": "Google-style Python docstrings",
+            "language": "python",
+            "example": '''"""
 Calculate the sum of two numbers.
 
 Args:
@@ -43,13 +43,13 @@ Args:
 
 Returns:
     int: The sum of a and b
-"""'''
+"""''',
         },
-        'numpy-rest': {
-            'name': 'NumPy + reST',
-            'description': 'NumPy docstring format with reStructuredText markup',
-            'language': 'python',
-            'example': '''"""
+        "numpy-rest": {
+            "name": "NumPy + reST",
+            "description": "NumPy docstring format with reStructuredText markup",
+            "language": "python",
+            "example": '''"""
 Calculate the sum of two numbers.
 
 Parameters
@@ -67,13 +67,13 @@ int
 Notes
 -----
 Use reST markup for emphasis: *italic*, **bold**, ``code``
-"""'''
+"""''',
         },
-        'numpy-markdown': {
-            'name': 'NumPy + Markdown',
-            'description': 'NumPy docstring format with Markdown markup',
-            'language': 'python',
-            'example': '''"""
+        "numpy-markdown": {
+            "name": "NumPy + Markdown",
+            "description": "NumPy docstring format with Markdown markup",
+            "language": "python",
+            "example": '''"""
 Calculate the sum of two numbers.
 
 Parameters
@@ -91,13 +91,13 @@ int
 Notes
 -----
 Use Markdown for emphasis: *italic*, **bold**, `code`
-"""'''
+"""''',
         },
-        'sphinx': {
-            'name': 'Pure reST (Sphinx)',
-            'description': 'Sphinx-style Python docstrings with reST directives',
-            'language': 'python',
-            'example': '''"""
+        "sphinx": {
+            "name": "Pure reST (Sphinx)",
+            "description": "Sphinx-style Python docstrings with reST directives",
+            "language": "python",
+            "example": '''"""
 Calculate the sum of two numbers.
 
 :param a: The first number
@@ -106,50 +106,53 @@ Calculate the sum of two numbers.
 :type b: int
 :return: The sum of a and b
 :rtype: int
-"""'''
+"""''',
         },
         # JavaScript style guides (3 variants)
-        'jsdoc-vanilla': {
-            'name': 'JSDoc (Vanilla)',
-            'description': 'Standard JSDoc format with @param, @returns, @typedef',
-            'language': 'javascript',
-            'example': """/**
+        "jsdoc-vanilla": {
+            "name": "JSDoc (Vanilla)",
+            "description": "Standard JSDoc format with @param, @returns, @typedef",
+            "language": "javascript",
+            "example": """/**
  * Calculate the sum of two numbers.
  * @param {number} a - The first number
  * @param {number} b - The second number
  * @returns {number} The sum of a and b
- */"""
+ */""",
         },
-        'jsdoc-google': {
-            'name': 'Google JSDoc',
-            'description': 'Google-flavored JSDoc with specific formatting conventions',
-            'language': 'javascript',
-            'example': """/**
+        "jsdoc-google": {
+            "name": "Google JSDoc",
+            "description": "Google-flavored JSDoc with specific formatting conventions",
+            "language": "javascript",
+            "example": """/**
  * Calculate the sum of two numbers.
  *
  * @param {number} a The first number.
  * @param {number} b The second number.
  * @return {number} The sum of a and b.
- */"""
+ */""",
         },
-        'jsdoc-closure': {
-            'name': 'Closure (JSDoc/Closure)',
-            'description': 'Google Closure Compiler style with nullable types and advanced annotations',
-            'language': 'javascript',
-            'example': """/**
+        "jsdoc-closure": {
+            "name": "Closure (JSDoc/Closure)",
+            "description": (
+                "Google Closure Compiler style with nullable types and "
+                "advanced annotations"
+            ),
+            "language": "javascript",
+            "example": """/**
  * Calculate the sum of two numbers.
  * @param {number} a The first number
  * @param {number} b The second number
  * @return {number} The sum of a and b
  * @public
- */"""
+ */""",
         },
         # TypeScript style guides (3 variants)
-        'tsdoc-typedoc': {
-            'name': 'TSDoc (TypeDoc)',
-            'description': 'TSDoc format optimized for TypeDoc documentation generator',
-            'language': 'typescript',
-            'example': """/**
+        "tsdoc-typedoc": {
+            "name": "TSDoc (TypeDoc)",
+            "description": "TSDoc format optimized for TypeDoc documentation generator",
+            "language": "typescript",
+            "example": """/**
  * Calculate the sum of two numbers.
  *
  * @param a - The first number
@@ -158,13 +161,16 @@ Calculate the sum of two numbers.
  *
  * @remarks
  * TypeScript types are inferred from the signature.
- */"""
+ */""",
         },
-        'tsdoc-aedoc': {
-            'name': 'TSDoc (API Extractor/AEDoc)',
-            'description': 'TSDoc format for Microsoft API Extractor with public API annotations',
-            'language': 'typescript',
-            'example': """/**
+        "tsdoc-aedoc": {
+            "name": "TSDoc (API Extractor/AEDoc)",
+            "description": (
+                "TSDoc format for Microsoft API Extractor with public API "
+                "annotations"
+            ),
+            "language": "typescript",
+            "example": """/**
  * Calculate the sum of two numbers.
  *
  * @param a - The first number
@@ -172,28 +178,31 @@ Calculate the sum of two numbers.
  * @returns The sum of a and b
  *
  * @public
- */"""
+ */""",
         },
-        'jsdoc-ts': {
-            'name': 'JSDoc-in-TS',
-            'description': 'JSDoc format in TypeScript files (hybrid approach)',
-            'language': 'typescript',
-            'example': """/**
+        "jsdoc-ts": {
+            "name": "JSDoc-in-TS",
+            "description": "JSDoc format in TypeScript files (hybrid approach)",
+            "language": "typescript",
+            "example": """/**
  * Calculate the sum of two numbers.
  * @param {number} a - The first number
  * @param {number} b - The second number
  * @returns {number} The sum of a and b
- */"""
-        }
+ */""",
+        },
     }
 
     TONE_DESCRIPTIONS = {
-        'concise': 'Be brief and to the point. Focus on essential information only.',
-        'detailed': 'Provide comprehensive explanations with examples where helpful.',
-        'friendly': 'Write in a conversational, approachable style while remaining professional.'
+        "concise": ("Be brief and to the point. Focus on essential information only."),
+        "detailed": ("Provide comprehensive explanations with examples where helpful."),
+        "friendly": (
+            "Write in a conversational, approachable style while remaining "
+            "professional."
+        ),
     }
 
-    def __init__(self, style_guide: str = 'google', tone: str = 'concise'):
+    def __init__(self, style_guide: str = "google", tone: str = "concise"):
         if style_guide not in self.STYLE_GUIDES:
             raise ValueError(
                 f"Unsupported style guide: {style_guide}. "
@@ -215,7 +224,7 @@ Calculate the sum of two numbers.
         item_type: str,
         language: str,
         context: Optional[str] = None,
-        feedback: Optional[str] = None
+        feedback: Optional[str] = None,
     ) -> str:
         """
         Build a documentation generation prompt.
@@ -234,7 +243,8 @@ Calculate the sum of two numbers.
             Additional surrounding code context.
         feedback : str, optional
             User feedback from a previous documentation attempt, used when
-            regenerating documentation to address specific user concerns.
+            regenerating documentation to address specific user
+            concerns.
 
         Returns
         -------
@@ -245,13 +255,16 @@ Calculate the sum of two numbers.
         tone_desc = self.TONE_DESCRIPTIONS[self.tone]
 
         prompt_parts = [
-            f"Generate documentation for the {language} {item_type} named '{item_name}'.",
+            (
+                f"Generate documentation for the {language} {item_type} "
+                f"named '{item_name}'."
+            ),
             "",
             f"Documentation Style: {style_info['name']}",
             f"Tone: {self.tone.capitalize()} - {tone_desc}",
             "",
             "Example format:",
-            style_info['example'],
+            style_info["example"],
             "",
             "Code to document:",
             "```" + language,
@@ -260,88 +273,143 @@ Calculate the sum of two numbers.
         ]
 
         if context:
-            prompt_parts.extend([
-                "",
-                "Surrounding context:",
-                "```" + language,
-                context.strip(),
-                "```",
-            ])
+            prompt_parts.extend(
+                [
+                    "",
+                    "Surrounding context:",
+                    "```" + language,
+                    context.strip(),
+                    "```",
+                ]
+            )
 
         if feedback:
-            prompt_parts.extend([
-                "",
-                "User Feedback from Previous Attempt:",
-                feedback.strip(),
-                "",
-                "IMPORTANT: Address the above feedback in your revised documentation.",
-            ])
+            prompt_parts.extend(
+                [
+                    "",
+                    "User Feedback from Previous Attempt:",
+                    feedback.strip(),
+                    "",
+                    (
+                        "IMPORTANT: Address the above feedback in your "
+                        "revised documentation."
+                    ),
+                ]
+            )
 
-        prompt_parts.extend([
-            "",
-            "Requirements:",
-            f"1. Return ONLY the documentation for the {item_type} '{item_name}' - nothing else",
-            "2. The surrounding code is for CONTEXT ONLY - do not document it",
-            "3. Do not include the code itself, only the documentation",
-            "4. Use the exact format shown in the example",
-        ])
+        prompt_parts.extend(
+            [
+                "",
+                "Requirements:",
+                (
+                    f"1. Return ONLY the documentation for the {item_type} "
+                    f"'{item_name}' - nothing else"
+                ),
+                ("2. The surrounding code is for CONTEXT ONLY - " "do not document it"),
+                "3. Do not include the code itself, only the documentation",
+                "4. Use the exact format shown in the example",
+            ]
+        )
 
         # OPTION A: Prevent markdown code fence wrappers
-        prompt_parts.extend([
-            "5. IMPORTANT: Return the raw docstring text only. Do NOT wrap your entire response in markdown code fences (```python, ```javascript, etc.)",
-            "6. Code examples WITHIN the docstring are fine and encouraged - just don't wrap the whole docstring in backticks",
-        ])
+        prompt_parts.extend(
+            [
+                (
+                    "5. IMPORTANT: Return the raw docstring text only. "
+                    "Do NOT wrap your entire response in markdown code "
+                    "fences (```python, ```javascript, etc.)"
+                ),
+                (
+                    "6. Code examples WITHIN the docstring are fine and "
+                    "encouraged - just don't wrap the whole docstring in "
+                    "backticks"
+                ),
+            ]
+        )
 
         # Add style-specific requirements
-        style_language = style_info.get('language')
+        style_language = style_info.get("language")
 
-        if style_language == 'python':
-            prompt_parts.extend([
-                "7. Include type hints for all parameters and return values",  # NOTE: Changed from "5" to "7"
-                "8. Return only the docstring content - do NOT include the triple-quote delimiters (they will be added automatically)",  # NOTE: Changed from "6" to "8"
-            ])
-            if self.style_guide == 'numpy-rest':
-                prompt_parts.append("7. Use reStructuredText markup: *italic*, **bold**, ``code``")
-            elif self.style_guide == 'numpy-markdown':
-                prompt_parts.append("7. Use Markdown markup: *italic*, **bold**, `code`")
-        elif style_language == 'javascript':
-            prompt_parts.extend([
-                "5. Ensure @param names exactly match the function parameter names",
-                "6. Include type annotations for all parameters and return values",
-            ])
-            if self.style_guide == 'jsdoc-vanilla':
+        if style_language == "python":
+            prompt_parts.extend(
+                [
+                    (
+                        "7. Include type hints for all parameters and " "return values"
+                    ),  # NOTE: Changed from "5" to "7"
+                    (
+                        "8. Return only the docstring content - do NOT "
+                        "include the triple-quote delimiters (they will be "
+                        "added automatically)"
+                    ),  # NOTE: Changed from "6" to "8"
+                ]
+            )
+            if self.style_guide == "numpy-rest":
+                prompt_parts.append(
+                    ("7. Use reStructuredText markup: *italic*, **bold**, " "``code``")
+                )
+            elif self.style_guide == "numpy-markdown":
+                prompt_parts.append(
+                    "7. Use Markdown markup: *italic*, **bold**, `code`"
+                )
+        elif style_language == "javascript":
+            prompt_parts.extend(
+                [
+                    (
+                        "5. Ensure @param names exactly match the function "
+                        "parameter names"
+                    ),
+                    (
+                        "6. Include type annotations for all parameters and "
+                        "return values"
+                    ),
+                ]
+            )
+            if self.style_guide == "jsdoc-vanilla":
                 prompt_parts.append("7. Use @returns (not @return)")
-            elif self.style_guide == 'jsdoc-google':
-                prompt_parts.extend([
-                    "7. Use @return (not @returns)",
-                    "8. End descriptions with periods",
-                    "9. No hyphens after parameter names",
-                ])
-            elif self.style_guide == 'jsdoc-closure':
-                prompt_parts.extend([
-                    "7. Use @return (not @returns)",
-                    "8. Include @public, @private, or @protected annotations",
-                ])
-        elif style_language == 'typescript':
-            if self.style_guide == 'tsdoc-typedoc':
-                prompt_parts.extend([
-                    "5. Use TSDoc format with hyphens after parameter names",
-                    "6. Use @returns (not @return)",
-                    "7. Types are inferred from TypeScript signatures",
-                    "8. Include @remarks for additional details",
-                ])
-            elif self.style_guide == 'tsdoc-aedoc':
-                prompt_parts.extend([
-                    "5. Use TSDoc format with hyphens after parameter names",
-                    "6. Use @returns (not @return)",
-                    "7. Include @public, @beta, or @internal annotations",
-                    "8. Types are inferred from TypeScript signatures",
-                ])
-            elif self.style_guide == 'jsdoc-ts':
-                prompt_parts.extend([
-                    "5. Use JSDoc format with explicit type annotations",
-                    "6. Include {type} annotations even though TypeScript provides types",
-                    "7. Use @returns (not @return)",
-                ])
+            elif self.style_guide == "jsdoc-google":
+                prompt_parts.extend(
+                    [
+                        "7. Use @return (not @returns)",
+                        "8. End descriptions with periods",
+                        "9. No hyphens after parameter names",
+                    ]
+                )
+            elif self.style_guide == "jsdoc-closure":
+                prompt_parts.extend(
+                    [
+                        "7. Use @return (not @returns)",
+                        ("8. Include @public, @private, or @protected " "annotations"),
+                    ]
+                )
+        elif style_language == "typescript":
+            if self.style_guide == "tsdoc-typedoc":
+                prompt_parts.extend(
+                    [
+                        ("5. Use TSDoc format with hyphens after " "parameter names"),
+                        "6. Use @returns (not @return)",
+                        ("7. Types are inferred from TypeScript " "signatures"),
+                        "8. Include @remarks for additional details",
+                    ]
+                )
+            elif self.style_guide == "tsdoc-aedoc":
+                prompt_parts.extend(
+                    [
+                        ("5. Use TSDoc format with hyphens after " "parameter names"),
+                        "6. Use @returns (not @return)",
+                        ("7. Include @public, @beta, or @internal " "annotations"),
+                        ("8. Types are inferred from TypeScript " "signatures"),
+                    ]
+                )
+            elif self.style_guide == "jsdoc-ts":
+                prompt_parts.extend(
+                    [
+                        ("5. Use JSDoc format with explicit type " "annotations"),
+                        (
+                            "6. Include {type} annotations even though "
+                            "TypeScript provides types"
+                        ),
+                        "7. Use @returns (not @return)",
+                    ]
+                )
 
         return "\n".join(prompt_parts)

--- a/analyzer/src/claude/response_parser.py
+++ b/analyzer/src/claude/response_parser.py
@@ -22,11 +22,7 @@ class ClaudeResponseParser:
     """
 
     # Supported language specifiers for markdown fences
-    LANGUAGE_SPECIFIERS = [
-        'python',
-        'javascript', 'js',
-        'typescript', 'ts'
-    ]
+    LANGUAGE_SPECIFIERS = ["python", "javascript", "js", "typescript", "ts"]
 
     @staticmethod
     def strip_markdown_fences(response: str, language: str) -> str:
@@ -77,7 +73,7 @@ class ClaudeResponseParser:
         #
         # re.DOTALL: . matches newlines
         # Non-greedy (.*?): stop at first closing fence
-        pattern = rf'^\s*```(?:{language_pattern})?\s*\n(.*?)\n```\s*$'
+        pattern = rf"^\s*```(?:{language_pattern})?\s*\n(.*?)\n```\s*$"
 
         match = re.match(pattern, response.strip(), re.DOTALL)
         if match:
@@ -103,10 +99,10 @@ class ClaudeResponseParser:
         """
         # Map language to all possible specifiers
         language_map = {
-            'python': ['python'],
-            'javascript': ['javascript', 'js'],
-            'typescript': ['typescript', 'ts']
+            "python": ["python"],
+            "javascript": ["javascript", "js"],
+            "typescript": ["typescript", "ts"],
         }
 
         specifiers = language_map.get(language.lower(), [language.lower()])
-        return '|'.join(specifiers)
+        return "|".join(specifiers)

--- a/analyzer/src/main.py
+++ b/analyzer/src/main.py
@@ -24,10 +24,7 @@ from .writer.docstring_writer import DocstringWriter
 from .writer.transaction_manager import TransactionManager
 
 
-def create_analyzer(
-    parsers: dict,
-    scorer: ImpactScorer
-) -> DocumentationAnalyzer:
+def create_analyzer(parsers: dict, scorer: ImpactScorer) -> DocumentationAnalyzer:
     """Create a DocumentationAnalyzer with injected dependencies.
 
     Args:
@@ -37,10 +34,7 @@ def create_analyzer(
     Returns:
         DocumentationAnalyzer: Configured analyzer instance.
     """
-    return DocumentationAnalyzer(
-        parsers=parsers,
-        scorer=scorer
-    )
+    return DocumentationAnalyzer(parsers=parsers, scorer=scorer)
 
 
 def format_json(result) -> str:
@@ -54,47 +48,44 @@ def format_json(result) -> str:
     """
     # Convert to dictionary for JSON serialization
     data = {
-        'coverage_percent': result.coverage_percent,
-        'total_items': result.total_items,
-        'documented_items': result.documented_items,
-        'by_language': {
+        "coverage_percent": result.coverage_percent,
+        "total_items": result.total_items,
+        "documented_items": result.documented_items,
+        "by_language": {
             lang: {
-                'language': metrics.language,
-                'total_items': metrics.total_items,
-                'documented_items': metrics.documented_items,
-                'coverage_percent': metrics.coverage_percent,
-                'avg_complexity': metrics.avg_complexity,
-                'avg_impact_score': metrics.avg_impact_score
+                "language": metrics.language,
+                "total_items": metrics.total_items,
+                "documented_items": metrics.documented_items,
+                "coverage_percent": metrics.coverage_percent,
+                "avg_complexity": metrics.avg_complexity,
+                "avg_impact_score": metrics.avg_impact_score,
             }
             for lang, metrics in result.by_language.items()
         },
-        'items': [
+        "items": [
             {
-                'name': item.name,
-                'type': item.type,
-                'filepath': item.filepath,
-                'line_number': item.line_number,
-                'end_line': item.end_line,
-                'language': item.language,
-                'complexity': item.complexity,
-                'impact_score': item.impact_score,
-                'has_docs': item.has_docs,
-                'parameters': item.parameters,
-                'return_type': item.return_type,
-                'docstring': item.docstring,
-                'export_type': item.export_type,
-                'module_system': item.module_system,
-                'audit_rating': item.audit_rating
+                "name": item.name,
+                "type": item.type,
+                "filepath": item.filepath,
+                "line_number": item.line_number,
+                "end_line": item.end_line,
+                "language": item.language,
+                "complexity": item.complexity,
+                "impact_score": item.impact_score,
+                "has_docs": item.has_docs,
+                "parameters": item.parameters,
+                "return_type": item.return_type,
+                "docstring": item.docstring,
+                "export_type": item.export_type,
+                "module_system": item.module_system,
+                "audit_rating": item.audit_rating,
             }
             for item in result.items
         ],
-        'parse_failures': [
-            {
-                'filepath': failure.filepath,
-                'error': failure.error
-            }
+        "parse_failures": [
+            {"filepath": failure.filepath, "error": failure.error}
             for failure in result.parse_failures
-        ]
+        ],
     }
     return json.dumps(data, indent=2)
 
@@ -113,8 +104,10 @@ def format_summary(result) -> str:
     lines.append("Documentation Coverage Analysis")
     lines.append("=" * 60)
     lines.append("")
-    lines.append(f"Overall Coverage: {result.coverage_percent:.1f}% "
-                 f"({result.documented_items}/{result.total_items} items)")
+    lines.append(
+        f"Overall Coverage: {result.coverage_percent:.1f}% "
+        f"({result.documented_items}/{result.total_items} items)"
+    )
     lines.append("")
 
     if result.by_language:
@@ -122,8 +115,10 @@ def format_summary(result) -> str:
         lines.append("-" * 60)
         for lang, metrics in sorted(result.by_language.items()):
             lines.append(f"  {lang.capitalize()}:")
-            lines.append(f"    Coverage: {metrics.coverage_percent:.1f}% "
-                        f"({metrics.documented_items}/{metrics.total_items})")
+            lines.append(
+                f"    Coverage: {metrics.coverage_percent:.1f}% "
+                f"({metrics.documented_items}/{metrics.total_items})"
+            )
             lines.append(f"    Avg Complexity: {metrics.avg_complexity:.1f}")
             lines.append(f"    Avg Impact Score: {metrics.avg_impact_score:.1f}")
             lines.append("")
@@ -135,8 +130,10 @@ def format_summary(result) -> str:
         lines.append("-" * 60)
         sorted_items = sorted(undocumented, key=lambda x: x.impact_score, reverse=True)
         for item in sorted_items[:10]:  # Show top 10
-            lines.append(f"  [{item.impact_score:5.1f}] {item.type:8s} "
-                        f"{item.name:30s} ({item.filepath}:{item.line_number})")
+            lines.append(
+                f"  [{item.impact_score:5.1f}] {item.type:8s} "
+                f"{item.name:30s} ({item.filepath}:{item.line_number})"
+            )
 
         if len(undocumented) > 10:
             lines.append(f"  ... and {len(undocumented) - 10} more")
@@ -146,16 +143,13 @@ def format_summary(result) -> str:
     return "\n".join(lines)
 
 
-def cmd_analyze(
-    args: argparse.Namespace,
-    parsers: dict,
-    scorer: ImpactScorer
-) -> int:
+def cmd_analyze(args: argparse.Namespace, parsers: dict, scorer: ImpactScorer) -> int:
     """Handle the analyze subcommand.
 
     Args:
         args: Parsed command-line arguments.
-        parsers: Dictionary mapping language names to parser instances (dependency injection).
+        parsers: Dictionary mapping language names to parser instances
+            (dependency injection).
         scorer: Impact scorer instance (dependency injection).
 
     Returns:
@@ -176,7 +170,10 @@ def cmd_analyze(
         else:
             files_removed = StateManager.clear_session_reports()
             if files_removed > 0:
-                print(f"Cleared {files_removed} previous session report(s)", file=sys.stderr)
+                print(
+                    f"Cleared {files_removed} previous session report(s)",
+                    file=sys.stderr,
+                )
 
         # Create analyzer with injected dependencies
         analyzer = create_analyzer(parsers, scorer)
@@ -188,14 +185,14 @@ def cmd_analyze(
         result = analyzer.analyze(args.path, verbose=args.verbose, strict=args.strict)
 
         # Save analysis result to state directory
-        with open(analyze_file, 'w') as f:
+        with open(analyze_file, "w") as f:
             f.write(format_json(result))
 
         if args.verbose:
             print(f"Analysis saved to: {analyze_file}", file=sys.stderr)
 
         # Format output
-        if args.format == 'json':
+        if args.format == "json":
             output = format_json(result)
         else:  # summary
             output = format_summary(result)
@@ -212,20 +209,18 @@ def cmd_analyze(
         print(f"Error: {e}", file=sys.stderr)
         if args.verbose:
             import traceback
+
             traceback.print_exc(file=sys.stderr)
         return 1
 
 
-def cmd_audit(
-    args: argparse.Namespace,
-    parsers: dict,
-    scorer: ImpactScorer
-) -> int:
+def cmd_audit(args: argparse.Namespace, parsers: dict, scorer: ImpactScorer) -> int:
     """Handle the audit subcommand.
 
     Args:
         args: Parsed command-line arguments.
-        parsers: Dictionary mapping language names to parser instances (dependency injection).
+        parsers: Dictionary mapping language names to parser instances
+            (dependency injection).
         scorer: Impact scorer instance (dependency injection).
 
     Returns:
@@ -249,17 +244,17 @@ def cmd_audit(
 
         # Format output as JSON for TypeScript to consume
         data = {
-            'items': [
+            "items": [
                 {
-                    'name': item.name,
-                    'type': item.type,
-                    'filepath': item.filepath,
-                    'line_number': item.line_number,
-                    'end_line': item.end_line,
-                    'language': item.language,
-                    'complexity': item.complexity,
-                    'docstring': item.docstring,
-                    'audit_rating': item.audit_rating
+                    "name": item.name,
+                    "type": item.type,
+                    "filepath": item.filepath,
+                    "line_number": item.line_number,
+                    "end_line": item.end_line,
+                    "language": item.language,
+                    "complexity": item.complexity,
+                    "docstring": item.docstring,
+                    "audit_rating": item.audit_rating,
                 }
                 for item in documented_items
             ]
@@ -275,6 +270,7 @@ def cmd_audit(
         print(f"Error: {e}", file=sys.stderr)
         if args.verbose:
             import traceback
+
             traceback.print_exc(file=sys.stderr)
         return 1
 
@@ -296,14 +292,17 @@ def cmd_apply_audit(args: argparse.Namespace) -> int:
         audit_data = json.load(sys.stdin)
 
         # Convert to AuditResult
-        audit_result = AuditResult(ratings=audit_data.get('ratings', {}))
+        audit_result = AuditResult(ratings=audit_data.get("ratings", {}))
 
         # Save to file
         save_audit_results(audit_result, Path(args.audit_file))
 
         if args.verbose:
             total_ratings = sum(len(items) for items in audit_result.ratings.values())
-            print(f"Saved {total_ratings} audit ratings to {args.audit_file}", file=sys.stderr)
+            print(
+                f"Saved {total_ratings} audit ratings to {args.audit_file}",
+                file=sys.stderr,
+            )
 
         return 0
 
@@ -314,20 +313,18 @@ def cmd_apply_audit(args: argparse.Namespace) -> int:
         print(f"Error: {e}", file=sys.stderr)
         if args.verbose:
             import traceback
+
             traceback.print_exc(file=sys.stderr)
         return 1
 
 
-def cmd_plan(
-    args: argparse.Namespace,
-    parsers: dict,
-    scorer: ImpactScorer
-) -> int:
+def cmd_plan(args: argparse.Namespace, parsers: dict, scorer: ImpactScorer) -> int:
     """Handle the plan subcommand.
 
     Args:
         args: Parsed command-line arguments.
-        parsers: Dictionary mapping language names to parser instances (dependency injection).
+        parsers: Dictionary mapping language names to parser instances
+            (dependency injection).
         scorer: Impact scorer instance (dependency injection).
 
     Returns:
@@ -353,7 +350,7 @@ def cmd_plan(
         plan = generate_plan(
             result,
             audit_file=Path(args.audit_file),
-            quality_threshold=args.quality_threshold
+            quality_threshold=args.quality_threshold,
         )
 
         # Display warning if invalid ratings were found
@@ -361,14 +358,19 @@ def cmd_plan(
             if args.verbose:
                 # Show detailed warnings for each invalid rating
                 for inv in plan.invalid_ratings:
-                    print(f"Warning: Invalid audit rating {inv['rating']} for {inv['name']} "
-                          f"in {inv['filepath']} (expected 1-4), skipped",
-                          file=sys.stderr)
+                    print(
+                        f"Warning: Invalid audit rating {inv['rating']} for "
+                        f"{inv['name']} in {inv['filepath']} (expected 1-4), "
+                        f"skipped",
+                        file=sys.stderr,
+                    )
             else:
                 # Show summary warning
-                print(f"Warning: {plan.invalid_ratings_count} invalid audit rating(s) skipped. "
-                      f"Run with --verbose for details.",
-                      file=sys.stderr)
+                print(
+                    f"Warning: {plan.invalid_ratings_count} invalid audit "
+                    f"rating(s) skipped. Run with --verbose for details.",
+                    file=sys.stderr,
+                )
 
         # Save plan to file
         plan_file = Path(args.plan_file)
@@ -389,33 +391,36 @@ def cmd_plan(
         print(f"Error: {e}", file=sys.stderr)
         if args.verbose:
             import traceback
+
             traceback.print_exc(file=sys.stderr)
         return 1
 
 
 def cmd_suggest(
-    args: argparse.Namespace,
-    claude_client: ClaudeClient,
-    prompt_builder: PromptBuilder
+    args: argparse.Namespace, claude_client: ClaudeClient, prompt_builder: PromptBuilder
 ) -> int:
     """Handle the suggest subcommand.
 
     Args:
         args: Parsed command-line arguments.
-        claude_client: ClaudeClient instance for API calls (dependency injection).
-        prompt_builder: PromptBuilder instance for formatting prompts (dependency injection).
+        claude_client: ClaudeClient instance for API calls
+            (dependency injection).
+        prompt_builder: PromptBuilder instance for formatting prompts
+            (dependency injection).
 
     Returns:
         Exit code (0 for success, 1 for error).
     """
     try:
         # Parse the target (filepath:itemname format)
-        if ':' not in args.target:
-            print("Error: Target must be in format 'filepath:itemname'", file=sys.stderr)
+        if ":" not in args.target:
+            print(
+                "Error: Target must be in format 'filepath:itemname'", file=sys.stderr
+            )
             print("Example: examples/test.py:my_function", file=sys.stderr)
             return 1
 
-        filepath, item_name = args.target.rsplit(':', 1)
+        filepath, item_name = args.target.rsplit(":", 1)
         filepath = Path(filepath)
 
         if not filepath.exists():
@@ -423,17 +428,17 @@ def cmd_suggest(
             return 1
 
         # Read the file
-        with open(filepath, 'r') as f:
+        with open(filepath, "r") as f:
             code_content = f.read()
 
         # Determine language from file extension
         ext = filepath.suffix.lower()
-        if ext == '.py':
-            language = 'python'
-        elif ext in ['.ts']:
-            language = 'typescript'
-        elif ext in ['.js', '.cjs', '.mjs']:
-            language = 'javascript'
+        if ext == ".py":
+            language = "python"
+        elif ext in [".ts"]:
+            language = "typescript"
+        elif ext in [".js", ".cjs", ".mjs"]:
+            language = "javascript"
         else:
             print(f"Error: Unsupported file type: {ext}", file=sys.stderr)
             return 1
@@ -447,9 +452,9 @@ def cmd_suggest(
         prompt = prompt_builder.build_prompt(
             code=target_code,
             item_name=item_name,
-            item_type='function',  # Simplified for MVP
+            item_type="function",  # Simplified for MVP
             language=language,
-            feedback=args.feedback
+            feedback=args.feedback,
         )
 
         if args.verbose:
@@ -472,19 +477,18 @@ def cmd_suggest(
         print(f"Error: {e}", file=sys.stderr)
         if args.verbose:
             import traceback
+
             traceback.print_exc(file=sys.stderr)
         return 1
 
 
-def cmd_apply(
-    args: argparse.Namespace,
-    docstring_writer: DocstringWriter
-) -> int:
+def cmd_apply(args: argparse.Namespace, docstring_writer: DocstringWriter) -> int:
     """Handle the apply subcommand to write documentation to files.
 
     Args:
         args: Parsed command-line arguments.
-        docstring_writer: DocstringWriter instance for file operations (dependency injection).
+        docstring_writer: DocstringWriter instance for file operations
+            (dependency injection).
 
     Returns:
         Exit code (0 for success, 1 for error).
@@ -493,13 +497,15 @@ def cmd_apply(
         # Read apply data from stdin (sent by TypeScript CLI)
         apply_data = json.load(sys.stdin)
 
-        filepath = apply_data.get('filepath')
-        item_name = apply_data.get('item_name')
-        item_type = apply_data.get('item_type')
-        docstring = apply_data.get('docstring')
-        language = apply_data.get('language')
-        line_number = apply_data.get('line_number')
-        backup_path = apply_data.get('backup_path')  # Optional, for transaction tracking
+        filepath = apply_data.get("filepath")
+        item_name = apply_data.get("item_name")
+        item_type = apply_data.get("item_type")
+        docstring = apply_data.get("docstring")
+        language = apply_data.get("language")
+        line_number = apply_data.get("line_number")
+        backup_path = apply_data.get(
+            "backup_path"
+        )  # Optional, for transaction tracking
 
         if not all([filepath, item_name, item_type, docstring, language]):
             print("Error: Missing required fields in apply data", file=sys.stderr)
@@ -507,7 +513,9 @@ def cmd_apply(
 
         # Write docstring
         if args.verbose:
-            print(f"Writing documentation for {item_name} in {filepath}", file=sys.stderr)
+            print(
+                f"Writing documentation for {item_name} in {filepath}", file=sys.stderr
+            )
 
         success = docstring_writer.write_docstring(
             filepath=filepath,
@@ -516,19 +524,15 @@ def cmd_apply(
             docstring=docstring,
             language=language,
             line_number=line_number,
-            explicit_backup_path=backup_path
+            explicit_backup_path=backup_path,
         )
 
         if success:
-            result = {
-                'success': True,
-                'filepath': filepath,
-                'item_name': item_name
-            }
+            result = {"success": True, "filepath": filepath, "item_name": item_name}
             print(json.dumps(result))
             return 0
         else:
-            print(json.dumps({'success': False, 'error': 'Failed to write docstring'}))
+            print(json.dumps({"success": False, "error": "Failed to write docstring"}))
             return 1
 
     except json.JSONDecodeError as e:
@@ -541,14 +545,12 @@ def cmd_apply(
         print(f"Error: {e}", file=sys.stderr)
         if args.verbose:
             import traceback
+
             traceback.print_exc(file=sys.stderr)
         return 1
 
 
-def cmd_list_sessions(
-    args: argparse.Namespace,
-    manager: TransactionManager
-) -> int:
+def cmd_list_sessions(args: argparse.Namespace, manager: TransactionManager) -> int:
     """Handle the list-sessions subcommand.
 
     Args:
@@ -561,32 +563,35 @@ def cmd_list_sessions(
     try:
         # Check git availability
         if not GitHelper.check_git_available():
-            print("Error: Git not installed - session tracking unavailable", file=sys.stderr)
+            print(
+                "Error: Git not installed - session tracking unavailable",
+                file=sys.stderr,
+            )
             return 1
 
         # Get transactions directory
-        transactions_dir = StateManager.get_state_dir() / 'transactions'
+        transactions_dir = StateManager.get_state_dir() / "transactions"
 
         # List uncommitted sessions
         sessions = manager.list_uncommitted_transactions(transactions_dir)
 
         if not sessions:
-            if args.format == 'json':
+            if args.format == "json":
                 print(json.dumps([]))
             else:
                 print("No active sessions found")
             return 0
 
         # Output format
-        if args.format == 'json':
+        if args.format == "json":
             # JSON format for TypeScript CLI
             data = [
                 {
-                    'session_id': session.session_id,
-                    'started_at': session.started_at,
-                    'completed_at': session.completed_at,
-                    'change_count': len(session.entries),
-                    'status': session.status
+                    "session_id": session.session_id,
+                    "started_at": session.started_at,
+                    "completed_at": session.completed_at,
+                    "change_count": len(session.entries),
+                    "status": session.status,
                 }
                 for session in sessions
             ]
@@ -600,8 +605,10 @@ def cmd_list_sessions(
             print("-" * 80)
 
             for session in sessions:
-                print(f"{session.session_id:<40} {session.started_at:<20} "
-                      f"{len(session.entries):<10} {session.status:<10}")
+                print(
+                    f"{session.session_id:<40} {session.started_at:<20} "
+                    f"{len(session.entries):<10} {session.status:<10}"
+                )
 
             print("=" * 80)
             print(f"\nTotal: {len(sessions)} session(s)")
@@ -612,14 +619,12 @@ def cmd_list_sessions(
         print(f"Error: {e}", file=sys.stderr)
         if args.verbose:
             import traceback
+
             traceback.print_exc(file=sys.stderr)
         return 1
 
 
-def cmd_list_changes(
-    args: argparse.Namespace,
-    manager: TransactionManager
-) -> int:
+def cmd_list_changes(args: argparse.Namespace, manager: TransactionManager) -> int:
     """Handle the list-changes subcommand.
 
     Args:
@@ -632,7 +637,10 @@ def cmd_list_changes(
     try:
         # Check git availability
         if not GitHelper.check_git_available():
-            print("Error: Git not installed - session tracking unavailable", file=sys.stderr)
+            print(
+                "Error: Git not installed - session tracking unavailable",
+                file=sys.stderr,
+            )
             return 1
 
         # List changes in the session
@@ -640,28 +648,30 @@ def cmd_list_changes(
             changes = manager.list_session_changes(args.session_id)
         except ValueError as e:
             print(f"Error: {e}", file=sys.stderr)
-            print("Use 'docimp list-sessions' to see available sessions", file=sys.stderr)
+            print(
+                "Use 'docimp list-sessions' to see available sessions", file=sys.stderr
+            )
             return 1
 
         if not changes:
-            if args.format == 'json':
+            if args.format == "json":
                 print(json.dumps([]))
             else:
                 print(f"No changes found in session: {args.session_id}")
             return 0
 
         # Output format
-        if args.format == 'json':
+        if args.format == "json":
             # JSON format for TypeScript CLI
             data = [
                 {
-                    'entry_id': change.entry_id,
-                    'filepath': change.filepath,
-                    'timestamp': change.timestamp,
-                    'item_name': change.item_name,
-                    'item_type': change.item_type,
-                    'language': change.language,
-                    'success': change.success
+                    "entry_id": change.entry_id,
+                    "filepath": change.filepath,
+                    "timestamp": change.timestamp,
+                    "item_name": change.item_name,
+                    "item_type": change.item_type,
+                    "language": change.language,
+                    "success": change.success,
                 }
                 for change in changes
             ]
@@ -675,10 +685,25 @@ def cmd_list_changes(
             print("-" * 100)
 
             for change in changes:
-                filepath_short = change.filepath[-37:] if len(change.filepath) > 40 else change.filepath
-                item_short = change.item_name[:22] + '...' if len(change.item_name) > 25 else change.item_name
-                timestamp_short = change.timestamp[:19] if len(change.timestamp) > 20 else change.timestamp
-                print(f"{change.entry_id:<12} {filepath_short:<40} {item_short:<25} {timestamp_short:<20}")
+                filepath_short = (
+                    change.filepath[-37:]
+                    if len(change.filepath) > 40
+                    else change.filepath
+                )
+                item_short = (
+                    change.item_name[:22] + "..."
+                    if len(change.item_name) > 25
+                    else change.item_name
+                )
+                timestamp_short = (
+                    change.timestamp[:19]
+                    if len(change.timestamp) > 20
+                    else change.timestamp
+                )
+                print(
+                    f"{change.entry_id:<12} {filepath_short:<40} "
+                    f"{item_short:<25} {timestamp_short:<20}"
+                )
 
             print("=" * 100)
             print(f"\nTotal: {len(changes)} change(s)")
@@ -689,6 +714,7 @@ def cmd_list_changes(
         print(f"Error: {e}", file=sys.stderr)
         if args.verbose:
             import traceback
+
             traceback.print_exc(file=sys.stderr)
         return 1
 
@@ -703,17 +729,14 @@ def _build_git_timeout_config(args: argparse.Namespace) -> GitTimeoutConfig:
         GitTimeoutConfig instance with values from CLI or defaults.
     """
     return GitTimeoutConfig(
-        base_timeout_ms=getattr(args, 'git_timeout_base', 30000),
-        fast_scale=getattr(args, 'git_timeout_fast_scale', 0.167),
-        slow_scale=getattr(args, 'git_timeout_slow_scale', 4.0),
-        max_timeout_ms=getattr(args, 'git_timeout_max', 300000)
+        base_timeout_ms=getattr(args, "git_timeout_base", 30000),
+        fast_scale=getattr(args, "git_timeout_fast_scale", 0.167),
+        slow_scale=getattr(args, "git_timeout_slow_scale", 4.0),
+        max_timeout_ms=getattr(args, "git_timeout_max", 300000),
     )
 
 
-def cmd_begin_transaction(
-    args: argparse.Namespace,
-    manager: TransactionManager
-) -> int:
+def cmd_begin_transaction(args: argparse.Namespace, manager: TransactionManager) -> int:
     """Handle the begin-transaction subcommand.
 
     Args:
@@ -727,11 +750,8 @@ def cmd_begin_transaction(
         # Check git availability
         if not GitHelper.check_git_available():
             error_msg = "Git not installed - transaction tracking unavailable"
-            if args.format == 'json':
-                result = {
-                    'success': False,
-                    'error': error_msg
-                }
+            if args.format == "json":
+                result = {"success": False, "error": error_msg}
                 print(json.dumps(result))
             else:
                 print(f"Error: {error_msg}", file=sys.stderr)
@@ -742,10 +762,10 @@ def cmd_begin_transaction(
         manager.begin_transaction(session_id)
 
         # Output result
-        if args.format == 'json':
+        if args.format == "json":
             result = {
-                'success': True,
-                'message': f'Transaction initialized for session {session_id}'
+                "success": True,
+                "message": f"Transaction initialized for session {session_id}",
             }
             print(json.dumps(result))
         else:
@@ -755,24 +775,19 @@ def cmd_begin_transaction(
 
     except Exception as e:
         error_msg = str(e)
-        if args.format == 'json':
-            result = {
-                'success': False,
-                'error': error_msg
-            }
+        if args.format == "json":
+            result = {"success": False, "error": error_msg}
             print(json.dumps(result))
         else:
             print(f"Error: {error_msg}", file=sys.stderr)
             if args.verbose:
                 import traceback
+
                 traceback.print_exc(file=sys.stderr)
         return 1
 
 
-def cmd_record_write(
-    args: argparse.Namespace,
-    manager: TransactionManager
-) -> int:
+def cmd_record_write(args: argparse.Namespace, manager: TransactionManager) -> int:
     """Handle the record-write subcommand.
 
     Args:
@@ -786,11 +801,8 @@ def cmd_record_write(
         # Check git availability
         if not GitHelper.check_git_available():
             error_msg = "Git not installed - transaction tracking unavailable"
-            if args.format == 'json':
-                result = {
-                    'success': False,
-                    'error': error_msg
-                }
+            if args.format == "json":
+                result = {"success": False, "error": error_msg}
                 print(json.dumps(result))
             else:
                 print(f"Error: {error_msg}", file=sys.stderr)
@@ -808,26 +820,21 @@ def cmd_record_write(
         # The manifest is built from git commits, so we just need the session_id
         from .writer.transaction_manager import TransactionManifest
         from datetime import datetime, UTC
+
         manifest = TransactionManifest(
-            session_id=session_id,
-            started_at=datetime.now(UTC).isoformat()
+            session_id=session_id, started_at=datetime.now(UTC).isoformat()
         )
 
         # Record the write (creates git commit)
         manager.record_write(
-            manifest,
-            filepath,
-            backup_path,
-            item_name,
-            item_type,
-            language
+            manifest, filepath, backup_path, item_name, item_type, language
         )
 
         # Output result
-        if args.format == 'json':
+        if args.format == "json":
             result = {
-                'success': True,
-                'message': f'Recorded write for {item_name} in session {session_id}'
+                "success": True,
+                "message": f"Recorded write for {item_name} in session {session_id}",
             }
             print(json.dumps(result))
         else:
@@ -837,23 +844,20 @@ def cmd_record_write(
 
     except Exception as e:
         error_msg = str(e)
-        if args.format == 'json':
-            result = {
-                'success': False,
-                'error': error_msg
-            }
+        if args.format == "json":
+            result = {"success": False, "error": error_msg}
             print(json.dumps(result))
         else:
             print(f"Error: {error_msg}", file=sys.stderr)
             if args.verbose:
                 import traceback
+
                 traceback.print_exc(file=sys.stderr)
         return 1
 
 
 def cmd_commit_transaction(
-    args: argparse.Namespace,
-    manager: TransactionManager
+    args: argparse.Namespace, manager: TransactionManager
 ) -> int:
     """Handle the commit-transaction subcommand.
 
@@ -871,11 +875,8 @@ def cmd_commit_transaction(
         # Check git availability
         if not GitHelper.check_git_available():
             error_msg = "Git not installed - transaction commit unavailable"
-            if args.format == 'json':
-                result = {
-                    'success': False,
-                    'error': error_msg
-                }
+            if args.format == "json":
+                result = {"success": False, "error": error_msg}
                 print(json.dumps(result))
             else:
                 print(f"Error: {error_msg}", file=sys.stderr)
@@ -888,20 +889,20 @@ def cmd_commit_transaction(
         # The manifest will be populated from git commits
         from .writer.transaction_manager import TransactionManifest
         from datetime import datetime, UTC
+
         manifest = TransactionManifest(
-            session_id=session_id,
-            started_at=datetime.now(UTC).isoformat()
+            session_id=session_id, started_at=datetime.now(UTC).isoformat()
         )
 
         # Commit the transaction (squash merge to main, delete backups)
         manager.commit_transaction(manifest)
 
         # Output result
-        if args.format == 'json':
+        if args.format == "json":
             result = {
-                'success': True,
-                'message': f'Transaction committed for session {session_id}',
-                'squash_commit_sha': manifest.git_commit_sha
+                "success": True,
+                "message": f"Transaction committed for session {session_id}",
+                "squash_commit_sha": manifest.git_commit_sha,
             }
             print(json.dumps(result))
         else:
@@ -913,24 +914,19 @@ def cmd_commit_transaction(
 
     except Exception as e:
         error_msg = str(e)
-        if args.format == 'json':
-            result = {
-                'success': False,
-                'error': error_msg
-            }
+        if args.format == "json":
+            result = {"success": False, "error": error_msg}
             print(json.dumps(result))
         else:
             print(f"Error: {error_msg}", file=sys.stderr)
             if args.verbose:
                 import traceback
+
                 traceback.print_exc(file=sys.stderr)
         return 1
 
 
-def cmd_rollback_session(
-    args: argparse.Namespace,
-    manager: TransactionManager
-) -> int:
+def cmd_rollback_session(args: argparse.Namespace, manager: TransactionManager) -> int:
     """Handle the rollback-session subcommand.
 
     Args:
@@ -948,9 +944,9 @@ def cmd_rollback_session(
 
         # Determine session ID (handle --last flag)
         session_id = args.session_id
-        transactions_dir = StateManager.get_state_dir() / 'transactions'
+        transactions_dir = StateManager.get_state_dir() / "transactions"
 
-        if session_id == 'last':
+        if session_id == "last":
             # Find most recent session
             sessions = manager.list_uncommitted_transactions(transactions_dir)
             if not sessions:
@@ -961,11 +957,13 @@ def cmd_rollback_session(
             session_id = sessions[0].session_id
 
         # Load the session manifest
-        manifest_path = transactions_dir / f'transaction-{session_id}.json'
+        manifest_path = transactions_dir / f"transaction-{session_id}.json"
 
         if not manifest_path.exists():
             print(f"Error: Session not found: {session_id}", file=sys.stderr)
-            print("Use 'docimp list-sessions' to see available sessions", file=sys.stderr)
+            print(
+                "Use 'docimp list-sessions' to see available sessions", file=sys.stderr
+            )
             return 1
 
         manifest = manager.load_manifest(manifest_path)
@@ -979,8 +977,10 @@ def cmd_rollback_session(
             print("=" * 60)
 
             # Prompt for confirmation
-            response = input("\nRollback this session? This will revert all changes. (y/N): ")
-            if response.lower() not in ['y', 'yes']:
+            response = input(
+                "\nRollback this session? This will revert all changes. (y/N): "
+            )
+            if response.lower() not in ["y", "yes"]:
                 print("Rollback cancelled")
                 return 0
 
@@ -991,13 +991,13 @@ def cmd_rollback_session(
         restored_count = manager.rollback_transaction(manifest)
 
         # Output result
-        if args.format == 'json':
+        if args.format == "json":
             # JSON format for TypeScript CLI
             result = {
-                'success': True,
-                'restored_count': restored_count,
-                'status': manifest.status,
-                'message': f'Rolled back {restored_count} file(s)'
+                "success": True,
+                "restored_count": restored_count,
+                "status": manifest.status,
+                "message": f"Rolled back {restored_count} file(s)",
             }
             print(json.dumps(result, indent=2))
         else:
@@ -1013,14 +1013,12 @@ def cmd_rollback_session(
         print(f"Error: {e}", file=sys.stderr)
         if args.verbose:
             import traceback
+
             traceback.print_exc(file=sys.stderr)
         return 1
 
 
-def cmd_rollback_change(
-    args: argparse.Namespace,
-    manager: TransactionManager
-) -> int:
+def cmd_rollback_change(args: argparse.Namespace, manager: TransactionManager) -> int:
     """Handle the rollback-change subcommand.
 
     Args:
@@ -1039,9 +1037,9 @@ def cmd_rollback_change(
         # Determine entry ID (handle --last flag)
         entry_id = args.entry_id
 
-        if entry_id == 'last':
+        if entry_id == "last":
             # Find most recent change across all sessions
-            transactions_dir = StateManager.get_state_dir() / 'transactions'
+            transactions_dir = StateManager.get_state_dir() / "transactions"
             sessions = manager.list_uncommitted_transactions(transactions_dir)
             if not sessions:
                 print("Error: No active sessions found", file=sys.stderr)
@@ -1078,7 +1076,7 @@ def cmd_rollback_change(
 
             # Prompt for confirmation
             response = input("\nRollback this change? (y/N): ")
-            if response.lower() not in ['y', 'yes']:
+            if response.lower() not in ["y", "yes"]:
                 print("Rollback cancelled")
                 return 0
 
@@ -1089,36 +1087,60 @@ def cmd_rollback_change(
         result = manager.rollback_change(entry_id)
 
         # Output result
-        if args.format == 'json':
+        if args.format == "json":
             # JSON format for TypeScript CLI
             result_data = {
-                'success': result.success,
-                'restored_count': result.restored_count,
-                'failed_count': result.failed_count,
-                'status': result.status,
-                'conflicts': result.conflicts,
-                'message': f'Rolled back {result.restored_count} file(s)' if result.success else f'Rollback failed: {result.failed_count} file(s) had conflicts'
+                "success": result.success,
+                "restored_count": result.restored_count,
+                "failed_count": result.failed_count,
+                "status": result.status,
+                "conflicts": result.conflicts,
+                "message": (
+                    f"Rolled back {result.restored_count} file(s)"
+                    if result.success
+                    else f"Rollback failed: {result.failed_count} file(s) had conflicts"
+                ),
             }
             print(json.dumps(result_data, indent=2))
         else:
             if result.success:
                 print(f"\nSuccess! Rolled back {result.restored_count} file(s)")
             else:
-                print(f"\nRollback failed: {result.failed_count} file(s) had conflicts", file=sys.stderr)
+                print(
+                    f"\nRollback failed: {result.failed_count} file(s) had conflicts",
+                    file=sys.stderr,
+                )
                 if result.conflicts:
                     print("\nConflict Details:", file=sys.stderr)
-                    print("The following files have been modified since this change was made:", file=sys.stderr)
+                    print(
+                        "The following files have been modified since this "
+                        "change was made:",
+                        file=sys.stderr,
+                    )
                     for conflict in result.conflicts:
                         print(f"  - {conflict}", file=sys.stderr)
                     print("\nResolution Options:", file=sys.stderr)
                     print("  1. Manually resolve conflicts:", file=sys.stderr)
-                    print("     - Review the file and decide which version to keep", file=sys.stderr)
+                    print(
+                        "     - Review the file and decide which version to keep",
+                        file=sys.stderr,
+                    )
                     print("     - Retry rollback after resolving", file=sys.stderr)
                     print("  2. Accept partial rollback:", file=sys.stderr)
-                    print("     - Non-conflicting files were rolled back successfully", file=sys.stderr)
-                    print("     - Conflicting files remain in their current state", file=sys.stderr)
+                    print(
+                        "     - Non-conflicting files were rolled back successfully",
+                        file=sys.stderr,
+                    )
+                    print(
+                        "     - Conflicting files remain in their current state",
+                        file=sys.stderr,
+                    )
                     print("  3. Use git directly:", file=sys.stderr)
-                    print("     - git --git-dir=.docimp/state/.git --work-tree=. revert <commit-sha>", file=sys.stderr)
+                    print(
+                        "     - git --git-dir=.docimp/state/.git "
+                        "--work-tree=. revert <commit-sha>",
+                        file=sys.stderr,
+                    )
 
         return 0 if result.success else 1
 
@@ -1126,13 +1148,13 @@ def cmd_rollback_change(
         print(f"Error: {e}", file=sys.stderr)
         if args.verbose:
             import traceback
+
             traceback.print_exc(file=sys.stderr)
         return 1
 
 
 def cmd_interactive_rollback(
-    args: argparse.Namespace,
-    manager: TransactionManager
+    args: argparse.Namespace, manager: TransactionManager
 ) -> int:
     """Handle the interactive-rollback subcommand.
 
@@ -1150,7 +1172,7 @@ def cmd_interactive_rollback(
             return 1
 
         # Step 1: List sessions
-        transactions_dir = StateManager.get_state_dir() / 'transactions'
+        transactions_dir = StateManager.get_state_dir() / "transactions"
         sessions = manager.list_uncommitted_transactions(transactions_dir)
 
         if not sessions:
@@ -1166,8 +1188,10 @@ def cmd_interactive_rollback(
 
         # Get session selection
         while True:
-            response = input(f"\nEnter session number (1-{len(sessions)}) or 'q' to quit: ")
-            if response.lower() == 'q':
+            response = input(
+                f"\nEnter session number (1-{len(sessions)}) or 'q' to quit: "
+            )
+            if response.lower() == "q":
                 print("Cancelled")
                 return 0
             try:
@@ -1194,8 +1218,10 @@ def cmd_interactive_rollback(
 
         # Get change selection
         while True:
-            response = input(f"\nEnter change number (1-{len(changes) + 1}) or 'q' to quit: ")
-            if response.lower() == 'q':
+            response = input(
+                f"\nEnter change number (1-{len(changes) + 1}) or 'q' to quit: "
+            )
+            if response.lower() == "q":
                 print("Cancelled")
                 return 0
             try:
@@ -1209,20 +1235,26 @@ def cmd_interactive_rollback(
         # Step 3: Confirm and rollback
         if change_idx == len(changes):
             # Rollback entire session
-            response = input(f"\nRollback entire session ({len(changes)} changes)? (y/N): ")
-            if response.lower() not in ['y', 'yes']:
+            response = input(
+                f"\nRollback entire session ({len(changes)} changes)? (y/N): "
+            )
+            if response.lower() not in ["y", "yes"]:
                 print("Cancelled")
                 return 0
 
-            manifest_path = transactions_dir / f'transaction-{selected_session.session_id}.json'
+            manifest_path = (
+                transactions_dir / f"transaction-{selected_session.session_id}.json"
+            )
             manifest = manager.load_manifest(manifest_path)
             restored_count = manager.rollback_transaction(manifest)
             print(f"\nSuccess! Rolled back {restored_count} file(s)")
         else:
             # Rollback individual change
             selected_change = changes[change_idx]
-            response = input(f"\nRollback change to {selected_change.item_name}? (y/N): ")
-            if response.lower() not in ['y', 'yes']:
+            response = input(
+                f"\nRollback change to {selected_change.item_name}? (y/N): "
+            )
+            if response.lower() not in ["y", "yes"]:
                 print("Cancelled")
                 return 0
 
@@ -1230,16 +1262,30 @@ def cmd_interactive_rollback(
             if result.success:
                 print(f"\nSuccess! Rolled back {result.restored_count} file(s)")
             else:
-                print(f"\nRollback failed: {result.failed_count} file(s) had conflicts", file=sys.stderr)
+                print(
+                    f"\nRollback failed: {result.failed_count} file(s) had conflicts",
+                    file=sys.stderr,
+                )
                 if result.conflicts:
                     print("\nConflict Details:", file=sys.stderr)
-                    print("The following files have been modified since this change was made:", file=sys.stderr)
+                    print(
+                        "The following files have been modified since this "
+                        "change was made:",
+                        file=sys.stderr,
+                    )
                     for conflict in result.conflicts:
                         print(f"  - {conflict}", file=sys.stderr)
                     print("\nResolution Options:", file=sys.stderr)
                     print("  1. Manually resolve conflicts and retry", file=sys.stderr)
-                    print("  2. Accept partial rollback (non-conflicting files rolled back)", file=sys.stderr)
-                    print("  3. Use git directly with --git-dir=.docimp/state/.git", file=sys.stderr)
+                    print(
+                        "  2. Accept partial rollback (non-conflicting files "
+                        "rolled back)",
+                        file=sys.stderr,
+                    )
+                    print(
+                        "  3. Use git directly with --git-dir=.docimp/state/.git",
+                        file=sys.stderr,
+                    )
                 return 1
 
         return 0
@@ -1248,6 +1294,7 @@ def cmd_interactive_rollback(
         print(f"Error: {e}", file=sys.stderr)
         if args.verbose:
             import traceback
+
             traceback.print_exc(file=sys.stderr)
         return 1
 
@@ -1262,440 +1309,389 @@ def main(argv: Optional[list] = None) -> int:
         Exit code (0 for success, 1 for error).
     """
     parser = argparse.ArgumentParser(
-        prog='analyzer',
-        description='Analyze documentation coverage in Python, TypeScript, and JavaScript codebases'
+        prog="analyzer",
+        description=(
+            "Analyze documentation coverage in Python, TypeScript, and "
+            "JavaScript codebases"
+        ),
     )
 
-    parser.add_argument(
-        '--version',
-        action='version',
-        version='%(prog)s 0.1.0'
-    )
+    parser.add_argument("--version", action="version", version="%(prog)s 0.1.0")
 
-    subparsers = parser.add_subparsers(dest='command', help='Available commands')
+    subparsers = parser.add_subparsers(dest="command", help="Available commands")
 
     # Analyze command
     analyze_parser = subparsers.add_parser(
-        'analyze',
-        help='Analyze documentation coverage'
+        "analyze", help="Analyze documentation coverage"
+    )
+    analyze_parser.add_argument("path", help="Path to file or directory to analyze")
+    analyze_parser.add_argument(
+        "--format",
+        choices=["json", "summary"],
+        default="summary",
+        help="Output format (default: summary)",
     )
     analyze_parser.add_argument(
-        'path',
-        help='Path to file or directory to analyze'
+        "--keep-old-reports",
+        action="store_true",
+        help="Preserve existing audit and plan files",
     )
     analyze_parser.add_argument(
-        '--format',
-        choices=['json', 'summary'],
-        default='summary',
-        help='Output format (default: summary)'
+        "--verbose", action="store_true", help="Enable verbose output"
     )
     analyze_parser.add_argument(
-        '--keep-old-reports',
-        action='store_true',
-        help='Preserve existing audit and plan files'
-    )
-    analyze_parser.add_argument(
-        '--verbose',
-        action='store_true',
-        help='Enable verbose output'
-    )
-    analyze_parser.add_argument(
-        '--strict',
-        action='store_true',
-        help='Fail immediately on first parse error (for CI/CD and debugging)'
+        "--strict",
+        action="store_true",
+        help="Fail immediately on first parse error (for CI/CD and debugging)",
     )
 
     # Audit command
     audit_parser = subparsers.add_parser(
-        'audit',
-        help='Find documented items for quality rating'
+        "audit", help="Find documented items for quality rating"
     )
+    audit_parser.add_argument("path", help="Path to file or directory to audit")
     audit_parser.add_argument(
-        'path',
-        help='Path to file or directory to audit'
-    )
-    audit_parser.add_argument(
-        '--audit-file',
+        "--audit-file",
         default=str(StateManager.get_audit_file()),
-        help=f'Path to audit results file (default: {StateManager.get_audit_file()})'
+        help=f"Path to audit results file (default: {StateManager.get_audit_file()})",
     )
     audit_parser.add_argument(
-        '--verbose',
-        action='store_true',
-        help='Enable verbose output'
+        "--verbose", action="store_true", help="Enable verbose output"
     )
 
     # Apply-audit command
     apply_audit_parser = subparsers.add_parser(
-        'apply-audit',
-        help='Save audit ratings from stdin'
+        "apply-audit", help="Save audit ratings from stdin"
     )
     apply_audit_parser.add_argument(
-        '--audit-file',
+        "--audit-file",
         default=str(StateManager.get_audit_file()),
-        help=f'Path to audit results file (default: {StateManager.get_audit_file()})'
+        help=f"Path to audit results file (default: {StateManager.get_audit_file()})",
     )
     apply_audit_parser.add_argument(
-        '--verbose',
-        action='store_true',
-        help='Enable verbose output'
+        "--verbose", action="store_true", help="Enable verbose output"
     )
 
     # Plan command
     plan_parser = subparsers.add_parser(
-        'plan',
-        help='Generate prioritized documentation improvement plan'
+        "plan", help="Generate prioritized documentation improvement plan"
     )
+    plan_parser.add_argument("path", help="Path to file or directory to analyze")
     plan_parser.add_argument(
-        'path',
-        help='Path to file or directory to analyze'
-    )
-    plan_parser.add_argument(
-        '--audit-file',
+        "--audit-file",
         default=str(StateManager.get_audit_file()),
-        help=f'Path to audit results file (default: {StateManager.get_audit_file()})'
+        help=f"Path to audit results file (default: {StateManager.get_audit_file()})",
     )
     plan_parser.add_argument(
-        '--plan-file',
+        "--plan-file",
         default=str(StateManager.get_plan_file()),
-        help=f'Path to save plan file (default: {StateManager.get_plan_file()})'
+        help=f"Path to save plan file (default: {StateManager.get_plan_file()})",
     )
     plan_parser.add_argument(
-        '--quality-threshold',
+        "--quality-threshold",
         type=int,
         default=2,
         choices=[1, 2, 3, 4],
-        help='Include items with audit rating <= threshold (default: 2)'
+        help="Include items with audit rating <= threshold (default: 2)",
     )
     plan_parser.add_argument(
-        '--verbose',
-        action='store_true',
-        help='Enable verbose output'
+        "--verbose", action="store_true", help="Enable verbose output"
     )
 
     # Suggest command
     suggest_parser = subparsers.add_parser(
-        'suggest',
-        help='Generate documentation suggestion for a specific item using Claude'
+        "suggest",
+        help="Generate documentation suggestion for a specific item using Claude",
     )
     suggest_parser.add_argument(
-        'target',
-        help='Target in format filepath:itemname (e.g., examples/test.py:my_function)'
+        "target",
+        help="Target in format filepath:itemname (e.g., examples/test.py:my_function)",
     )
     suggest_parser.add_argument(
-        '--style-guide',
+        "--style-guide",
         choices=[
             # Python (4 variants)
-            'google', 'numpy-rest', 'numpy-markdown', 'sphinx',
+            "google",
+            "numpy-rest",
+            "numpy-markdown",
+            "sphinx",
             # JavaScript (3 variants)
-            'jsdoc-vanilla', 'jsdoc-google', 'jsdoc-closure',
+            "jsdoc-vanilla",
+            "jsdoc-google",
+            "jsdoc-closure",
             # TypeScript (3 variants)
-            'tsdoc-typedoc', 'tsdoc-aedoc', 'jsdoc-ts'
+            "tsdoc-typedoc",
+            "tsdoc-aedoc",
+            "jsdoc-ts",
         ],
-        default='google',
-        help='Documentation style guide (default: google)'
+        default="google",
+        help="Documentation style guide (default: google)",
     )
     suggest_parser.add_argument(
-        '--tone',
-        choices=['concise', 'detailed', 'friendly'],
-        default='concise',
-        help='Documentation tone (default: concise)'
+        "--tone",
+        choices=["concise", "detailed", "friendly"],
+        default="concise",
+        help="Documentation tone (default: concise)",
     )
     suggest_parser.add_argument(
-        '--timeout',
+        "--timeout",
         type=float,
         default=30.0,
-        help='Claude API request timeout in seconds (default: 30.0)'
+        help="Claude API request timeout in seconds (default: 30.0)",
     )
     suggest_parser.add_argument(
-        '--max-retries',
+        "--max-retries",
         type=int,
         default=3,
-        help='Maximum retry attempts for Claude API (default: 3)'
+        help="Maximum retry attempts for Claude API (default: 3)",
     )
     suggest_parser.add_argument(
-        '--retry-delay',
+        "--retry-delay",
         type=float,
         default=1.0,
-        help='Base delay between retries in seconds (default: 1.0)'
+        help="Base delay between retries in seconds (default: 1.0)",
     )
     suggest_parser.add_argument(
-        '--verbose',
-        action='store_true',
-        help='Enable verbose output'
+        "--verbose", action="store_true", help="Enable verbose output"
     )
     suggest_parser.add_argument(
-        '--feedback',
+        "--feedback",
         type=str,
         default=None,
-        help='User feedback for regeneration (optional)'
+        help="User feedback for regeneration (optional)",
     )
 
     # Apply command (write documentation to files)
     apply_parser = subparsers.add_parser(
-        'apply',
-        help='Apply documentation to a source file (reads JSON from stdin)'
+        "apply", help="Apply documentation to a source file (reads JSON from stdin)"
     )
     apply_parser.add_argument(
-        '--verbose',
-        action='store_true',
-        help='Enable verbose output'
+        "--verbose", action="store_true", help="Enable verbose output"
     )
 
     # List-sessions command (list active sessions)
     list_sessions_parser = subparsers.add_parser(
-        'list-sessions',
-        help='List active DocImp sessions'
+        "list-sessions", help="List active DocImp sessions"
     )
     list_sessions_parser.add_argument(
-        '--format',
-        choices=['json', 'table'],
-        default='table',
-        help='Output format (default: table)'
+        "--format",
+        choices=["json", "table"],
+        default="table",
+        help="Output format (default: table)",
     )
     list_sessions_parser.add_argument(
-        '--verbose',
-        action='store_true',
-        help='Enable verbose output'
+        "--verbose", action="store_true", help="Enable verbose output"
     )
 
     # List-changes command (list changes in a session)
     list_changes_parser = subparsers.add_parser(
-        'list-changes',
-        help='List changes in a specific session'
+        "list-changes", help="List changes in a specific session"
     )
     list_changes_parser.add_argument(
-        'session_id',
-        help='Session ID to list changes for'
+        "session_id", help="Session ID to list changes for"
     )
     list_changes_parser.add_argument(
-        '--format',
-        choices=['json', 'table'],
-        default='table',
-        help='Output format (default: table)'
+        "--format",
+        choices=["json", "table"],
+        default="table",
+        help="Output format (default: table)",
     )
     list_changes_parser.add_argument(
-        '--verbose',
-        action='store_true',
-        help='Enable verbose output'
+        "--verbose", action="store_true", help="Enable verbose output"
     )
 
     # Begin-transaction command (initialize transaction tracking)
     begin_transaction_parser = subparsers.add_parser(
-        'begin-transaction',
-        help='Initialize transaction tracking for a session'
+        "begin-transaction", help="Initialize transaction tracking for a session"
+    )
+    begin_transaction_parser.add_argument("session_id", help="Session UUID")
+    begin_transaction_parser.add_argument(
+        "--format",
+        choices=["json", "text"],
+        default="text",
+        help="Output format (json or text)",
     )
     begin_transaction_parser.add_argument(
-        'session_id',
-        help='Session UUID'
+        "--verbose", action="store_true", help="Enable verbose output"
     )
     begin_transaction_parser.add_argument(
-        '--format',
-        choices=['json', 'text'],
-        default='text',
-        help='Output format (json or text)'
-    )
-    begin_transaction_parser.add_argument(
-        '--verbose',
-        action='store_true',
-        help='Enable verbose output'
-    )
-    begin_transaction_parser.add_argument(
-        '--git-timeout-base',
+        "--git-timeout-base",
         type=int,
         default=30000,
-        help='Base timeout for default git operations (milliseconds, default: 30000)'
+        help="Base timeout for default git operations (milliseconds, default: 30000)",
     )
     begin_transaction_parser.add_argument(
-        '--git-timeout-fast-scale',
+        "--git-timeout-fast-scale",
         type=float,
         default=0.167,
-        help='Scale factor for fast git operations (default: 0.167, produces 5s)'
+        help="Scale factor for fast git operations (default: 0.167, produces 5s)",
     )
     begin_transaction_parser.add_argument(
-        '--git-timeout-slow-scale',
+        "--git-timeout-slow-scale",
         type=float,
         default=4.0,
-        help='Scale factor for slow git operations (default: 4.0, produces 120s)'
+        help="Scale factor for slow git operations (default: 4.0, produces 120s)",
     )
     begin_transaction_parser.add_argument(
-        '--git-timeout-max',
+        "--git-timeout-max",
         type=int,
         default=300000,
-        help='Maximum timeout cap for any git operation (milliseconds, default: 300000)'
+        help=(
+            "Maximum timeout cap for any git operation "
+            "(milliseconds, default: 300000)"
+        ),
     )
 
     # Record-write command (record a documentation write in transaction)
     record_write_parser = subparsers.add_parser(
-        'record-write',
-        help='Record a documentation write in the current transaction'
+        "record-write", help="Record a documentation write in the current transaction"
+    )
+    record_write_parser.add_argument("session_id", help="Session UUID")
+    record_write_parser.add_argument(
+        "filepath", help="Absolute path to the modified file"
+    )
+    record_write_parser.add_argument("backup_path", help="Path to the backup file")
+    record_write_parser.add_argument(
+        "item_name", help="Name of the documented function/class/method"
     )
     record_write_parser.add_argument(
-        'session_id',
-        help='Session UUID'
+        "item_type", help="Type of code item (function, class, method)"
     )
     record_write_parser.add_argument(
-        'filepath',
-        help='Absolute path to the modified file'
+        "language", help="Programming language (python, javascript, typescript)"
     )
     record_write_parser.add_argument(
-        'backup_path',
-        help='Path to the backup file'
+        "--format",
+        choices=["json", "text"],
+        default="text",
+        help="Output format (json or text)",
     )
     record_write_parser.add_argument(
-        'item_name',
-        help='Name of the documented function/class/method'
+        "--verbose", action="store_true", help="Enable verbose output"
     )
     record_write_parser.add_argument(
-        'item_type',
-        help='Type of code item (function, class, method)'
-    )
-    record_write_parser.add_argument(
-        'language',
-        help='Programming language (python, javascript, typescript)'
-    )
-    record_write_parser.add_argument(
-        '--format',
-        choices=['json', 'text'],
-        default='text',
-        help='Output format (json or text)'
-    )
-    record_write_parser.add_argument(
-        '--verbose',
-        action='store_true',
-        help='Enable verbose output'
-    )
-    record_write_parser.add_argument(
-        '--git-timeout-base',
+        "--git-timeout-base",
         type=int,
         default=30000,
-        help='Base timeout for default git operations (milliseconds, default: 30000)'
+        help="Base timeout for default git operations (milliseconds, default: 30000)",
     )
     record_write_parser.add_argument(
-        '--git-timeout-fast-scale',
+        "--git-timeout-fast-scale",
         type=float,
         default=0.167,
-        help='Scale factor for fast git operations (default: 0.167, produces 5s)'
+        help="Scale factor for fast git operations (default: 0.167, produces 5s)",
     )
     record_write_parser.add_argument(
-        '--git-timeout-slow-scale',
+        "--git-timeout-slow-scale",
         type=float,
         default=4.0,
-        help='Scale factor for slow git operations (default: 4.0, produces 120s)'
+        help="Scale factor for slow git operations (default: 4.0, produces 120s)",
     )
     record_write_parser.add_argument(
-        '--git-timeout-max',
+        "--git-timeout-max",
         type=int,
         default=300000,
-        help='Maximum timeout cap for any git operation (milliseconds, default: 300000)'
+        help=(
+            "Maximum timeout cap for any git operation "
+            "(milliseconds, default: 300000)"
+        ),
     )
 
     # Commit-transaction command (finalize transaction with squash merge)
     commit_transaction_parser = subparsers.add_parser(
-        'commit-transaction',
-        help='Finalize transaction by squash-merging session to main'
+        "commit-transaction",
+        help="Finalize transaction by squash-merging session to main",
+    )
+    commit_transaction_parser.add_argument("session_id", help="Session UUID")
+    commit_transaction_parser.add_argument(
+        "--format",
+        choices=["json", "text"],
+        default="text",
+        help="Output format (json or text)",
     )
     commit_transaction_parser.add_argument(
-        'session_id',
-        help='Session UUID'
+        "--verbose", action="store_true", help="Enable verbose output"
     )
     commit_transaction_parser.add_argument(
-        '--format',
-        choices=['json', 'text'],
-        default='text',
-        help='Output format (json or text)'
-    )
-    commit_transaction_parser.add_argument(
-        '--verbose',
-        action='store_true',
-        help='Enable verbose output'
-    )
-    commit_transaction_parser.add_argument(
-        '--git-timeout-base',
+        "--git-timeout-base",
         type=int,
         default=30000,
-        help='Base timeout for default git operations (milliseconds, default: 30000)'
+        help="Base timeout for default git operations (milliseconds, default: 30000)",
     )
     commit_transaction_parser.add_argument(
-        '--git-timeout-fast-scale',
+        "--git-timeout-fast-scale",
         type=float,
         default=0.167,
-        help='Scale factor for fast git operations (default: 0.167, produces 5s)'
+        help="Scale factor for fast git operations (default: 0.167, produces 5s)",
     )
     commit_transaction_parser.add_argument(
-        '--git-timeout-slow-scale',
+        "--git-timeout-slow-scale",
         type=float,
         default=4.0,
-        help='Scale factor for slow git operations (default: 4.0, produces 120s)'
+        help="Scale factor for slow git operations (default: 4.0, produces 120s)",
     )
     commit_transaction_parser.add_argument(
-        '--git-timeout-max',
+        "--git-timeout-max",
         type=int,
         default=300000,
-        help='Maximum timeout cap for any git operation (milliseconds, default: 300000)'
+        help=(
+            "Maximum timeout cap for any git operation "
+            "(milliseconds, default: 300000)"
+        ),
     )
 
     # Rollback-session command (rollback entire session)
     rollback_session_parser = subparsers.add_parser(
-        'rollback-session',
-        help='Rollback an entire session (revert all changes)'
+        "rollback-session", help="Rollback an entire session (revert all changes)"
     )
     rollback_session_parser.add_argument(
-        'session_id',
-        help='Session ID to rollback, or "last" for most recent session'
+        "session_id", help='Session ID to rollback, or "last" for most recent session'
     )
     rollback_session_parser.add_argument(
-        '--format',
-        choices=['json', 'table'],
-        default='table',
-        help='Output format (default: table)'
+        "--format",
+        choices=["json", "table"],
+        default="table",
+        help="Output format (default: table)",
     )
     rollback_session_parser.add_argument(
-        '--no-confirm',
-        action='store_true',
-        help='Skip confirmation prompt (for scripting)'
+        "--no-confirm",
+        action="store_true",
+        help="Skip confirmation prompt (for scripting)",
     )
     rollback_session_parser.add_argument(
-        '--verbose',
-        action='store_true',
-        help='Enable verbose output'
+        "--verbose", action="store_true", help="Enable verbose output"
     )
 
     # Rollback-change command (rollback individual change)
     rollback_change_parser = subparsers.add_parser(
-        'rollback-change',
-        help='Rollback a specific change'
+        "rollback-change", help="Rollback a specific change"
     )
     rollback_change_parser.add_argument(
-        'entry_id',
-        help='Entry ID (commit SHA) to rollback, or "last" for most recent change'
+        "entry_id",
+        help='Entry ID (commit SHA) to rollback, or "last" for most recent change',
     )
     rollback_change_parser.add_argument(
-        '--format',
-        choices=['json', 'table'],
-        default='table',
-        help='Output format (default: table)'
+        "--format",
+        choices=["json", "table"],
+        default="table",
+        help="Output format (default: table)",
     )
     rollback_change_parser.add_argument(
-        '--no-confirm',
-        action='store_true',
-        help='Skip confirmation prompt (for scripting)'
+        "--no-confirm",
+        action="store_true",
+        help="Skip confirmation prompt (for scripting)",
     )
     rollback_change_parser.add_argument(
-        '--verbose',
-        action='store_true',
-        help='Enable verbose output'
+        "--verbose", action="store_true", help="Enable verbose output"
     )
 
     # Interactive-rollback command (interactive session/change selection)
     interactive_rollback_parser = subparsers.add_parser(
-        'interactive-rollback',
-        help='Interactive rollback with session and change selection'
+        "interactive-rollback",
+        help="Interactive rollback with session and change selection",
     )
     interactive_rollback_parser.add_argument(
-        '--verbose',
-        action='store_true',
-        help='Enable verbose output'
+        "--verbose", action="store_true", help="Enable verbose output"
     )
 
     # Parse arguments
@@ -1709,85 +1705,85 @@ def main(argv: Optional[list] = None) -> int:
     # Instantiate dependencies (ONLY place with instantiation in Python)
     # These are shared across most commands
     parsers = {
-        'python': PythonParser(),
-        'typescript': TypeScriptParser(),
-        'javascript': TypeScriptParser()
+        "python": PythonParser(),
+        "typescript": TypeScriptParser(),
+        "javascript": TypeScriptParser(),
     }
     scorer = ImpactScorer()
 
     # Dispatch to command handler with injected dependencies
-    if args.command == 'analyze':
+    if args.command == "analyze":
         return cmd_analyze(args, parsers, scorer)
-    elif args.command == 'audit':
+    elif args.command == "audit":
         return cmd_audit(args, parsers, scorer)
-    elif args.command == 'apply-audit':
+    elif args.command == "apply-audit":
         return cmd_apply_audit(args)
-    elif args.command == 'plan':
+    elif args.command == "plan":
         return cmd_plan(args, parsers, scorer)
-    elif args.command == 'suggest':
+    elif args.command == "suggest":
         # Create Claude client and prompt builder for suggest command
         try:
             claude_client = ClaudeClient(
                 timeout=args.timeout,
                 max_retries=args.max_retries,
-                retry_delay=args.retry_delay
+                retry_delay=args.retry_delay,
             )
         except ValueError as e:
             print(f"Error: {e}", file=sys.stderr)
-            print("Please set the ANTHROPIC_API_KEY environment variable", file=sys.stderr)
+            print(
+                "Please set the ANTHROPIC_API_KEY environment variable", file=sys.stderr
+            )
             return 1
-        prompt_builder = PromptBuilder(
-            style_guide=args.style_guide,
-            tone=args.tone
-        )
+        prompt_builder = PromptBuilder(style_guide=args.style_guide, tone=args.tone)
         return cmd_suggest(args, claude_client, prompt_builder)
-    elif args.command == 'apply':
+    elif args.command == "apply":
         # Create docstring writer for apply command
         apply_data = json.load(sys.stdin)
-        base_path = apply_data.get('base_path', '/')
+        base_path = apply_data.get("base_path", "/")
         docstring_writer = DocstringWriter(base_path=base_path)
         # Need to "rewind" stdin for cmd_apply to read it again
         import io
+
         sys.stdin = io.StringIO(json.dumps(apply_data))
         return cmd_apply(args, docstring_writer)
-    elif args.command == 'list-sessions':
+    elif args.command == "list-sessions":
         # Create transaction manager for session listing
         manager = TransactionManager()
         return cmd_list_sessions(args, manager)
-    elif args.command == 'list-changes':
+    elif args.command == "list-changes":
         # Create transaction manager for change listing
         base_path = Path.cwd()
         manager = TransactionManager(base_path=base_path)
         return cmd_list_changes(args, manager)
-    elif args.command == 'begin-transaction':
+    elif args.command == "begin-transaction":
         # Create transaction manager for beginning transaction
         base_path = Path.cwd()
         timeout_config = _build_git_timeout_config(args)
         manager = TransactionManager(base_path=base_path, timeout_config=timeout_config)
         return cmd_begin_transaction(args, manager)
-    elif args.command == 'record-write':
+    elif args.command == "record-write":
         # Create transaction manager for recording write
         base_path = Path.cwd()
         timeout_config = _build_git_timeout_config(args)
         manager = TransactionManager(base_path=base_path, timeout_config=timeout_config)
         return cmd_record_write(args, manager)
-    elif args.command == 'commit-transaction':
+    elif args.command == "commit-transaction":
         # Create transaction manager for committing transaction
         base_path = Path.cwd()
         timeout_config = _build_git_timeout_config(args)
         manager = TransactionManager(base_path=base_path, timeout_config=timeout_config)
         return cmd_commit_transaction(args, manager)
-    elif args.command == 'rollback-session':
+    elif args.command == "rollback-session":
         # Create transaction manager for session rollback
         base_path = Path.cwd()
         manager = TransactionManager(base_path=base_path)
         return cmd_rollback_session(args, manager)
-    elif args.command == 'rollback-change':
+    elif args.command == "rollback-change":
         # Create transaction manager for change rollback
         base_path = Path.cwd()
         manager = TransactionManager(base_path=base_path)
         return cmd_rollback_change(args, manager)
-    elif args.command == 'interactive-rollback':
+    elif args.command == "interactive-rollback":
         # Create transaction manager for interactive rollback
         base_path = Path.cwd()
         manager = TransactionManager(base_path=base_path)
@@ -1796,5 +1792,5 @@ def main(argv: Optional[list] = None) -> int:
     return 1
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/analyzer/src/models/analysis_result.py
+++ b/analyzer/src/models/analysis_result.py
@@ -94,14 +94,17 @@ class AnalysisResult:
         """
         result = asdict(self)
         # Ensure nested dataclasses are also converted
-        result['items'] = [item.to_dict() if hasattr(item, 'to_dict') else item
-                          for item in self.items]
-        result['by_language'] = {
-            lang: metrics.to_dict() if hasattr(metrics, 'to_dict') else metrics
+        result["items"] = [
+            item.to_dict() if hasattr(item, "to_dict") else item for item in self.items
+        ]
+        result["by_language"] = {
+            lang: metrics.to_dict() if hasattr(metrics, "to_dict") else metrics
             for lang, metrics in self.by_language.items()
         }
-        result['parse_failures'] = [failure.to_dict() if hasattr(failure, 'to_dict') else failure
-                                   for failure in self.parse_failures]
+        result["parse_failures"] = [
+            failure.to_dict() if hasattr(failure, "to_dict") else failure
+            for failure in self.parse_failures
+        ]
         return result
 
     def get_undocumented_items(self) -> list[CodeItem]:

--- a/analyzer/src/models/code_item.py
+++ b/analyzer/src/models/code_item.py
@@ -28,7 +28,8 @@ class CodeItem:
         return_type: Return type annotation if available.
         docstring: Existing documentation string if present.
         impact_score: Calculated priority score (0-100), set by ImpactScorer.
-        audit_rating: Quality rating from audit command (1-4), or None if skipped/not audited.
+        audit_rating: Quality rating from audit command (1-4), or None if
+            skipped/not audited.
     """
 
     # Required identity fields

--- a/analyzer/src/parsers/__init__.py
+++ b/analyzer/src/parsers/__init__.py
@@ -4,4 +4,4 @@ from .base_parser import BaseParser
 from .python_parser import PythonParser
 from .typescript_parser import TypeScriptParser
 
-__all__ = ['BaseParser', 'PythonParser', 'TypeScriptParser']
+__all__ = ["BaseParser", "PythonParser", "TypeScriptParser"]

--- a/analyzer/src/parsers/python_parser.py
+++ b/analyzer/src/parsers/python_parser.py
@@ -36,7 +36,7 @@ class PythonParser(BaseParser):
             If the file contains invalid Python syntax
         """
         try:
-            with open(filepath, 'r', encoding='utf-8') as f:
+            with open(filepath, "r", encoding="utf-8") as f:
                 source = f.read()
 
             tree = ast.parse(source, filename=filepath)
@@ -44,8 +44,8 @@ class PythonParser(BaseParser):
 
             # Build parent map to detect methods (functions inside classes)
             # This prevents method duplication while still extracting nested functions.
-            # Uses ast.walk() for full traversal to capture functions at all nesting levels.
-            # See issue #67.
+            # Uses ast.walk() for full traversal to capture functions at all
+            # nesting levels. See issue #67.
             parent_map = {}
             for node in ast.walk(tree):
                 for child in ast.iter_child_nodes(node):
@@ -55,7 +55,8 @@ class PythonParser(BaseParser):
                 if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
                     parent = parent_map.get(node)
                     if isinstance(parent, ast.ClassDef):
-                        # Skip - this is a method, will be extracted when processing the class
+                        # Skip - this is a method, will be extracted when
+                        # processing the class
                         continue
                     # This is a function (top-level or nested in another function)
                     item = self._extract_function(node, filepath)
@@ -67,8 +68,12 @@ class PythonParser(BaseParser):
                         items.append(item)
                     # Also extract methods from the class
                     for method_node in node.body:
-                        if isinstance(method_node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                            method_item = self._extract_method(method_node, node.name, filepath)
+                        if isinstance(
+                            method_node, (ast.FunctionDef, ast.AsyncFunctionDef)
+                        ):
+                            method_item = self._extract_method(
+                                method_node, node.name, filepath
+                            )
                             if method_item:
                                 items.append(method_item)
 
@@ -79,68 +84,79 @@ class PythonParser(BaseParser):
         except SyntaxError as e:
             raise SyntaxError(f"Syntax error in {filepath}: {e}")
 
-    def _extract_function(self, node: ast.FunctionDef | ast.AsyncFunctionDef, filepath: str) -> Optional[CodeItem]:
+    def _extract_function(
+        self, node: ast.FunctionDef | ast.AsyncFunctionDef, filepath: str
+    ) -> Optional[CodeItem]:
         """Extract a function definition as a CodeItem."""
         return CodeItem(
             name=node.name,
-            type='function',
+            type="function",
             filepath=filepath,
             line_number=node.lineno,
             end_line=node.end_lineno if node.end_lineno is not None else node.lineno,
-            language='python',
+            language="python",
             complexity=self._calculate_complexity(node),
             impact_score=0,  # Will be calculated by ImpactScorer
             has_docs=self._has_docstring(node),
             parameters=self._extract_parameters(node),
             return_type=self._extract_return_type(node),
             docstring=ast.get_docstring(node),
-            export_type='internal',  # Python doesn't have explicit exports
-            module_system='unknown'  # Python uses imports, not module systems
+            export_type="internal",  # Python doesn't have explicit exports
+            module_system="unknown",  # Python uses imports, not module systems
         )
 
     def _extract_class(self, node: ast.ClassDef, filepath: str) -> Optional[CodeItem]:
         """Extract a class definition as a CodeItem."""
         return CodeItem(
             name=node.name,
-            type='class',
+            type="class",
             filepath=filepath,
             line_number=node.lineno,
             end_line=node.end_lineno if node.end_lineno is not None else node.lineno,
-            language='python',
+            language="python",
             complexity=self._calculate_complexity(node),
             impact_score=0,  # Will be calculated by ImpactScorer
             has_docs=self._has_docstring(node),
             parameters=[],  # Classes don't have parameters in Python
             return_type=None,
             docstring=ast.get_docstring(node),
-            export_type='internal',
-            module_system='unknown'
+            export_type="internal",
+            module_system="unknown",
         )
 
-    def _extract_method(self, node: ast.FunctionDef | ast.AsyncFunctionDef, class_name: str, filepath: str) -> Optional[CodeItem]:
+    def _extract_method(
+        self,
+        node: ast.FunctionDef | ast.AsyncFunctionDef,
+        class_name: str,
+        filepath: str,
+    ) -> Optional[CodeItem]:
         """Extract a method definition as a CodeItem."""
         return CodeItem(
             name=f"{class_name}.{node.name}",
-            type='method',
+            type="method",
             filepath=filepath,
             line_number=node.lineno,
             end_line=node.end_lineno if node.end_lineno is not None else node.lineno,
-            language='python',
+            language="python",
             complexity=self._calculate_complexity(node),
             impact_score=0,  # Will be calculated by ImpactScorer
             has_docs=self._has_docstring(node),
             parameters=self._extract_parameters(node),
             return_type=self._extract_return_type(node),
             docstring=ast.get_docstring(node),
-            export_type='internal',
-            module_system='unknown'
+            export_type="internal",
+            module_system="unknown",
         )
 
-    def _has_docstring(self, node: ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef | ast.Module) -> bool:
+    def _has_docstring(
+        self, node: ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef | ast.Module
+    ) -> bool:
         """Check if a node has a docstring."""
         return ast.get_docstring(node) is not None
 
-    def _extract_parameters(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> List[str]:
+    def _extract_parameters(
+        self, node: ast.FunctionDef | ast.AsyncFunctionDef
+    ) -> List[str]:
         """Extract parameter names from a function."""
         params = []
 
@@ -158,7 +174,9 @@ class PythonParser(BaseParser):
 
         return params
 
-    def _extract_return_type(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> Optional[str]:
+    def _extract_return_type(
+        self, node: ast.FunctionDef | ast.AsyncFunctionDef
+    ) -> Optional[str]:
         """Extract return type annotation if present."""
         if node.returns:
             return ast.unparse(node.returns)
@@ -193,7 +211,9 @@ class PythonParser(BaseParser):
                     complexity += 1
                 elif isinstance(child, ast.BoolOp):
                     complexity += len(child.values) - 1
-                elif isinstance(child, (ast.ListComp, ast.SetComp, ast.DictComp, ast.GeneratorExp)):
+                elif isinstance(
+                    child, (ast.ListComp, ast.SetComp, ast.DictComp, ast.GeneratorExp)
+                ):
                     complexity += 1
                 elif isinstance(child, ast.Assert):
                     complexity += 1

--- a/analyzer/src/planning/__init__.py
+++ b/analyzer/src/planning/__init__.py
@@ -2,4 +2,4 @@
 
 from .plan_generator import PlanItem, PlanResult, generate_plan
 
-__all__ = ['PlanItem', 'PlanResult', 'generate_plan']
+__all__ = ["PlanItem", "PlanResult", "generate_plan"]

--- a/analyzer/src/planning/plan_generator.py
+++ b/analyzer/src/planning/plan_generator.py
@@ -1,7 +1,8 @@
 """Plan generator for prioritizing documentation improvements.
 
-This module generates prioritized plans for documentation improvements by combining
-items that need documentation (missing docs or poor quality) and sorting by impact score.
+This module generates prioritized plans for documentation improvements by
+combining items that need documentation (missing docs or poor quality) and
+sorting by impact score.
 """
 
 import json
@@ -60,7 +61,7 @@ class PlanItem:
     reason: str
 
     @classmethod
-    def from_code_item(cls, item: CodeItem, reason: str) -> 'PlanItem':
+    def from_code_item(cls, item: CodeItem, reason: str) -> "PlanItem":
         """Create a PlanItem from a CodeItem.
 
         Args:
@@ -86,7 +87,7 @@ class PlanItem:
             docstring=item.docstring,
             export_type=item.export_type,
             module_system=item.module_system,
-            reason=reason
+            reason=reason,
         )
 
     def to_dict(self) -> dict:
@@ -125,12 +126,12 @@ class PlanResult:
             Dictionary representation with all plan items.
         """
         return {
-            'items': [item.to_dict() for item in self.items],
-            'total_items': self.total_items,
-            'missing_docs_count': self.missing_docs_count,
-            'poor_quality_count': self.poor_quality_count,
-            'invalid_ratings_count': self.invalid_ratings_count,
-            'invalid_ratings': self.invalid_ratings
+            "items": [item.to_dict() for item in self.items],
+            "total_items": self.total_items,
+            "missing_docs_count": self.missing_docs_count,
+            "poor_quality_count": self.poor_quality_count,
+            "invalid_ratings_count": self.invalid_ratings_count,
+            "invalid_ratings": self.invalid_ratings,
         }
 
 
@@ -138,7 +139,7 @@ def generate_plan(
     result: AnalysisResult,
     audit_file: Optional[Path] = None,
     quality_threshold: int = 2,
-    scorer: Optional[ImpactScorer] = None
+    scorer: Optional[ImpactScorer] = None,
 ) -> PlanResult:
     """Generate a prioritized documentation improvement plan.
 
@@ -162,11 +163,13 @@ def generate_plan(
     Args:
         result: Analysis result containing all code items. Items will be modified
                 in-place to apply audit ratings and recalculate impact scores.
-        audit_file: Path to audit results file. If None, uses StateManager.get_audit_file().
-        quality_threshold: Items with audit rating <= this value are included (default: 2).
-                          Scale: 1=Terrible, 2=OK, 3=Good, 4=Excellent.
-        scorer: Impact scorer instance for recalculating scores with audit ratings (dependency injection).
-                If None, creates a new ImpactScorer with default settings.
+        audit_file: Path to audit results file. If None, uses
+                StateManager.get_audit_file().
+        quality_threshold: Items with audit rating <= this value are included
+                (default: 2). Scale: 1=Terrible, 2=OK, 3=Good, 4=Excellent.
+        scorer: Impact scorer instance for recalculating scores with audit
+                ratings (dependency injection). If None, creates a new
+                ImpactScorer with default settings.
 
     Returns:
         PlanResult with prioritized items to improve.
@@ -202,11 +205,9 @@ def generate_plan(
             if rating is not None:
                 # Validate rating is in expected range (1-4)
                 if not (1 <= rating <= 4):
-                    invalid_ratings.append({
-                        'filepath': item.filepath,
-                        'name': item.name,
-                        'rating': rating
-                    })
+                    invalid_ratings.append(
+                        {"filepath": item.filepath, "name": item.name, "rating": rating}
+                    )
                     continue  # Skip this invalid rating
 
                 item.audit_rating = rating
@@ -227,7 +228,9 @@ def generate_plan(
         # Include items with poor quality documentation (if audited)
         elif item.audit_rating is not None and item.audit_rating <= quality_threshold:
             quality_labels = {1: "Terrible", 2: "OK"}
-            quality_label = quality_labels.get(item.audit_rating, f"Rating {item.audit_rating}")
+            quality_label = quality_labels.get(
+                item.audit_rating, f"Rating {item.audit_rating}"
+            )
             reason = f"Poor quality documentation ({quality_label})"
             poor_quality_count += 1
 
@@ -244,7 +247,7 @@ def generate_plan(
         missing_docs_count=missing_docs_count,
         poor_quality_count=poor_quality_count,
         invalid_ratings_count=len(invalid_ratings),
-        invalid_ratings=invalid_ratings
+        invalid_ratings=invalid_ratings,
     )
 
 
@@ -260,5 +263,5 @@ def save_plan(plan: PlanResult, output_file: Optional[Path] = None) -> None:
 
     # Ensure state directory exists before writing
     StateManager.ensure_state_dir()
-    with open(output_file, 'w') as f:
+    with open(output_file, "w") as f:
         json.dump(plan.to_dict(), f, indent=2)

--- a/analyzer/src/scoring/impact_scorer.py
+++ b/analyzer/src/scoring/impact_scorer.py
@@ -26,17 +26,15 @@ class ImpactScorer:
     # Rating to penalty mapping for audit scores
     QUALITY_PENALTIES = {
         None: 100,  # No docs
-        0: 100,     # No docs (explicit)
-        1: 80,      # Terrible
-        2: 40,      # OK
-        3: 20,      # Good
-        4: 0,       # Excellent
+        0: 100,  # No docs (explicit)
+        1: 80,  # Terrible
+        2: 40,  # OK
+        3: 20,  # Good
+        4: 0,  # Excellent
     }
 
     def __init__(
-        self,
-        complexity_weight: float = 0.6,
-        quality_weight: float = 0.4
+        self, complexity_weight: float = 0.6, quality_weight: float = 0.4
     ) -> None:
         """Initialize the impact scorer with configurable weights.
 
@@ -49,9 +47,7 @@ class ImpactScorer:
         """
         weight_sum = complexity_weight + quality_weight
         if not math.isclose(weight_sum, 1.0, abs_tol=0.01):
-            raise ValueError(
-                f"Weights must sum to 1.0 (±0.01), got {weight_sum}"
-            )
+            raise ValueError(f"Weights must sum to 1.0 (±0.01), got {weight_sum}")
 
         self.complexity_weight = complexity_weight
         self.quality_weight = quality_weight
@@ -84,8 +80,8 @@ class ImpactScorer:
         # With audit rating, blend complexity and quality
         quality_penalty = self._get_quality_penalty(item.audit_rating)
         score = (
-            self.complexity_weight * complexity_score +
-            self.quality_weight * quality_penalty
+            self.complexity_weight * complexity_score
+            + self.quality_weight * quality_penalty
         )
 
         return min(100.0, score)

--- a/analyzer/src/utils/__init__.py
+++ b/analyzer/src/utils/__init__.py
@@ -2,4 +2,4 @@
 
 from .state_manager import StateManager
 
-__all__ = ['StateManager']
+__all__ = ["StateManager"]

--- a/analyzer/src/utils/state_manager.py
+++ b/analyzer/src/utils/state_manager.py
@@ -26,22 +26,23 @@ class StateManager:
     All methods return absolute paths resolved from the current working directory.
     """
 
-    STATE_DIR_NAME = '.docimp'
-    SESSION_REPORTS_DIR = 'session-reports'
-    HISTORY_DIR = 'history'
-    TRANSACTION_DIR = 'transactions'
-    GIT_STATE_DIR = 'state'
+    STATE_DIR_NAME = ".docimp"
+    SESSION_REPORTS_DIR = "session-reports"
+    HISTORY_DIR = "history"
+    TRANSACTION_DIR = "transactions"
+    GIT_STATE_DIR = "state"
 
-    AUDIT_FILE = 'audit.json'
-    PLAN_FILE = 'plan.json'
-    ANALYZE_FILE = 'analyze-latest.json'
+    AUDIT_FILE = "audit.json"
+    PLAN_FILE = "plan.json"
+    ANALYZE_FILE = "analyze-latest.json"
 
     @classmethod
     def get_state_dir(cls, base_path: Optional[Path] = None) -> Path:
         """Get the absolute path to the .docimp/ state directory.
 
         Args:
-            base_path: Base directory to resolve from. If None, uses current working directory.
+            base_path: Base directory to resolve from. If None, uses current
+                working directory.
 
         Returns:
             Absolute path to .docimp/ directory.
@@ -55,7 +56,8 @@ class StateManager:
         """Get the absolute path to the session-reports/ directory.
 
         Args:
-            base_path: Base directory to resolve from. If None, uses current working directory.
+            base_path: Base directory to resolve from. If None, uses current
+                working directory.
 
         Returns:
             Absolute path to .docimp/session-reports/ directory.
@@ -67,7 +69,8 @@ class StateManager:
         """Get the absolute path to the history/ directory.
 
         Args:
-            base_path: Base directory to resolve from. If None, uses current working directory.
+            base_path: Base directory to resolve from. If None, uses current
+                working directory.
 
         Returns:
             Absolute path to .docimp/history/ directory.
@@ -79,7 +82,8 @@ class StateManager:
         """Get the absolute path to the audit.json file.
 
         Args:
-            base_path: Base directory to resolve from. If None, uses current working directory.
+            base_path: Base directory to resolve from. If None, uses current
+                working directory.
 
         Returns:
             Absolute path to .docimp/session-reports/audit.json.
@@ -91,7 +95,8 @@ class StateManager:
         """Get the absolute path to the plan.json file.
 
         Args:
-            base_path: Base directory to resolve from. If None, uses current working directory.
+            base_path: Base directory to resolve from. If None, uses current
+                working directory.
 
         Returns:
             Absolute path to .docimp/session-reports/plan.json.
@@ -103,7 +108,8 @@ class StateManager:
         """Get the absolute path to the analyze-latest.json file.
 
         Args:
-            base_path: Base directory to resolve from. If None, uses current working directory.
+            base_path: Base directory to resolve from. If None, uses current
+                working directory.
 
         Returns:
             Absolute path to .docimp/session-reports/analyze-latest.json.
@@ -120,7 +126,8 @@ class StateManager:
         - .docimp/history/
 
         Args:
-            base_path: Base directory to resolve from. If None, uses current working directory.
+            base_path: Base directory to resolve from. If None, uses current
+                working directory.
         """
         state_dir = cls.get_state_dir(base_path)
         session_reports_dir = cls.get_session_reports_dir(base_path)
@@ -140,7 +147,8 @@ class StateManager:
         The history/ directory is NOT touched.
 
         Args:
-            base_path: Base directory to resolve from. If None, uses current working directory.
+            base_path: Base directory to resolve from. If None, uses current
+                working directory.
 
         Returns:
             Number of files removed.
@@ -166,7 +174,8 @@ class StateManager:
         """Check if the state directory exists.
 
         Args:
-            base_path: Base directory to resolve from. If None, uses current working directory.
+            base_path: Base directory to resolve from. If None, uses current
+                working directory.
 
         Returns:
             True if .docimp/ directory exists, False otherwise.
@@ -185,7 +194,8 @@ class StateManager:
             file_path: Path to the file to validate.
 
         Raises:
-            PermissionError: If we don't have write permission with a helpful error message.
+            PermissionError: If we don't have write permission with a helpful
+                error message.
         """
         # If file exists, check if it's writable
         if file_path.exists():
@@ -218,7 +228,8 @@ class StateManager:
         Each transaction is stored as transaction-{session_id}.json.
 
         Args:
-            base_path: Base directory to resolve from. If None, uses current working directory.
+            base_path: Base directory to resolve from. If None, uses current
+                working directory.
 
         Returns:
             Absolute path to .docimp/session-reports/transactions/ directory.
@@ -226,17 +237,21 @@ class StateManager:
         return cls.get_session_reports_dir(base_path) / cls.TRANSACTION_DIR
 
     @classmethod
-    def get_transaction_file(cls, session_id: str, base_path: Optional[Path] = None) -> Path:
+    def get_transaction_file(
+        cls, session_id: str, base_path: Optional[Path] = None
+    ) -> Path:
         """Get the absolute path to a specific transaction manifest file.
 
         Args:
             session_id: UUID of the transaction session
-            base_path: Base directory to resolve from. If None, uses current working directory.
+            base_path: Base directory to resolve from. If None, uses current
+                working directory.
 
         Returns:
-            Absolute path to .docimp/session-reports/transactions/transaction-{session_id}.json.
+            Absolute path to
+            .docimp/session-reports/transactions/transaction-{session_id}.json.
         """
-        return cls.get_transactions_dir(base_path) / f'transaction-{session_id}.json'
+        return cls.get_transactions_dir(base_path) / f"transaction-{session_id}.json"
 
     @classmethod
     def list_transaction_files(cls, base_path: Optional[Path] = None) -> List[Path]:
@@ -246,7 +261,8 @@ class StateManager:
         If the transactions directory doesn't exist, returns an empty list.
 
         Args:
-            base_path: Base directory to resolve from. If None, uses current working directory.
+            base_path: Base directory to resolve from. If None, uses current
+                working directory.
 
         Returns:
             List of Paths to transaction manifest files, newest first.
@@ -256,9 +272,9 @@ class StateManager:
             return []
 
         return sorted(
-            transactions_dir.glob('transaction-*.json'),
+            transactions_dir.glob("transaction-*.json"),
             key=lambda p: p.stat().st_mtime,
-            reverse=True
+            reverse=True,
         )
 
     @classmethod
@@ -269,7 +285,8 @@ class StateManager:
         transaction tracking and rollback capability.
 
         Args:
-            base_path: Base directory to resolve from. If None, uses current working directory.
+            base_path: Base directory to resolve from. If None, uses current
+                working directory.
 
         Returns:
             Absolute path to .docimp/state/ directory.
@@ -285,7 +302,8 @@ class StateManager:
         (graceful degradation).
 
         Args:
-            base_path: Base directory to resolve from. If None, uses current working directory.
+            base_path: Base directory to resolve from. If None, uses current
+                working directory.
 
         Returns:
             True if git state was successfully initialized, False if git unavailable.

--- a/analyzer/src/writer/__init__.py
+++ b/analyzer/src/writer/__init__.py
@@ -7,4 +7,4 @@ ensuring idempotency.
 
 from .docstring_writer import DocstringWriter
 
-__all__ = ['DocstringWriter']
+__all__ = ["DocstringWriter"]

--- a/analyzer/tests/test_analyze_auto_clean.py
+++ b/analyzer/tests/test_analyze_auto_clean.py
@@ -39,7 +39,7 @@ class TestAnalyzeAutoClean:
                 assert audit_file.exists()
 
                 # Run analyze
-                result = main(['analyze', '.', '--format', 'json'])
+                result = main(["analyze", ".", "--format", "json"])
 
                 # Should succeed
                 assert result == 0
@@ -73,7 +73,7 @@ class TestAnalyzeAutoClean:
                 assert plan_file.exists()
 
                 # Run analyze
-                result = main(['analyze', '.', '--format', 'json'])
+                result = main(["analyze", ".", "--format", "json"])
 
                 # Should succeed
                 assert result == 0
@@ -111,7 +111,9 @@ class TestAnalyzeAutoClean:
                 assert plan_file.exists()
 
                 # Run analyze with --keep-old-reports
-                result = main(['analyze', '.', '--format', 'json', '--keep-old-reports'])
+                result = main(
+                    ["analyze", ".", "--format", "json", "--keep-old-reports"]
+                )
 
                 # Should succeed
                 assert result == 0
@@ -123,8 +125,8 @@ class TestAnalyzeAutoClean:
                 # Verify content is unchanged
                 audit_content = json.loads(audit_file.read_text())
                 plan_content = json.loads(plan_file.read_text())
-                assert audit_content['ratings']['preserved'] == 'audit'
-                assert plan_content['items'][0]['name'] == 'preserved'
+                assert audit_content["ratings"]["preserved"] == "audit"
+                assert plan_content["items"][0]["name"] == "preserved"
             finally:
                 # Restore original working directory
                 os.chdir(original_cwd)
@@ -144,7 +146,7 @@ class TestAnalyzeAutoClean:
                 test_file.write_text("def foo():\n    pass\n")
 
                 # Run analyze
-                result = main(['analyze', '.', '--format', 'json'])
+                result = main(["analyze", ".", "--format", "json"])
 
                 # Should succeed
                 assert result == 0
@@ -155,11 +157,11 @@ class TestAnalyzeAutoClean:
 
                 # Verify content is valid JSON with expected structure
                 content = json.loads(analyze_file.read_text())
-                assert 'coverage_percent' in content
-                assert 'total_items' in content
-                assert 'documented_items' in content
-                assert 'items' in content
-                assert 'by_language' in content
+                assert "coverage_percent" in content
+                assert "total_items" in content
+                assert "documented_items" in content
+                assert "items" in content
+                assert "by_language" in content
             finally:
                 # Restore original working directory
                 os.chdir(original_cwd)
@@ -196,7 +198,7 @@ class TestAnalyzeAutoClean:
                 assert old_analyze_file.exists()
 
                 # Run analyze
-                result = main(['analyze', '.', '--format', 'json'])
+                result = main(["analyze", ".", "--format", "json"])
 
                 # Should succeed
                 assert result == 0
@@ -209,7 +211,9 @@ class TestAnalyzeAutoClean:
                 new_analyze_file = StateManager.get_analyze_file()
                 assert new_analyze_file.exists()
                 new_content = json.loads(new_analyze_file.read_text())
-                assert 'old' not in new_content  # Should be new analysis, not old content
+                assert (
+                    "old" not in new_content
+                )  # Should be new analysis, not old content
             finally:
                 # Restore original working directory
                 os.chdir(original_cwd)
@@ -238,7 +242,7 @@ class TestAnalyzeAutoClean:
                 assert history_file.exists()
 
                 # Run analyze
-                result = main(['analyze', '.', '--format', 'json'])
+                result = main(["analyze", ".", "--format", "json"])
 
                 # Should succeed
                 assert result == 0
@@ -246,7 +250,7 @@ class TestAnalyzeAutoClean:
                 # Verify history file was preserved
                 assert history_file.exists()
                 content = json.loads(history_file.read_text())
-                assert content['historical'] == 'data'
+                assert content["historical"] == "data"
             finally:
                 # Restore original working directory
                 os.chdir(original_cwd)
@@ -270,7 +274,7 @@ class TestAnalyzeAutoClean:
                 assert not state_dir.exists()
 
                 # Run analyze
-                result = main(['analyze', '.', '--format', 'json'])
+                result = main(["analyze", ".", "--format", "json"])
 
                 # Should succeed
                 assert result == 0

--- a/analyzer/tests/test_analyzer.py
+++ b/analyzer/tests/test_analyzer.py
@@ -14,9 +14,9 @@ from src.scoring.impact_scorer import ImpactScorer
 
 # Test fixture paths
 PROJECT_ROOT = Path(__file__).parent.parent.parent
-MALFORMED_SAMPLES = PROJECT_ROOT / 'test-samples' / 'malformed'
-MIXED_SAMPLES = PROJECT_ROOT / 'test-samples' / 'mixed-valid-invalid'
-EXAMPLES_DIR = PROJECT_ROOT / 'examples'
+MALFORMED_SAMPLES = PROJECT_ROOT / "test-samples" / "malformed"
+MIXED_SAMPLES = PROJECT_ROOT / "test-samples" / "mixed-valid-invalid"
+EXAMPLES_DIR = PROJECT_ROOT / "examples"
 
 
 class TestDocumentationAnalyzer:
@@ -27,18 +27,18 @@ class TestDocumentationAnalyzer:
         """Create analyzer instance with all parsers."""
         return DocumentationAnalyzer(
             parsers={
-                'python': PythonParser(),
-                'typescript': TypeScriptParser(),
-                'javascript': TypeScriptParser()
+                "python": PythonParser(),
+                "typescript": TypeScriptParser(),
+                "javascript": TypeScriptParser(),
             },
-            scorer=ImpactScorer()
+            scorer=ImpactScorer(),
         )
 
     @pytest.fixture
     def examples_dir(self):
         """Return path to examples directory."""
         project_root = Path(__file__).parent.parent.parent
-        return str(project_root / 'examples')
+        return str(project_root / "examples")
 
     def test_analyze_examples_directory(self, analyzer, examples_dir):
         """Test analyzing the examples directory."""
@@ -55,25 +55,28 @@ class TestDocumentationAnalyzer:
         result = analyzer.analyze(examples_dir)
 
         # Check language-specific items
-        python_items = [i for i in result.items if i.language == 'python']
-        typescript_items = [i for i in result.items if i.language == 'typescript']
-        javascript_items = [i for i in result.items if i.language == 'javascript']
+        python_items = [i for i in result.items if i.language == "python"]
+        typescript_items = [i for i in result.items if i.language == "typescript"]
+        javascript_items = [i for i in result.items if i.language == "javascript"]
 
         # Verify we have items from multiple languages
         assert len(python_items) > 0, "Should find Python items"
-        assert len(typescript_items) + len(javascript_items) > 0, "Should find TS/JS items"
+        assert (
+            len(typescript_items) + len(javascript_items) > 0
+        ), "Should find TS/JS items"
 
-        print(f'✓ Python items: {len(python_items)}')
-        print(f'✓ TypeScript items: {len(typescript_items)}')
-        print(f'✓ JavaScript items: {len(javascript_items)}')
+        print(f"✓ Python items: {len(python_items)}")
+        print(f"✓ TypeScript items: {len(typescript_items)}")
+        print(f"✓ JavaScript items: {len(javascript_items)}")
 
     def test_impact_scores_calculated(self, analyzer, examples_dir):
         """Test that impact scores are calculated for all items."""
         result = analyzer.analyze(examples_dir)
 
         for item in result.items:
-            assert 0 <= item.impact_score <= 100, \
-                f"Impact score for {item.name} should be 0-100, got {item.impact_score}"
+            assert (
+                0 <= item.impact_score <= 100
+            ), f"Impact score for {item.name} should be 0-100, got {item.impact_score}"
 
     def test_by_language_metrics(self, analyzer, examples_dir):
         """Test that per-language metrics are computed."""
@@ -90,44 +93,44 @@ class TestDocumentationAnalyzer:
     def test_file_exclusions(self, analyzer):
         """Test that excluded directories are skipped."""
         # Analyzer should have default exclusions
-        assert 'node_modules' in analyzer.exclude_patterns
-        assert 'venv' in analyzer.exclude_patterns
-        assert '__pycache__' in analyzer.exclude_patterns
+        assert "node_modules" in analyzer.exclude_patterns
+        assert "venv" in analyzer.exclude_patterns
+        assert "__pycache__" in analyzer.exclude_patterns
 
     def test_single_file_analysis(self, analyzer):
         """Test analyzing a single file."""
         project_root = Path(__file__).parent.parent.parent
-        test_file = project_root / 'examples' / 'test_simple.py'
+        test_file = project_root / "examples" / "test_simple.py"
 
         result = analyzer.analyze(str(test_file))
 
         assert len(result.items) > 0, "Should parse items from single file"
-        assert all(item.language == 'python' for item in result.items)
+        assert all(item.language == "python" for item in result.items)
 
     def test_nonexistent_path_raises_error(self, analyzer):
         """Test that analyzing nonexistent path raises FileNotFoundError."""
         with pytest.raises(FileNotFoundError):
-            analyzer.analyze('/nonexistent/path/that/does/not/exist')
+            analyzer.analyze("/nonexistent/path/that/does/not/exist")
 
     def test_custom_exclude_patterns(self):
         """Test that custom exclude patterns are merged with defaults."""
-        custom_excludes = {'custom_dir', 'temp'}
+        custom_excludes = {"custom_dir", "temp"}
         analyzer = DocumentationAnalyzer(
-            parsers={'python': PythonParser()},
+            parsers={"python": PythonParser()},
             scorer=ImpactScorer(),
-            exclude_patterns=custom_excludes
+            exclude_patterns=custom_excludes,
         )
 
         # Should have both default and custom excludes
-        assert 'node_modules' in analyzer.exclude_patterns
-        assert 'custom_dir' in analyzer.exclude_patterns
-        assert 'temp' in analyzer.exclude_patterns
+        assert "node_modules" in analyzer.exclude_patterns
+        assert "custom_dir" in analyzer.exclude_patterns
+        assert "temp" in analyzer.exclude_patterns
 
     def test_strict_path_resolution(self, analyzer):
         """Test that paths are resolved with strict validation."""
         # Nonexistent path should raise FileNotFoundError
         with pytest.raises(FileNotFoundError, match="does not exist or is invalid"):
-            analyzer.analyze('/this/path/definitely/does/not/exist/anywhere')
+            analyzer.analyze("/this/path/definitely/does/not/exist/anywhere")
 
     def test_symlink_resolution(self, analyzer):
         """Test that symlinks are properly resolved during analysis."""
@@ -135,13 +138,13 @@ class TestDocumentationAnalyzer:
 
         with tempfile.TemporaryDirectory() as temp_dir:
             # Create a real directory with a Python file
-            real_dir = Path(temp_dir) / 'real_project'
+            real_dir = Path(temp_dir) / "real_project"
             real_dir.mkdir()
-            py_file = real_dir / 'module.py'
-            py_file.write_text('def foo():\n    pass')
+            py_file = real_dir / "module.py"
+            py_file.write_text("def foo():\n    pass")
 
             # Create a symlink to it
-            symlink_dir = Path(temp_dir) / 'link_to_project'
+            symlink_dir = Path(temp_dir) / "link_to_project"
             symlink_dir.symlink_to(real_dir)
 
             # Analyze via symlink should work and resolve correctly
@@ -150,8 +153,9 @@ class TestDocumentationAnalyzer:
             assert len(result.items) > 0, "Should parse file via symlink"
             # The filepath in results should be the resolved real path
             for item in result.items:
-                assert str(real_dir) in item.filepath, \
-                    "Filepath should be resolved from symlink"
+                assert (
+                    str(real_dir) in item.filepath
+                ), "Filepath should be resolved from symlink"
 
     def test_parse_failure_tracking(self, analyzer):
         """Test that syntax errors are captured in parse_failures."""
@@ -161,12 +165,12 @@ class TestDocumentationAnalyzer:
             temp_path = Path(temp_dir)
 
             # Create a valid file so analysis doesn't fail entirely
-            valid_file = temp_path / 'valid.py'
-            valid_file.write_text('def bar():\n    pass')
+            valid_file = temp_path / "valid.py"
+            valid_file.write_text("def bar():\n    pass")
 
             # Create a file with syntax error
-            broken_file = temp_path / 'broken.py'
-            broken_file.write_text('def foo(\n    # Missing closing paren')
+            broken_file = temp_path / "broken.py"
+            broken_file.write_text("def foo(\n    # Missing closing paren")
 
             # Analyze should not crash
             result = analyzer.analyze(str(temp_path))
@@ -174,7 +178,9 @@ class TestDocumentationAnalyzer:
             # Should have captured the parse failure
             assert len(result.parse_failures) == 1, "Should capture one parse failure"
             assert str(broken_file) in result.parse_failures[0].filepath
-            assert len(result.parse_failures[0].error) > 0, "Error message should not be empty"
+            assert (
+                len(result.parse_failures[0].error) > 0
+            ), "Error message should not be empty"
 
     def test_analysis_continues_after_failures(self, analyzer):
         """Test that analysis continues after encountering parse failures."""
@@ -184,19 +190,21 @@ class TestDocumentationAnalyzer:
             temp_path = Path(temp_dir)
 
             # Create a valid file
-            valid_file = temp_path / 'valid.py'
-            valid_file.write_text('def good_function():\n    """A good function."""\n    pass')
+            valid_file = temp_path / "valid.py"
+            valid_file.write_text(
+                'def good_function():\n    """A good function."""\n    pass'
+            )
 
             # Create a file with syntax error
-            broken_file = temp_path / 'broken.py'
-            broken_file.write_text('def bad(\n    # Syntax error')
+            broken_file = temp_path / "broken.py"
+            broken_file.write_text("def bad(\n    # Syntax error")
 
             # Analyze should process both files
             result = analyzer.analyze(str(temp_path))
 
             # Should have one successful parse
             assert len(result.items) >= 1, "Should parse valid file"
-            assert any('good_function' in item.name for item in result.items)
+            assert any("good_function" in item.name for item in result.items)
 
             # Should have one failure
             assert len(result.parse_failures) == 1, "Should capture parse failure"
@@ -210,11 +218,11 @@ class TestDocumentationAnalyzer:
             temp_path = Path(temp_dir)
 
             # Create only broken files
-            broken1 = temp_path / 'broken1.py'
-            broken1.write_text('def bad1(\n    # Syntax error')
+            broken1 = temp_path / "broken1.py"
+            broken1.write_text("def bad1(\n    # Syntax error")
 
-            broken2 = temp_path / 'broken2.py'
-            broken2.write_text('class Bad2\n    # Missing colon')
+            broken2 = temp_path / "broken2.py"
+            broken2.write_text("class Bad2\n    # Missing colon")
 
             # Should raise ValueError when all files fail
             with pytest.raises(ValueError, match="Failed to parse all"):
@@ -225,8 +233,12 @@ class TestDocumentationAnalyzer:
         result = analyzer.analyze(examples_dir)
 
         # All example files should parse successfully
-        assert isinstance(result.parse_failures, list), "parse_failures should be a list"
-        assert len(result.parse_failures) == 0, "Should have no parse failures for valid files"
+        assert isinstance(
+            result.parse_failures, list
+        ), "parse_failures should be a list"
+        assert (
+            len(result.parse_failures) == 0
+        ), "Should have no parse failures for valid files"
 
     def test_empty_error_message_fallback(self, analyzer):
         """Test that empty error messages get fallback text."""
@@ -243,30 +255,37 @@ class TestDocumentationAnalyzer:
             temp_path = Path(temp_dir)
 
             # Create a valid file so analysis doesn't fail entirely
-            valid_file = temp_path / 'valid.py'
-            valid_file.write_text('def bar():\n    pass')
+            valid_file = temp_path / "valid.py"
+            valid_file.write_text("def bar():\n    pass")
 
             # Create a file that will trigger the empty error
-            bad_file = temp_path / 'bad.py'
-            bad_file.write_text('def foo():\n    pass')
+            bad_file = temp_path / "bad.py"
+            bad_file.write_text("def foo():\n    pass")
 
             # Create a mock that raises EmptyException only for bad.py
-            original_parse = analyzer.parsers['python'].parse_file
+            original_parse = analyzer.parsers["python"].parse_file
+
             def mock_parse(filepath):
-                if 'bad.py' in filepath:
+                if "bad.py" in filepath:
                     raise EmptyException()
                 return original_parse(filepath)
 
             # Mock the parser to raise exception with empty string for bad.py only
-            with patch.object(analyzer.parsers['python'], 'parse_file', side_effect=mock_parse):
+            with patch.object(
+                analyzer.parsers["python"], "parse_file", side_effect=mock_parse
+            ):
                 result = analyzer.analyze(str(temp_path))
 
                 # Should have captured the parse failure with fallback message
-                assert len(result.parse_failures) == 1, "Should capture one parse failure"
-                assert result.parse_failures[0].error == "Unknown parse error", \
-                    "Should use fallback message for empty error"
-                assert 'bad.py' in result.parse_failures[0].filepath, \
-                    "Should capture the bad.py file"
+                assert (
+                    len(result.parse_failures) == 1
+                ), "Should capture one parse failure"
+                assert (
+                    result.parse_failures[0].error == "Unknown parse error"
+                ), "Should use fallback message for empty error"
+                assert (
+                    "bad.py" in result.parse_failures[0].filepath
+                ), "Should capture the bad.py file"
 
     def test_expected_exceptions_are_caught(self, analyzer):
         """Test that expected parsing exceptions are caught and tracked."""
@@ -277,8 +296,8 @@ class TestDocumentationAnalyzer:
             temp_path = Path(temp_dir)
 
             # Create a valid file so analysis doesn't fail entirely
-            valid_file = temp_path / 'valid.py'
-            valid_file.write_text('def bar():\n    pass')
+            valid_file = temp_path / "valid.py"
+            valid_file.write_text("def bar():\n    pass")
 
             # Test each expected exception type
             expected_exceptions = [
@@ -291,23 +310,27 @@ class TestDocumentationAnalyzer:
 
             for exc in expected_exceptions:
                 # Create a file for this test
-                test_file = temp_path / f'test_{exc.__class__.__name__}.py'
-                test_file.write_text('def foo():\n    pass')
+                test_file = temp_path / f"test_{exc.__class__.__name__}.py"
+                test_file.write_text("def foo():\n    pass")
 
                 # Mock parser to raise the exception
-                original_parse = analyzer.parsers['python'].parse_file
+                original_parse = analyzer.parsers["python"].parse_file
+
                 def mock_parse(filepath):
                     if exc.__class__.__name__ in filepath:
                         raise exc
                     return original_parse(filepath)
 
-                with patch.object(analyzer.parsers['python'], 'parse_file', side_effect=mock_parse):
+                with patch.object(
+                    analyzer.parsers["python"], "parse_file", side_effect=mock_parse
+                ):
                     # Should not raise - should capture in parse_failures
                     result = analyzer.analyze(str(temp_path))
 
                     # Should have captured at least one failure
-                    assert len(result.parse_failures) >= 1, \
-                        f"Should capture parse failure for {exc.__class__.__name__}"
+                    assert (
+                        len(result.parse_failures) >= 1
+                    ), f"Should capture parse failure for {exc.__class__.__name__}"
 
                 # Clean up test file
                 test_file.unlink()
@@ -325,12 +348,15 @@ class TestDocumentationAnalyzer:
             temp_path = Path(temp_dir)
 
             # Create a test file
-            test_file = temp_path / 'test.py'
-            test_file.write_text('def foo():\n    pass')
+            test_file = temp_path / "test.py"
+            test_file.write_text("def foo():\n    pass")
 
             # Mock parser to raise unexpected exception
-            with patch.object(analyzer.parsers['python'], 'parse_file',
-                            side_effect=UnexpectedException("unexpected")):
+            with patch.object(
+                analyzer.parsers["python"],
+                "parse_file",
+                side_effect=UnexpectedException("unexpected"),
+            ):
                 # Should re-raise the unexpected exception
                 with pytest.raises(UnexpectedException):
                     analyzer.analyze(str(temp_path))
@@ -343,126 +369,166 @@ class TestDocumentationAnalyzer:
             temp_path = Path(temp_dir)
 
             # Create a valid file
-            valid_file = temp_path / 'valid.py'
-            valid_file.write_text('def good_function():\n    """A good function."""\n    pass')
+            valid_file = temp_path / "valid.py"
+            valid_file.write_text(
+                'def good_function():\n    """A good function."""\n    pass'
+            )
 
             # Create a file with syntax error
-            broken_file = temp_path / 'broken.py'
-            broken_file.write_text('def bad_function(\n    # Syntax error - missing closing paren')
+            broken_file = temp_path / "broken.py"
+            broken_file.write_text(
+                "def bad_function(\n    # Syntax error - missing closing paren"
+            )
 
             # In strict mode, should raise SyntaxError immediately
             with pytest.raises(SyntaxError):
                 analyzer.analyze(str(temp_path), strict=True)
 
     def test_non_strict_mode_collects_all_parse_errors(self, analyzer):
-        """Test that strict=False (default) collects all parse errors without raising."""
+        """Test that strict=False (default) collects all parse errors.
+
+        (without raising)."""
         import tempfile
 
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)
 
             # Create a valid file
-            valid_file = temp_path / 'valid.py'
-            valid_file.write_text('def good_function():\n    """A good function."""\n    pass')
+            valid_file = temp_path / "valid.py"
+            valid_file.write_text(
+                'def good_function():\n    """A good function."""\n    pass'
+            )
 
             # Create two files with syntax errors
-            broken1 = temp_path / 'broken1.py'
-            broken1.write_text('def bad1(\n    # Missing closing paren')
+            broken1 = temp_path / "broken1.py"
+            broken1.write_text("def bad1(\n    # Missing closing paren")
 
-            broken2 = temp_path / 'broken2.py'
-            broken2.write_text('class Bad2\n    # Missing colon')
+            broken2 = temp_path / "broken2.py"
+            broken2.write_text("class Bad2\n    # Missing colon")
 
             # In non-strict mode (default), should collect all failures
             result = analyzer.analyze(str(temp_path), strict=False)
 
             # Should have two parse failures
             assert len(result.parse_failures) == 2, "Should capture both parse failures"
-            assert any('broken1.py' in f.filepath for f in result.parse_failures)
-            assert any('broken2.py' in f.filepath for f in result.parse_failures)
+            assert any("broken1.py" in f.filepath for f in result.parse_failures)
+            assert any("broken2.py" in f.filepath for f in result.parse_failures)
 
             # Should still have parsed the valid file
             assert len(result.items) >= 1, "Should parse valid file"
-            assert any('good_function' in item.name for item in result.items)
+            assert any("good_function" in item.name for item in result.items)
 
     def test_malformed_directory_analysis(self, analyzer):
-        """Test analyzing test-samples/malformed/ directory with broken files (Issue #199)."""
+        """Test analyzing test-samples/malformed/ directory with broken files.
+
+        (Issue #199)."""
         # Analyze directory with malformed files
         result = analyzer.analyze(str(MALFORMED_SAMPLES))
 
         # TypeScript/JavaScript parsers use error recovery and parse partial ASTs
         # Only Python files with syntax errors fail to parse
         # Should have exactly 4 Python parse failures
-        python_failures = [f for f in result.parse_failures if f.filepath.endswith('.py')]
-        assert len(python_failures) == 4, \
-            f"Expected exactly 4 Python failures, got {len(python_failures)}. " \
+        python_failures = [
+            f for f in result.parse_failures if f.filepath.endswith(".py")
+        ]
+        assert len(python_failures) == 4, (
+            f"Expected exactly 4 Python failures, got {len(python_failures)}. "
             f"Check that test-samples/malformed/ hasn't been modified."
+        )
 
         # Check that Python malformed files are tracked as failures
         failed_files = [f.filepath for f in result.parse_failures]
-        assert any('python_missing_colon.py' in f for f in failed_files), \
-            "Python missing colon file should fail to parse"
-        assert any('python_unclosed_paren.py' in f for f in failed_files), \
-            "Python unclosed paren file should fail to parse"
-        assert any('python_invalid_indentation.py' in f for f in failed_files), \
-            "Python invalid indentation file should fail to parse"
-        assert any('python_incomplete_statement.py' in f for f in failed_files), \
-            "Python incomplete statement file should fail to parse"
+        assert any(
+            "python_missing_colon.py" in f for f in failed_files
+        ), "Python missing colon file should fail to parse"
+        assert any(
+            "python_unclosed_paren.py" in f for f in failed_files
+        ), "Python unclosed paren file should fail to parse"
+        assert any(
+            "python_invalid_indentation.py" in f for f in failed_files
+        ), "Python invalid indentation file should fail to parse"
+        assert any(
+            "python_incomplete_statement.py" in f for f in failed_files
+        ), "Python incomplete statement file should fail to parse"
 
         # Analysis should complete without crashing
         # TypeScript/JavaScript items may be present due to error recovery
         assert result.total_items >= 0, "Analysis should complete successfully"
 
     def test_mixed_valid_invalid_analysis(self, analyzer):
-        """Test analyzing test-samples/mixed-valid-invalid/ with mix of valid and broken files (Issue #199)."""
+        """Test analyzing test-samples/mixed-valid-invalid/ with mix of files.
+
+        (valid and broken files, Issue #199)."""
         # Analyze directory with 3 valid and 3 broken files
         result = analyzer.analyze(str(MIXED_SAMPLES))
 
-        # Should have items from the 3 valid files + partial items from TS/JS (error recovery)
+        # Should have items from the 3 valid files + partial items
+        # from TS/JS (error recovery)
         assert len(result.items) > 0, "Should parse valid files"
 
         # Python file with syntax error should fail
         # TypeScript/JavaScript use error recovery, so they may not fail
-        assert len(result.parse_failures) >= 1, \
-            f"Expected at least 1 parse failure (Python), got {len(result.parse_failures)}"
+        assert len(result.parse_failures) >= 1, (
+            f"Expected at least 1 parse failure (Python), "
+            f"got {len(result.parse_failures)}"
+        )
 
         # Check that Python broken file is tracked as failure
         failed_files = [f.filepath for f in result.parse_failures]
-        assert any('broken_syntax.py' in f for f in failed_files), \
-            "Python broken file should fail to parse"
+        assert any(
+            "broken_syntax.py" in f for f in failed_files
+        ), "Python broken file should fail to parse"
 
         # Check that valid files were parsed successfully
         item_names = [item.name for item in result.items]
-        assert any('calculate_area' in name or 'Shape' in name for name in item_names), \
-            "Should parse Python valid file"
+        assert any(
+            "calculate_area" in name or "Shape" in name for name in item_names
+        ), "Should parse Python valid file"
         # TypeScript/JavaScript valid files should be parsed
-        assert any('DataProcessor' in name or 'formatMessage' in name or
-                  'add' in name or 'Calculator' in name for name in item_names), \
-            "Should parse TypeScript/JavaScript valid files"
+        assert any(
+            "DataProcessor" in name
+            or "formatMessage" in name
+            or "add" in name
+            or "Calculator" in name
+            for name in item_names
+        ), "Should parse TypeScript/JavaScript valid files"
 
     def test_python_syntax_failures_tracked(self, analyzer):
-        """Test that Python syntax failures are properly tracked in parse_failures (Issue #199)."""
+        """Test that Python syntax failures are properly tracked.
+
+        (in parse_failures, Issue #199)."""
         result = analyzer.analyze(str(MALFORMED_SAMPLES))
 
         # Get Python failures (by file extension)
-        python_failures = [f for f in result.parse_failures if f.filepath.endswith('.py')]
-        assert len(python_failures) == 4, \
-            f"Expected 4 Python failures, got {len(python_failures)}"
+        python_failures = [
+            f for f in result.parse_failures if f.filepath.endswith(".py")
+        ]
+        assert (
+            len(python_failures) == 4
+        ), f"Expected 4 Python failures, got {len(python_failures)}"
 
         # Verify each Python failure has error message
         for failure in python_failures:
-            assert failure.error, \
-                f"Python failure {failure.filepath} should have error message"
-            assert 'Syntax error' in failure.error or 'syntax' in failure.error.lower(), \
-                f"Error should mention syntax: {failure.error}"
+            assert (
+                failure.error
+            ), f"Python failure {failure.filepath} should have error message"
+            assert (
+                "Syntax error" in failure.error or "syntax" in failure.error.lower()
+            ), f"Error should mention syntax: {failure.error}"
 
     def test_polyglot_analysis_with_python_errors(self, analyzer):
-        """Test that Python syntax errors are handled while TS/JS use error recovery (Issue #199)."""
+        """Test that Python syntax errors are handled while TS/JS use error
+
+        recovery (Issue #199)."""
         result = analyzer.analyze(str(MALFORMED_SAMPLES))
 
         # Python files should fail to parse (4 failures expected)
-        python_failures = [f for f in result.parse_failures if f.filepath.endswith('.py')]
-        assert len(python_failures) == 4, \
-            f"Expected 4 Python failures, got {len(python_failures)}"
+        python_failures = [
+            f for f in result.parse_failures if f.filepath.endswith(".py")
+        ]
+        assert (
+            len(python_failures) == 4
+        ), f"Expected 4 Python failures, got {len(python_failures)}"
 
         # TypeScript/JavaScript parsers use error recovery, so they may succeed
         # or partially succeed. The key is that analysis completes without crashing.
@@ -471,5 +537,6 @@ class TestDocumentationAnalyzer:
         # Verify Python failures have error messages
         for failure in python_failures:
             assert failure.error, "Python failures should have error messages"
-            assert 'Syntax error' in failure.error or 'syntax' in failure.error.lower(), \
-                f"Error message should mention syntax: {failure.error}"
+            assert (
+                "Syntax error" in failure.error or "syntax" in failure.error.lower()
+            ), f"Error message should mention syntax: {failure.error}"

--- a/analyzer/tests/test_audit.py
+++ b/analyzer/tests/test_audit.py
@@ -9,11 +9,7 @@ import pytest
 # Add parent directory to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from src.audit.quality_rater import (
-    AuditResult,
-    load_audit_results,
-    save_audit_results
-)
+from src.audit.quality_rater import AuditResult, load_audit_results, save_audit_results
 from src.main import cmd_audit, cmd_apply_audit
 from src.parsers.python_parser import PythonParser
 from src.parsers.typescript_parser import TypeScriptParser
@@ -30,39 +26,39 @@ class TestAuditCommand:
         from src.models.analysis_result import AnalysisResult
 
         documented_item = CodeItem(
-            name='documented_func',
-            type='function',
-            filepath='test.py',
+            name="documented_func",
+            type="function",
+            filepath="test.py",
             line_number=10,
             end_line=15,
-            language='python',
+            language="python",
             complexity=5,
             impact_score=25.0,
             has_docs=True,
-            parameters=['x', 'y'],
-            return_type='int',
-            docstring='This function has documentation.',
-            export_type='named',
-            module_system='esm',
-            audit_rating=None
+            parameters=["x", "y"],
+            return_type="int",
+            docstring="This function has documentation.",
+            export_type="named",
+            module_system="esm",
+            audit_rating=None,
         )
 
         undocumented_item = CodeItem(
-            name='undocumented_func',
-            type='function',
-            filepath='test.py',
+            name="undocumented_func",
+            type="function",
+            filepath="test.py",
             line_number=20,
             end_line=23,
-            language='python',
+            language="python",
             complexity=3,
             impact_score=15.0,
             has_docs=False,
-            parameters=['a'],
-            return_type='str',
+            parameters=["a"],
+            return_type="str",
             docstring=None,
-            export_type='named',
-            module_system='esm',
-            audit_rating=None
+            export_type="named",
+            module_system="esm",
+            audit_rating=None,
         )
 
         result = AnalysisResult(
@@ -70,7 +66,7 @@ class TestAuditCommand:
             coverage_percent=50.0,
             total_items=2,
             documented_items=1,
-            by_language={}
+            by_language={},
         )
         return result
 
@@ -80,19 +76,17 @@ class TestAuditCommand:
 
         # Create mock dependencies for DI
         parsers = {
-            'python': PythonParser(),
-            'typescript': TypeScriptParser(),
-            'javascript': TypeScriptParser()
+            "python": PythonParser(),
+            "typescript": TypeScriptParser(),
+            "javascript": TypeScriptParser(),
         }
         scorer = ImpactScorer()
 
-        with patch('src.main.create_analyzer') as mock_create:
+        with patch("src.main.create_analyzer") as mock_create:
             mock_create.return_value.analyze.return_value = mock_analyzer
 
             args = argparse.Namespace(
-                path='./test',
-                verbose=False,
-                audit_file='.docimp-audit.json'
+                path="./test", verbose=False, audit_file=".docimp-audit.json"
             )
 
             exit_code = cmd_audit(args, parsers, scorer)
@@ -102,9 +96,9 @@ class TestAuditCommand:
             captured = capsys.readouterr()
             output = json.loads(captured.out)
 
-            assert 'items' in output
-            assert len(output['items']) == 1
-            assert output['items'][0]['name'] == 'documented_func'
+            assert "items" in output
+            assert len(output["items"]) == 1
+            assert output["items"][0]["name"] == "documented_func"
 
     def test_audit_excludes_undocumented(self, mock_analyzer, capsys):
         """Test audit command excludes items without docs."""
@@ -112,19 +106,17 @@ class TestAuditCommand:
 
         # Create mock dependencies for DI
         parsers = {
-            'python': PythonParser(),
-            'typescript': TypeScriptParser(),
-            'javascript': TypeScriptParser()
+            "python": PythonParser(),
+            "typescript": TypeScriptParser(),
+            "javascript": TypeScriptParser(),
         }
         scorer = ImpactScorer()
 
-        with patch('src.main.create_analyzer') as mock_create:
+        with patch("src.main.create_analyzer") as mock_create:
             mock_create.return_value.analyze.return_value = mock_analyzer
 
             args = argparse.Namespace(
-                path='./test',
-                verbose=False,
-                audit_file='.docimp-audit.json'
+                path="./test", verbose=False, audit_file=".docimp-audit.json"
             )
 
             exit_code = cmd_audit(args, parsers, scorer)
@@ -135,8 +127,8 @@ class TestAuditCommand:
             output = json.loads(captured.out)
 
             # Should NOT contain undocumented_func
-            item_names = [item['name'] for item in output['items']]
-            assert 'undocumented_func' not in item_names
+            item_names = [item["name"] for item in output["items"]]
+            assert "undocumented_func" not in item_names
 
 
 class TestApplyAuditCommand:
@@ -147,35 +139,25 @@ class TestApplyAuditCommand:
         import argparse
         from io import StringIO
 
-        audit_file = tmp_path / '.docimp-audit.json'
+        audit_file = tmp_path / ".docimp-audit.json"
 
-        audit_data = {
-            'ratings': {
-                'test.py': {
-                    'func1': 3,
-                    'func2': 2
-                }
-            }
-        }
+        audit_data = {"ratings": {"test.py": {"func1": 3, "func2": 2}}}
 
-        args = argparse.Namespace(
-            audit_file=str(audit_file),
-            verbose=False
-        )
+        args = argparse.Namespace(audit_file=str(audit_file), verbose=False)
 
         # Mock stdin with StringIO
         mock_stdin = StringIO(json.dumps(audit_data))
-        with patch('sys.stdin', mock_stdin):
+        with patch("sys.stdin", mock_stdin):
             exit_code = cmd_apply_audit(args)
 
         assert exit_code == 0
         assert audit_file.exists()
 
         # Verify contents
-        with open(audit_file, 'r') as f:
+        with open(audit_file, "r") as f:
             saved_data = json.load(f)
 
-        assert saved_data['ratings'] == audit_data['ratings']
+        assert saved_data["ratings"] == audit_data["ratings"]
 
 
 class TestAuditPersistence:
@@ -183,82 +165,66 @@ class TestAuditPersistence:
 
     def test_load_audit_empty_file(self):
         """Test loading when file doesn't exist returns empty."""
-        result = load_audit_results(Path('/nonexistent/path/.docimp-audit.json'))
+        result = load_audit_results(Path("/nonexistent/path/.docimp-audit.json"))
 
         assert isinstance(result, AuditResult)
         assert result.ratings == {}
 
     def test_load_audit_existing(self, tmp_path):
         """Test loading existing ratings."""
-        audit_file = tmp_path / '.docimp-audit.json'
+        audit_file = tmp_path / ".docimp-audit.json"
 
         test_data = {
-            'ratings': {
-                'file1.py': {
-                    'func_a': 4,
-                    'func_b': 2
-                },
-                'file2.py': {
-                    'func_c': 3
-                }
+            "ratings": {
+                "file1.py": {"func_a": 4, "func_b": 2},
+                "file2.py": {"func_c": 3},
             }
         }
 
-        with open(audit_file, 'w') as f:
+        with open(audit_file, "w") as f:
             json.dump(test_data, f)
 
         result = load_audit_results(audit_file)
 
-        assert result.ratings == test_data['ratings']
-        assert result.get_rating('file1.py', 'func_a') == 4
-        assert result.get_rating('file2.py', 'func_c') == 3
+        assert result.ratings == test_data["ratings"]
+        assert result.get_rating("file1.py", "func_a") == 4
+        assert result.get_rating("file2.py", "func_c") == 3
 
     def test_save_audit_creates_file(self, tmp_path):
         """Test saving creates .docimp-audit.json."""
-        audit_file = tmp_path / '.docimp-audit.json'
+        audit_file = tmp_path / ".docimp-audit.json"
 
-        audit_result = AuditResult(
-            ratings={
-                'test.py': {
-                    'my_func': 3
-                }
-            }
-        )
+        audit_result = AuditResult(ratings={"test.py": {"my_func": 3}})
 
         save_audit_results(audit_result, audit_file)
 
         assert audit_file.exists()
 
         # Verify contents
-        with open(audit_file, 'r') as f:
+        with open(audit_file, "r") as f:
             saved_data = json.load(f)
 
-        assert 'ratings' in saved_data
-        assert saved_data['ratings']['test.py']['my_func'] == 3
+        assert "ratings" in saved_data
+        assert saved_data["ratings"]["test.py"]["my_func"] == 3
 
     def test_skip_saved_as_none(self, tmp_path):
         """Test that skipped items are saved as None, not a number."""
-        audit_file = tmp_path / '.docimp-audit.json'
+        audit_file = tmp_path / ".docimp-audit.json"
 
         audit_result = AuditResult(
-            ratings={
-                'test.py': {
-                    'rated_func': 3,
-                    'skipped_func': None
-                }
-            }
+            ratings={"test.py": {"rated_func": 3, "skipped_func": None}}
         )
 
         save_audit_results(audit_result, audit_file)
 
         # Load and verify
-        with open(audit_file, 'r') as f:
+        with open(audit_file, "r") as f:
             saved_data = json.load(f)
 
-        assert saved_data['ratings']['test.py']['rated_func'] == 3
-        assert saved_data['ratings']['test.py']['skipped_func'] is None
+        assert saved_data["ratings"]["test.py"]["rated_func"] == 3
+        assert saved_data["ratings"]["test.py"]["skipped_func"] is None
 
         # Also verify through load function
         loaded = load_audit_results(audit_file)
-        assert loaded.get_rating('test.py', 'rated_func') == 3
-        assert loaded.get_rating('test.py', 'skipped_func') is None
+        assert loaded.get_rating("test.py", "rated_func") == 3
+        assert loaded.get_rating("test.py", "skipped_func") is None

--- a/analyzer/tests/test_backup_cleanup.py
+++ b/analyzer/tests/test_backup_cleanup.py
@@ -48,26 +48,29 @@ def test_find_orphaned_backups_tracked_excluded():
         bak_file.write_text("backup content")
 
         # Create a transaction that references this backup
-        manifest = manager.begin_transaction('test-session')
+        manifest = manager.begin_transaction("test-session")
         manifest.entries.append(
             TransactionEntry(
-                entry_id='abc123',
-                filepath=str(base_path / 'tracked.py'),
+                entry_id="abc123",
+                filepath=str(base_path / "tracked.py"),
                 backup_path=str(bak_file),
-                timestamp='2024-01-01T10:00:00',
-                item_name='test_func',
-                item_type='function',
-                language='python',
-                success=True
+                timestamp="2024-01-01T10:00:00",
+                item_name="test_func",
+                item_type="function",
+                language="python",
+                success=True,
             )
         )
 
         # Save the manifest
         from src.utils.state_manager import StateManager
+
         StateManager.ensure_state_dir(base_path)
-        transactions_dir = StateManager.get_state_dir(base_path) / 'session-reports' / 'transactions'
+        transactions_dir = (
+            StateManager.get_state_dir(base_path) / "session-reports" / "transactions"
+        )
         transactions_dir.mkdir(parents=True, exist_ok=True)
-        manifest_path = transactions_dir / f'transaction-{manifest.session_id}.json'
+        manifest_path = transactions_dir / f"transaction-{manifest.session_id}.json"
         manager.save_manifest(manifest, manifest_path)
 
         # Check for orphans
@@ -91,6 +94,7 @@ def test_find_orphaned_backups_age_filter():
         old_time = time.time() - (8 * 24 * 3600)  # 8 days ago
         old_bak.touch()
         import os
+
         os.utime(old_bak, (old_time, old_time))
 
         # Create a recent backup file
@@ -143,6 +147,7 @@ def test_cleanup_orphaned_backups_deletes_files():
         # Make them old (8 days)
         old_time = time.time() - (8 * 24 * 3600)
         import os
+
         for bak in [bak1, bak2]:
             os.utime(bak, (old_time, old_time))
 
@@ -167,6 +172,7 @@ def test_cleanup_orphaned_backups_dry_run():
         # Make it old
         old_time = time.time() - (8 * 24 * 3600)
         import os
+
         os.utime(bak, (old_time, old_time))
 
         # Dry run
@@ -191,6 +197,7 @@ def test_cleanup_orphaned_backups_respects_age():
         # Make one old
         old_time = time.time() - (8 * 24 * 3600)
         import os
+
         os.utime(old_bak, (old_time, old_time))
 
         # Cleanup (7 day threshold)

--- a/analyzer/tests/test_claude_client.py
+++ b/analyzer/tests/test_claude_client.py
@@ -19,60 +19,56 @@ class TestClaudeClientInitialization:
 
     def test_initialization_with_api_key_parameter(self):
         """Test ClaudeClient initialization with API key as parameter."""
-        client = ClaudeClient(api_key='sk-ant-test-key')
-        assert client.api_key == 'sk-ant-test-key'
-        assert client.model == 'claude-sonnet-4-20250514'
+        client = ClaudeClient(api_key="sk-ant-test-key")
+        assert client.api_key == "sk-ant-test-key"
+        assert client.model == "claude-sonnet-4-20250514"
         assert client.max_retries == 3
         assert client.retry_delay == 1.0
 
     def test_initialization_with_environment_variable(self):
         """Test ClaudeClient initialization with API key from environment."""
-        with patch.dict('os.environ', {'ANTHROPIC_API_KEY': 'sk-ant-env-key'}):
+        with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "sk-ant-env-key"}):
             client = ClaudeClient()
-            assert client.api_key == 'sk-ant-env-key'
+            assert client.api_key == "sk-ant-env-key"
 
     def test_initialization_without_api_key_raises_error(self):
         """Test that missing API key raises ValueError."""
-        with patch.dict('os.environ', {}, clear=True):
-            with pytest.raises(ValueError, match='API key must be provided'):
+        with patch.dict("os.environ", {}, clear=True):
+            with pytest.raises(ValueError, match="API key must be provided"):
                 ClaudeClient()
 
     def test_custom_model_configuration(self):
         """Test ClaudeClient with custom model."""
-        client = ClaudeClient(api_key='sk-ant-test', model='claude-opus-4-20250514')
-        assert client.model == 'claude-opus-4-20250514'
+        client = ClaudeClient(api_key="sk-ant-test", model="claude-opus-4-20250514")
+        assert client.model == "claude-opus-4-20250514"
 
     def test_custom_retry_configuration(self):
         """Test ClaudeClient with custom retry settings."""
-        client = ClaudeClient(
-            api_key='sk-ant-test',
-            max_retries=5,
-            retry_delay=2.0
-        )
+        client = ClaudeClient(api_key="sk-ant-test", max_retries=5, retry_delay=2.0)
         assert client.max_retries == 5
         assert client.retry_delay == 2.0
 
     def test_default_timeout_configuration(self):
         """Test ClaudeClient has default timeout of 30 seconds."""
-        client = ClaudeClient(api_key='sk-ant-test')
+        client = ClaudeClient(api_key="sk-ant-test")
         assert client.timeout == 30.0
 
     def test_custom_timeout_configuration(self):
         """Test ClaudeClient with custom timeout."""
-        client = ClaudeClient(api_key='sk-ant-test', timeout=60.0)
+        client = ClaudeClient(api_key="sk-ant-test", timeout=60.0)
         assert client.timeout == 60.0
 
     def test_full_custom_configuration(self):
         """Test ClaudeClient with all custom configuration parameters."""
         client = ClaudeClient(
-            api_key='sk-ant-test',
-            model='claude-opus-4-20250514',
+            api_key="sk-ant-test",
+            model="claude-opus-4-20250514",
             timeout=45.0,
             max_retries=5,
-            retry_delay=2.0
+            retry_delay=2.0,
         )
-        assert client.api_key == 'sk-ant-test'
-        assert client.model == 'claude-opus-4-20250514'
+        assert client.api_key == "sk-ant-test"
+        assert client.model == "claude-opus-4-20250514"
         assert client.timeout == 45.0
         assert client.max_retries == 5
         assert client.retry_delay == 2.0
@@ -83,7 +79,7 @@ class TestClaudeClientRetryBackoffHelper:
 
     def test_should_retry_calculation_first_attempt(self):
         """Test retry calculation for first attempt (attempt=0)."""
-        client = ClaudeClient(api_key='sk-ant-test', max_retries=3, retry_delay=1.0)
+        client = ClaudeClient(api_key="sk-ant-test", max_retries=3, retry_delay=1.0)
         should_retry, delay = client._should_retry(0)
 
         assert should_retry is True
@@ -91,7 +87,7 @@ class TestClaudeClientRetryBackoffHelper:
 
     def test_should_retry_calculation_second_attempt(self):
         """Test retry calculation for second attempt (attempt=1)."""
-        client = ClaudeClient(api_key='sk-ant-test', max_retries=3, retry_delay=1.0)
+        client = ClaudeClient(api_key="sk-ant-test", max_retries=3, retry_delay=1.0)
         should_retry, delay = client._should_retry(1)
 
         assert should_retry is True
@@ -99,7 +95,7 @@ class TestClaudeClientRetryBackoffHelper:
 
     def test_should_retry_calculation_third_attempt(self):
         """Test retry calculation for third attempt (attempt=2)."""
-        client = ClaudeClient(api_key='sk-ant-test', max_retries=3, retry_delay=1.0)
+        client = ClaudeClient(api_key="sk-ant-test", max_retries=3, retry_delay=1.0)
         should_retry, delay = client._should_retry(2)
 
         # This is the last retry (attempt 2 < max_retries-1 is False)
@@ -108,7 +104,7 @@ class TestClaudeClientRetryBackoffHelper:
 
     def test_should_retry_with_custom_delay(self):
         """Test retry calculation with custom base delay."""
-        client = ClaudeClient(api_key='sk-ant-test', max_retries=3, retry_delay=2.0)
+        client = ClaudeClient(api_key="sk-ant-test", max_retries=3, retry_delay=2.0)
         should_retry, delay = client._should_retry(0)
 
         assert should_retry is True
@@ -120,14 +116,16 @@ class TestClaudeClientRetryBackoffHelper:
 
     def test_should_retry_exponential_progression(self):
         """Test that delays follow exponential progression."""
-        client = ClaudeClient(api_key='sk-ant-test', max_retries=5, retry_delay=1.0)
+        client = ClaudeClient(api_key="sk-ant-test", max_retries=5, retry_delay=1.0)
 
         # Test exponential progression: 1.0, 2.0, 4.0, 8.0
         expected_delays = [1.0, 2.0, 4.0, 8.0]
         for attempt, expected_delay in enumerate(expected_delays):
             should_retry, delay = client._should_retry(attempt)
             assert should_retry is True
-            assert delay == expected_delay, f"Attempt {attempt}: expected {expected_delay}, got {delay}"
+            assert (
+                delay == expected_delay
+            ), f"Attempt {attempt}: expected {expected_delay}, got {delay}"
 
         # Last attempt should not retry
         should_retry, delay = client._should_retry(4)
@@ -138,7 +136,7 @@ class TestClaudeClientRetryBackoffHelper:
 class TestClaudeClientAPIInteraction:
     """Test ClaudeClient API calls and response handling."""
 
-    @patch('anthropic.Anthropic')
+    @patch("anthropic.Anthropic")
     def test_successful_docstring_generation(self, mock_anthropic_class):
         """Test successful documentation generation."""
         # Mock the API response
@@ -146,12 +144,14 @@ class TestClaudeClientAPIInteraction:
         mock_anthropic_class.return_value = mock_client
 
         mock_message = MagicMock()
-        mock_message.content = [MagicMock(spec=TextBlock, text='"""Generated docstring"""')]
+        mock_message.content = [
+            MagicMock(spec=TextBlock, text='"""Generated docstring"""')
+        ]
         mock_client.messages.create.return_value = mock_message
 
         # Create client and generate docstring
-        client = ClaudeClient(api_key='sk-ant-test')
-        result = client.generate_docstring('Generate docs for this function')
+        client = ClaudeClient(api_key="sk-ant-test")
+        result = client.generate_docstring("Generate docs for this function")
 
         # Verify result
         assert result == '"""Generated docstring"""'
@@ -159,12 +159,14 @@ class TestClaudeClientAPIInteraction:
         # Verify API call
         mock_client.messages.create.assert_called_once()
         call_kwargs = mock_client.messages.create.call_args[1]
-        assert call_kwargs['model'] == 'claude-sonnet-4-20250514'
-        assert call_kwargs['max_tokens'] == 1024
-        assert call_kwargs['messages'][0]['role'] == 'user'
-        assert call_kwargs['messages'][0]['content'] == 'Generate docs for this function'
+        assert call_kwargs["model"] == "claude-sonnet-4-20250514"
+        assert call_kwargs["max_tokens"] == 1024
+        assert call_kwargs["messages"][0]["role"] == "user"
+        assert (
+            call_kwargs["messages"][0]["content"] == "Generate docs for this function"
+        )
 
-    @patch('anthropic.Anthropic')
+    @patch("anthropic.Anthropic")
     def test_custom_max_tokens(self, mock_anthropic_class):
         """Test docstring generation with custom max_tokens."""
         mock_client = MagicMock()
@@ -174,13 +176,13 @@ class TestClaudeClientAPIInteraction:
         mock_message.content = [MagicMock(spec=TextBlock, text='"""Docstring"""')]
         mock_client.messages.create.return_value = mock_message
 
-        client = ClaudeClient(api_key='sk-ant-test')
-        client.generate_docstring('prompt', max_tokens=2048)
+        client = ClaudeClient(api_key="sk-ant-test")
+        client.generate_docstring("prompt", max_tokens=2048)
 
         call_kwargs = mock_client.messages.create.call_args[1]
-        assert call_kwargs['max_tokens'] == 2048
+        assert call_kwargs["max_tokens"] == 2048
 
-    @patch('anthropic.Anthropic')
+    @patch("anthropic.Anthropic")
     def test_timeout_passed_to_api_call(self, mock_anthropic_class):
         """Test that timeout is passed to API call."""
         mock_client = MagicMock()
@@ -190,13 +192,13 @@ class TestClaudeClientAPIInteraction:
         mock_message.content = [MagicMock(spec=TextBlock, text='"""Docstring"""')]
         mock_client.messages.create.return_value = mock_message
 
-        client = ClaudeClient(api_key='sk-ant-test', timeout=45.0)
-        client.generate_docstring('test prompt')
+        client = ClaudeClient(api_key="sk-ant-test", timeout=45.0)
+        client.generate_docstring("test prompt")
 
         call_kwargs = mock_client.messages.create.call_args[1]
-        assert call_kwargs['timeout'] == 45.0
+        assert call_kwargs["timeout"] == 45.0
 
-    @patch('anthropic.Anthropic')
+    @patch("anthropic.Anthropic")
     def test_response_text_extraction(self, mock_anthropic_class):
         """Test that response text is correctly extracted from API response."""
         mock_client = MagicMock()
@@ -205,16 +207,16 @@ class TestClaudeClientAPIInteraction:
         # Mock response with specific structure
         mock_message = MagicMock()
         mock_content_block = MagicMock(spec=TextBlock)
-        mock_content_block.text = 'Expected documentation text'
+        mock_content_block.text = "Expected documentation text"
         mock_message.content = [mock_content_block]
         mock_client.messages.create.return_value = mock_message
 
-        client = ClaudeClient(api_key='sk-ant-test')
-        result = client.generate_docstring('test prompt')
+        client = ClaudeClient(api_key="sk-ant-test")
+        result = client.generate_docstring("test prompt")
 
-        assert result == 'Expected documentation text'
+        assert result == "Expected documentation text"
 
-    @patch('anthropic.Anthropic')
+    @patch("anthropic.Anthropic")
     def test_unexpected_content_block_type_raises_error(self, mock_anthropic_class):
         """Test that non-TextBlock content raises RuntimeError."""
         mock_client = MagicMock()
@@ -224,16 +226,16 @@ class TestClaudeClientAPIInteraction:
         mock_message = MagicMock()
         mock_tool_block = MagicMock()
         # Set the spec to ToolUseBlock so isinstance check will fail
-        mock_tool_block.__class__.__name__ = 'ToolUseBlock'
+        mock_tool_block.__class__.__name__ = "ToolUseBlock"
         # Remove text attribute to make it clearly not a TextBlock
         del mock_tool_block.text
         mock_message.content = [mock_tool_block]
         mock_client.messages.create.return_value = mock_message
 
-        client = ClaudeClient(api_key='sk-ant-test')
+        client = ClaudeClient(api_key="sk-ant-test")
 
-        with pytest.raises(RuntimeError, match='Unexpected content block type'):
-            client.generate_docstring('test prompt')
+        with pytest.raises(RuntimeError, match="Unexpected content block type"):
+            client.generate_docstring("test prompt")
 
 
 class TestClaudeClientRetryLogic:
@@ -246,8 +248,8 @@ class TestClaudeClientRetryLogic:
         mock_response.headers = {}
         return mock_response
 
-    @patch('anthropic.Anthropic')
-    @patch('time.sleep')
+    @patch("anthropic.Anthropic")
+    @patch("time.sleep")
     def test_retry_on_rate_limit(self, mock_sleep, mock_anthropic_class):
         """Test that client retries on rate limit error."""
         import anthropic
@@ -262,20 +264,22 @@ class TestClaudeClientRetryLogic:
         mock_message = MagicMock()
         mock_message.content = [MagicMock(spec=TextBlock, text='"""Success"""')]
         mock_client.messages.create.side_effect = [
-            anthropic.RateLimitError('Rate limit exceeded', response=mock_response, body=None),
-            mock_message
+            anthropic.RateLimitError(
+                "Rate limit exceeded", response=mock_response, body=None
+            ),
+            mock_message,
         ]
 
-        client = ClaudeClient(api_key='sk-ant-test', retry_delay=1.0)
-        result = client.generate_docstring('test prompt')
+        client = ClaudeClient(api_key="sk-ant-test", retry_delay=1.0)
+        result = client.generate_docstring("test prompt")
 
         # Verify retry happened
         assert result == '"""Success"""'
         assert mock_client.messages.create.call_count == 2
         mock_sleep.assert_called_once_with(1.0)  # First retry: 1.0 * (2^0)
 
-    @patch('anthropic.Anthropic')
-    @patch('time.sleep')
+    @patch("anthropic.Anthropic")
+    @patch("time.sleep")
     def test_exponential_backoff(self, mock_sleep, mock_anthropic_class):
         """Test exponential backoff on multiple rate limit errors."""
         import anthropic
@@ -290,13 +294,13 @@ class TestClaudeClientRetryLogic:
         mock_message = MagicMock()
         mock_message.content = [MagicMock(spec=TextBlock, text='"""Success"""')]
         mock_client.messages.create.side_effect = [
-            anthropic.RateLimitError('Rate limit', response=mock_response, body=None),
-            anthropic.RateLimitError('Rate limit', response=mock_response, body=None),
-            mock_message
+            anthropic.RateLimitError("Rate limit", response=mock_response, body=None),
+            anthropic.RateLimitError("Rate limit", response=mock_response, body=None),
+            mock_message,
         ]
 
-        client = ClaudeClient(api_key='sk-ant-test', retry_delay=1.0)
-        result = client.generate_docstring('test prompt')
+        client = ClaudeClient(api_key="sk-ant-test", retry_delay=1.0)
+        result = client.generate_docstring("test prompt")
 
         # Verify exponential backoff
         assert result == '"""Success"""'
@@ -306,8 +310,8 @@ class TestClaudeClientRetryLogic:
         mock_sleep.assert_any_call(1.0)
         mock_sleep.assert_any_call(2.0)
 
-    @patch('anthropic.Anthropic')
-    @patch('time.sleep')
+    @patch("anthropic.Anthropic")
+    @patch("time.sleep")
     def test_max_retries_exceeded(self, mock_sleep, mock_anthropic_class):
         """Test that RateLimitError is raised after max retries."""
         import anthropic
@@ -320,20 +324,18 @@ class TestClaudeClientRetryLogic:
 
         # Always fail with rate limit
         mock_client.messages.create.side_effect = anthropic.RateLimitError(
-            'Rate limit',
-            response=mock_response,
-            body=None
+            "Rate limit", response=mock_response, body=None
         )
 
-        client = ClaudeClient(api_key='sk-ant-test', max_retries=3)
+        client = ClaudeClient(api_key="sk-ant-test", max_retries=3)
 
         with pytest.raises(anthropic.RateLimitError):
-            client.generate_docstring('test prompt')
+            client.generate_docstring("test prompt")
 
         # Verify it tried max_retries times
         assert mock_client.messages.create.call_count == 3
 
-    @patch('anthropic.Anthropic')
+    @patch("anthropic.Anthropic")
     def test_no_retry_on_other_api_errors(self, mock_anthropic_class):
         """Test that other API errors are not retried."""
         import anthropic
@@ -346,15 +348,13 @@ class TestClaudeClientRetryLogic:
 
         # Raise a different API error
         mock_client.messages.create.side_effect = anthropic.APIError(
-            'Invalid request',
-            request=mock_request,
-            body=None
+            "Invalid request", request=mock_request, body=None
         )
 
-        client = ClaudeClient(api_key='sk-ant-test')
+        client = ClaudeClient(api_key="sk-ant-test")
 
         with pytest.raises(anthropic.APIError):
-            client.generate_docstring('test prompt')
+            client.generate_docstring("test prompt")
 
         # Verify it only tried once (no retry)
         assert mock_client.messages.create.call_count == 1
@@ -363,8 +363,8 @@ class TestClaudeClientRetryLogic:
 class TestClaudeClientTimeoutHandling:
     """Test ClaudeClient timeout behavior and retry logic."""
 
-    @patch('anthropic.Anthropic')
-    @patch('time.sleep')
+    @patch("anthropic.Anthropic")
+    @patch("time.sleep")
     def test_retry_on_timeout(self, mock_sleep, mock_anthropic_class):
         """Test that client retries on timeout error."""
         import anthropic
@@ -376,20 +376,20 @@ class TestClaudeClientTimeoutHandling:
         mock_message = MagicMock()
         mock_message.content = [MagicMock(spec=TextBlock, text='"""Success"""')]
         mock_client.messages.create.side_effect = [
-            anthropic.APITimeoutError('Request timed out'),
-            mock_message
+            anthropic.APITimeoutError("Request timed out"),
+            mock_message,
         ]
 
-        client = ClaudeClient(api_key='sk-ant-test', retry_delay=1.0)
-        result = client.generate_docstring('test prompt')
+        client = ClaudeClient(api_key="sk-ant-test", retry_delay=1.0)
+        result = client.generate_docstring("test prompt")
 
         # Verify retry happened
         assert result == '"""Success"""'
         assert mock_client.messages.create.call_count == 2
         mock_sleep.assert_called_once_with(1.0)
 
-    @patch('anthropic.Anthropic')
-    @patch('time.sleep')
+    @patch("anthropic.Anthropic")
+    @patch("time.sleep")
     def test_timeout_exponential_backoff(self, mock_sleep, mock_anthropic_class):
         """Test exponential backoff on multiple timeout errors."""
         import anthropic
@@ -401,13 +401,13 @@ class TestClaudeClientTimeoutHandling:
         mock_message = MagicMock()
         mock_message.content = [MagicMock(spec=TextBlock, text='"""Success"""')]
         mock_client.messages.create.side_effect = [
-            anthropic.APITimeoutError('Timeout 1'),
-            anthropic.APITimeoutError('Timeout 2'),
-            mock_message
+            anthropic.APITimeoutError("Timeout 1"),
+            anthropic.APITimeoutError("Timeout 2"),
+            mock_message,
         ]
 
-        client = ClaudeClient(api_key='sk-ant-test', retry_delay=1.0)
-        result = client.generate_docstring('test prompt')
+        client = ClaudeClient(api_key="sk-ant-test", retry_delay=1.0)
+        result = client.generate_docstring("test prompt")
 
         # Verify exponential backoff
         assert result == '"""Success"""'
@@ -417,8 +417,8 @@ class TestClaudeClientTimeoutHandling:
         mock_sleep.assert_any_call(1.0)
         mock_sleep.assert_any_call(2.0)
 
-    @patch('anthropic.Anthropic')
-    @patch('time.sleep')
+    @patch("anthropic.Anthropic")
+    @patch("time.sleep")
     def test_timeout_max_retries_exceeded(self, mock_sleep, mock_anthropic_class):
         """Test that RuntimeError is raised after max timeout retries."""
         import anthropic
@@ -427,18 +427,22 @@ class TestClaudeClientTimeoutHandling:
         mock_anthropic_class.return_value = mock_client
 
         # Always timeout
-        mock_client.messages.create.side_effect = anthropic.APITimeoutError('Persistent timeout')
+        mock_client.messages.create.side_effect = anthropic.APITimeoutError(
+            "Persistent timeout"
+        )
 
-        client = ClaudeClient(api_key='sk-ant-test', max_retries=3, timeout=30.0)
+        client = ClaudeClient(api_key="sk-ant-test", max_retries=3, timeout=30.0)
 
-        with pytest.raises(RuntimeError, match=r'Claude API request timed out after 3 attempts'):
-            client.generate_docstring('test prompt')
+        with pytest.raises(
+            RuntimeError, match=r"Claude API request timed out after 3 attempts"
+        ):
+            client.generate_docstring("test prompt")
 
         # Verify it tried max_retries times
         assert mock_client.messages.create.call_count == 3
 
-    @patch('anthropic.Anthropic')
-    @patch('time.sleep')
+    @patch("anthropic.Anthropic")
+    @patch("time.sleep")
     def test_timeout_error_message_clarity(self, mock_sleep, mock_anthropic_class):
         """Test that timeout error message includes useful information."""
         import anthropic
@@ -446,21 +450,23 @@ class TestClaudeClientTimeoutHandling:
         mock_client = MagicMock()
         mock_anthropic_class.return_value = mock_client
 
-        mock_client.messages.create.side_effect = anthropic.APITimeoutError('Timeout')
+        mock_client.messages.create.side_effect = anthropic.APITimeoutError("Timeout")
 
-        client = ClaudeClient(api_key='sk-ant-test', max_retries=2, timeout=45.0)
+        client = ClaudeClient(api_key="sk-ant-test", max_retries=2, timeout=45.0)
 
         with pytest.raises(RuntimeError) as exc_info:
-            client.generate_docstring('test prompt')
+            client.generate_docstring("test prompt")
 
         error_message = str(exc_info.value)
         # Verify error message includes retry count and timeout duration
-        assert '2 attempts' in error_message
-        assert '45.0 second timeout' in error_message
+        assert "2 attempts" in error_message
+        assert "45.0 second timeout" in error_message
 
-    @patch('anthropic.Anthropic')
-    @patch('time.sleep')
-    def test_timeout_and_rate_limit_retries_independent(self, mock_sleep, mock_anthropic_class):
+    @patch("anthropic.Anthropic")
+    @patch("time.sleep")
+    def test_timeout_and_rate_limit_retries_independent(
+        self, mock_sleep, mock_anthropic_class
+    ):
         """Test that timeout and rate limit errors are handled independently."""
         import anthropic
 
@@ -476,13 +482,13 @@ class TestClaudeClientTimeoutHandling:
         mock_message = MagicMock()
         mock_message.content = [MagicMock(spec=TextBlock, text='"""Success"""')]
         mock_client.messages.create.side_effect = [
-            anthropic.APITimeoutError('Timeout'),
-            anthropic.RateLimitError('Rate limit', response=mock_response, body=None),
-            mock_message
+            anthropic.APITimeoutError("Timeout"),
+            anthropic.RateLimitError("Rate limit", response=mock_response, body=None),
+            mock_message,
         ]
 
-        client = ClaudeClient(api_key='sk-ant-test', retry_delay=1.0)
-        result = client.generate_docstring('test prompt')
+        client = ClaudeClient(api_key="sk-ant-test", retry_delay=1.0)
+        result = client.generate_docstring("test prompt")
 
         # Verify both errors were retried and succeeded
         assert result == '"""Success"""'
@@ -500,6 +506,7 @@ class TestMultiItemResponseDetection:
     def _count_python_docstrings(self, text: str) -> int:
         """Count Python docstrings (triple-quoted strings) in text."""
         import re
+
         # Match triple-quoted docstrings (both """ and ''')
         pattern = r'("""[\s\S]*?"""|\'\'\'[\s\S]*?\'\'\')'
         return len(re.findall(pattern, text))
@@ -507,11 +514,12 @@ class TestMultiItemResponseDetection:
     def _count_jsdoc_comments(self, text: str) -> int:
         """Count JSDoc comments (/** ... */) in text."""
         import re
+
         # Match JSDoc comments
-        pattern = r'/\*\*[\s\S]*?\*/'
+        pattern = r"/\*\*[\s\S]*?\*/"
         return len(re.findall(pattern, text))
 
-    @patch('anthropic.Anthropic')
+    @patch("anthropic.Anthropic")
     def test_detect_single_python_function_response(self, mock_anthropic_class):
         """Test detection of single Python function documentation (expected)."""
         mock_client = MagicMock()
@@ -538,16 +546,18 @@ int
         mock_message.content = [MagicMock(spec=TextBlock, text=single_docstring)]
         mock_client.messages.create.return_value = mock_message
 
-        client = ClaudeClient(api_key='sk-ant-test')
-        result = client.generate_docstring('test prompt')
+        client = ClaudeClient(api_key="sk-ant-test")
+        result = client.generate_docstring("test prompt")
 
         # Verify only one docstring in response
         docstring_count = self._count_python_docstrings(result)
         assert docstring_count == 1, f"Expected 1 docstring, found {docstring_count}"
 
-    @patch('anthropic.Anthropic')
+    @patch("anthropic.Anthropic")
     def test_detect_multiple_python_function_responses(self, mock_anthropic_class):
-        """Test detection of multiple Python functions (bug scenario from issue #220)."""
+        """Test detection of multiple Python functions (bug scenario from
+
+        issue #220)."""
         mock_client = MagicMock()
         mock_anthropic_class.return_value = mock_client
 
@@ -598,14 +608,16 @@ str
         mock_message.content = [MagicMock(spec=TextBlock, text=multiple_docstrings)]
         mock_client.messages.create.return_value = mock_message
 
-        client = ClaudeClient(api_key='sk-ant-test')
-        result = client.generate_docstring('test prompt')
+        client = ClaudeClient(api_key="sk-ant-test")
+        result = client.generate_docstring("test prompt")
 
         # Verify multiple docstrings detected (this is the problem)
         docstring_count = self._count_python_docstrings(result)
-        assert docstring_count == 3, f"Expected 3 docstrings (bug scenario), found {docstring_count}"
+        assert (
+            docstring_count == 3
+        ), f"Expected 3 docstrings (bug scenario), found {docstring_count}"
 
-    @patch('anthropic.Anthropic')
+    @patch("anthropic.Anthropic")
     def test_detect_single_python_class_response(self, mock_anthropic_class):
         """Test detection of single Python class documentation (expected)."""
         mock_client = MagicMock()
@@ -627,19 +639,20 @@ strict_mode : bool, optional
         mock_message.content = [MagicMock(spec=TextBlock, text=single_class_doc)]
         mock_client.messages.create.return_value = mock_message
 
-        client = ClaudeClient(api_key='sk-ant-test')
-        result = client.generate_docstring('test prompt')
+        client = ClaudeClient(api_key="sk-ant-test")
+        result = client.generate_docstring("test prompt")
 
         docstring_count = self._count_python_docstrings(result)
         assert docstring_count == 1
 
-    @patch('anthropic.Anthropic')
+    @patch("anthropic.Anthropic")
     def test_detect_class_with_method_docs(self, mock_anthropic_class):
         """Test detection of class doc plus method docs (bug scenario)."""
         mock_client = MagicMock()
         mock_anthropic_class.return_value = mock_client
 
-        # Class documentation plus method documentation (should only be one or the other)
+        # Class documentation plus method documentation (should only be one or
+        # the other)
         class_plus_methods = '''"""
 Validator for user input data.
 
@@ -667,42 +680,42 @@ bool
         mock_message.content = [MagicMock(spec=TextBlock, text=class_plus_methods)]
         mock_client.messages.create.return_value = mock_message
 
-        client = ClaudeClient(api_key='sk-ant-test')
-        result = client.generate_docstring('test prompt')
+        client = ClaudeClient(api_key="sk-ant-test")
+        result = client.generate_docstring("test prompt")
 
         docstring_count = self._count_python_docstrings(result)
         assert docstring_count == 2, "Detected class + method docs (bug scenario)"
 
-    @patch('anthropic.Anthropic')
+    @patch("anthropic.Anthropic")
     def test_detect_single_jsdoc_function_response(self, mock_anthropic_class):
         """Test detection of single JSDoc function documentation (expected)."""
         mock_client = MagicMock()
         mock_anthropic_class.return_value = mock_client
 
-        single_jsdoc = '''/**
+        single_jsdoc = """/**
  * Calculate the sum of two numbers.
  * @param {number} a - The first number
  * @param {number} b - The second number
  * @returns {number} The sum of a and b
- */'''
+ */"""
 
         mock_message = MagicMock()
         mock_message.content = [MagicMock(spec=TextBlock, text=single_jsdoc)]
         mock_client.messages.create.return_value = mock_message
 
-        client = ClaudeClient(api_key='sk-ant-test')
-        result = client.generate_docstring('test prompt')
+        client = ClaudeClient(api_key="sk-ant-test")
+        result = client.generate_docstring("test prompt")
 
         jsdoc_count = self._count_jsdoc_comments(result)
         assert jsdoc_count == 1
 
-    @patch('anthropic.Anthropic')
+    @patch("anthropic.Anthropic")
     def test_detect_multiple_jsdoc_function_responses(self, mock_anthropic_class):
         """Test detection of multiple JSDoc functions (bug scenario)."""
         mock_client = MagicMock()
         mock_anthropic_class.return_value = mock_client
 
-        multiple_jsdocs = '''/**
+        multiple_jsdocs = """/**
  * Validate password strength.
  * @param {string} password - Password to validate
  * @returns {boolean} True if password is strong enough
@@ -718,26 +731,28 @@ bool
  * Sanitize user input.
  * @param {string} input - Raw user input
  * @returns {string} Sanitized input
- */'''
+ */"""
 
         mock_message = MagicMock()
         mock_message.content = [MagicMock(spec=TextBlock, text=multiple_jsdocs)]
         mock_client.messages.create.return_value = mock_message
 
-        client = ClaudeClient(api_key='sk-ant-test')
-        result = client.generate_docstring('test prompt')
+        client = ClaudeClient(api_key="sk-ant-test")
+        result = client.generate_docstring("test prompt")
 
         jsdoc_count = self._count_jsdoc_comments(result)
-        assert jsdoc_count == 3, f"Expected 3 JSDoc comments (bug scenario), found {jsdoc_count}"
+        assert (
+            jsdoc_count == 3
+        ), f"Expected 3 JSDoc comments (bug scenario), found {jsdoc_count}"
 
-    @patch('anthropic.Anthropic')
+    @patch("anthropic.Anthropic")
     def test_detect_typescript_class_with_methods(self, mock_anthropic_class):
         """Test detection of TypeScript class with multiple method docs (bug)."""
         mock_client = MagicMock()
         mock_anthropic_class.return_value = mock_client
 
         # TSDoc for class plus multiple methods
-        class_and_methods = '''/**
+        class_and_methods = """/**
  * Validator for user input data.
  *
  * @remarks
@@ -756,19 +771,19 @@ bool
  *
  * @param password - The password to validate
  * @returns True if password meets requirements
- */'''
+ */"""
 
         mock_message = MagicMock()
         mock_message.content = [MagicMock(spec=TextBlock, text=class_and_methods)]
         mock_client.messages.create.return_value = mock_message
 
-        client = ClaudeClient(api_key='sk-ant-test')
-        result = client.generate_docstring('test prompt')
+        client = ClaudeClient(api_key="sk-ant-test")
+        result = client.generate_docstring("test prompt")
 
         jsdoc_count = self._count_jsdoc_comments(result)
         assert jsdoc_count == 3, "Detected class + 2 methods (bug scenario)"
 
-    @patch('anthropic.Anthropic')
+    @patch("anthropic.Anthropic")
     def test_detect_mixed_documented_and_target(self, mock_anthropic_class):
         """
         Test the exact scenario from issue #220.
@@ -827,8 +842,8 @@ str
         mock_message.content = [MagicMock(spec=TextBlock, text=issue_220_response)]
         mock_client.messages.create.return_value = mock_message
 
-        client = ClaudeClient(api_key='sk-ant-test')
-        result = client.generate_docstring('Generate docs for validate_username')
+        client = ClaudeClient(api_key="sk-ant-test")
+        result = client.generate_docstring("Generate docs for validate_username")
 
         # This is the problem: we asked for ONE function but got THREE
         docstring_count = self._count_python_docstrings(result)

--- a/analyzer/tests/test_cli.py
+++ b/analyzer/tests/test_cli.py
@@ -21,7 +21,7 @@ class TestCLI:
     def examples_dir(self):
         """Return path to examples directory."""
         project_root = Path(__file__).parent.parent.parent
-        return str(project_root / 'examples')
+        return str(project_root / "examples")
 
     def test_main_no_command(self, capsys):
         """Test that running without command shows help."""
@@ -29,31 +29,31 @@ class TestCLI:
         captured = capsys.readouterr()
 
         assert exit_code == 1
-        assert 'usage:' in captured.out or 'usage:' in captured.err
+        assert "usage:" in captured.out or "usage:" in captured.err
 
     def test_main_help(self, capsys):
         """Test help flag."""
         with pytest.raises(SystemExit) as exc:
-            main(['--help'])
+            main(["--help"])
 
         assert exc.value.code == 0
         captured = capsys.readouterr()
-        assert 'usage:' in captured.out
-        assert 'analyze' in captured.out
+        assert "usage:" in captured.out
+        assert "analyze" in captured.out
 
     def test_main_version(self, capsys):
         """Test version flag."""
         with pytest.raises(SystemExit) as exc:
-            main(['--version'])
+            main(["--version"])
 
         assert exc.value.code == 0
         captured = capsys.readouterr()
-        assert 'analyzer' in captured.out
-        assert '0.1.0' in captured.out
+        assert "analyzer" in captured.out
+        assert "0.1.0" in captured.out
 
     def test_analyze_json_format(self, examples_dir, capsys):
         """Test analyze command with JSON output."""
-        exit_code = main(['analyze', examples_dir, '--format', 'json'])
+        exit_code = main(["analyze", examples_dir, "--format", "json"])
         captured = capsys.readouterr()
 
         assert exit_code == 0
@@ -61,66 +61,66 @@ class TestCLI:
         # Parse JSON output
         data = json.loads(captured.out)
 
-        assert 'coverage_percent' in data
-        assert 'total_items' in data
-        assert 'documented_items' in data
-        assert 'by_language' in data
-        assert 'items' in data
+        assert "coverage_percent" in data
+        assert "total_items" in data
+        assert "documented_items" in data
+        assert "by_language" in data
+        assert "items" in data
 
-        assert isinstance(data['coverage_percent'], (int, float))
-        assert isinstance(data['total_items'], int)
-        assert isinstance(data['documented_items'], int)
-        assert isinstance(data['items'], list)
+        assert isinstance(data["coverage_percent"], (int, float))
+        assert isinstance(data["total_items"], int)
+        assert isinstance(data["documented_items"], int)
+        assert isinstance(data["items"], list)
 
     def test_analyze_summary_format(self, examples_dir, capsys):
         """Test analyze command with summary output."""
-        exit_code = main(['analyze', examples_dir, '--format', 'summary'])
+        exit_code = main(["analyze", examples_dir, "--format", "summary"])
         captured = capsys.readouterr()
 
         assert exit_code == 0
-        assert 'Documentation Coverage Analysis' in captured.out
-        assert 'Overall Coverage:' in captured.out
-        assert 'By Language:' in captured.out
+        assert "Documentation Coverage Analysis" in captured.out
+        assert "Overall Coverage:" in captured.out
+        assert "By Language:" in captured.out
 
     def test_analyze_default_format(self, examples_dir, capsys):
         """Test analyze command with default format (summary)."""
-        exit_code = main(['analyze', examples_dir])
+        exit_code = main(["analyze", examples_dir])
         captured = capsys.readouterr()
 
         assert exit_code == 0
-        assert 'Documentation Coverage Analysis' in captured.out
+        assert "Documentation Coverage Analysis" in captured.out
 
     def test_analyze_verbose(self, examples_dir, capsys):
         """Test analyze command with verbose flag."""
-        exit_code = main(['analyze', examples_dir, '--verbose'])
+        exit_code = main(["analyze", examples_dir, "--verbose"])
         captured = capsys.readouterr()
 
         assert exit_code == 0
         # Verbose messages go to stderr
-        assert 'Analyzing:' in captured.err or len(captured.err) > 0
+        assert "Analyzing:" in captured.err or len(captured.err) > 0
 
     def test_analyze_nonexistent_path(self, capsys):
         """Test analyze command with nonexistent path."""
-        exit_code = main(['analyze', '/nonexistent/path/that/does/not/exist'])
+        exit_code = main(["analyze", "/nonexistent/path/that/does/not/exist"])
         captured = capsys.readouterr()
 
         assert exit_code == 1
-        assert 'Error:' in captured.err
+        assert "Error:" in captured.err
 
     def test_analyze_single_file(self, capsys):
         """Test analyzing a single file."""
         project_root = Path(__file__).parent.parent.parent
-        test_file = project_root / 'examples' / 'test_simple.py'
+        test_file = project_root / "examples" / "test_simple.py"
 
-        exit_code = main(['analyze', str(test_file), '--format', 'json'])
+        exit_code = main(["analyze", str(test_file), "--format", "json"])
         captured = capsys.readouterr()
 
         assert exit_code == 0
 
         data = json.loads(captured.out)
-        assert data['total_items'] > 0
+        assert data["total_items"] > 0
         # All items should be Python
-        assert all(item['language'] == 'python' for item in data['items'])
+        assert all(item["language"] == "python" for item in data["items"])
 
     def test_create_analyzer(self):
         """Test analyzer factory function."""
@@ -130,43 +130,43 @@ class TestCLI:
 
         # Create dependencies for DI
         parsers = {
-            'python': PythonParser(),
-            'typescript': TypeScriptParser(),
-            'javascript': TypeScriptParser()
+            "python": PythonParser(),
+            "typescript": TypeScriptParser(),
+            "javascript": TypeScriptParser(),
         }
         scorer = ImpactScorer()
 
         analyzer = create_analyzer(parsers, scorer)
 
         assert isinstance(analyzer, DocumentationAnalyzer)
-        assert 'python' in analyzer.parsers
-        assert 'typescript' in analyzer.parsers
-        assert 'javascript' in analyzer.parsers
+        assert "python" in analyzer.parsers
+        assert "typescript" in analyzer.parsers
+        assert "javascript" in analyzer.parsers
 
     def test_format_json_structure(self):
         """Test JSON formatting with mock data."""
         # Create mock result
         item = CodeItem(
-            name='test_func',
-            type='function',
-            filepath='test.py',
+            name="test_func",
+            type="function",
+            filepath="test.py",
             line_number=10,
             end_line=15,
-            language='python',
+            language="python",
             complexity=5,
             impact_score=25.0,
             has_docs=True,
-            export_type='named',
-            module_system='esm'
+            export_type="named",
+            module_system="esm",
         )
 
         metrics = LanguageMetrics(
-            language='python',
+            language="python",
             total_items=1,
             documented_items=1,
             coverage_percent=100.0,
             avg_complexity=5.0,
-            avg_impact_score=25.0
+            avg_impact_score=25.0,
         )
 
         result = AnalysisResult(
@@ -174,56 +174,56 @@ class TestCLI:
             coverage_percent=100.0,
             total_items=1,
             documented_items=1,
-            by_language={'python': metrics}
+            by_language={"python": metrics},
         )
 
         json_str = format_json(result)
         data = json.loads(json_str)
 
-        assert data['coverage_percent'] == 100.0
-        assert data['total_items'] == 1
-        assert data['documented_items'] == 1
-        assert 'python' in data['by_language']
-        assert len(data['items']) == 1
-        assert data['items'][0]['name'] == 'test_func'
+        assert data["coverage_percent"] == 100.0
+        assert data["total_items"] == 1
+        assert data["documented_items"] == 1
+        assert "python" in data["by_language"]
+        assert len(data["items"]) == 1
+        assert data["items"][0]["name"] == "test_func"
 
     def test_format_summary_structure(self):
         """Test summary formatting with mock data."""
         item1 = CodeItem(
-            name='documented_func',
-            type='function',
-            filepath='test.py',
+            name="documented_func",
+            type="function",
+            filepath="test.py",
             line_number=10,
             end_line=15,
-            language='python',
+            language="python",
             complexity=5,
             impact_score=25.0,
             has_docs=True,
-            export_type='named',
-            module_system='esm'
+            export_type="named",
+            module_system="esm",
         )
 
         item2 = CodeItem(
-            name='undocumented_func',
-            type='function',
-            filepath='test.py',
+            name="undocumented_func",
+            type="function",
+            filepath="test.py",
             line_number=20,
             end_line=25,
-            language='python',
+            language="python",
             complexity=10,
             impact_score=50.0,
             has_docs=False,
-            export_type='named',
-            module_system='esm'
+            export_type="named",
+            module_system="esm",
         )
 
         metrics = LanguageMetrics(
-            language='python',
+            language="python",
             total_items=2,
             documented_items=1,
             coverage_percent=50.0,
             avg_complexity=7.5,
-            avg_impact_score=37.5
+            avg_impact_score=37.5,
         )
 
         result = AnalysisResult(
@@ -231,14 +231,14 @@ class TestCLI:
             coverage_percent=50.0,
             total_items=2,
             documented_items=1,
-            by_language={'python': metrics}
+            by_language={"python": metrics},
         )
 
         summary = format_summary(result)
 
-        assert 'Documentation Coverage Analysis' in summary
-        assert '50.0%' in summary
-        assert '(1/2 items)' in summary
-        assert 'By Language:' in summary
-        assert 'Top Undocumented Items' in summary
-        assert 'undocumented_func' in summary
+        assert "Documentation Coverage Analysis" in summary
+        assert "50.0%" in summary
+        assert "(1/2 items)" in summary
+        assert "By Language:" in summary
+        assert "Top Undocumented Items" in summary
+        assert "undocumented_func" in summary

--- a/analyzer/tests/test_conflict_resolution.py
+++ b/analyzer/tests/test_conflict_resolution.py
@@ -31,19 +31,21 @@ class TestMultiFileRollback:
             # Create three files
             originals = {}
             for i in range(3):
-                filepath = base_path / f'file{i}.py'
-                content = f'# Original file {i}\n'
+                filepath = base_path / f"file{i}.py"
+                content = f"# Original file {i}\n"
                 filepath.write_text(content)
                 originals[str(filepath)] = content
 
             # Record transaction for all three
-            manifest = manager.begin_transaction('test-session')
+            manifest = manager.begin_transaction("test-session")
             for i in range(3):
-                filepath = base_path / f'file{i}.py'
-                backup = str(filepath) + '.bak'
+                filepath = base_path / f"file{i}.py"
+                backup = str(filepath) + ".bak"
                 Path(backup).write_text(originals[str(filepath)])
-                filepath.write_text(f'def func{i}(): pass\n')
-                manager.record_write(manifest, str(filepath), backup, f'func{i}', 'function', 'python')
+                filepath.write_text(f"def func{i}(): pass\n")
+                manager.record_write(
+                    manifest, str(filepath), backup, f"func{i}", "function", "python"
+                )
 
             # Rollback all changes
             result = manager.rollback_transaction(manifest)
@@ -51,7 +53,7 @@ class TestMultiFileRollback:
 
             # Verify all files restored
             for i in range(3):
-                filepath = base_path / f'file{i}.py'
+                filepath = base_path / f"file{i}.py"
                 assert filepath.read_text() == originals[str(filepath)]
 
     def test_rollback_partial_on_missing_backup(self):
@@ -64,20 +66,22 @@ class TestMultiFileRollback:
 
             # Create files
             for i in range(3):
-                filepath = base_path / f'file{i}.py'
-                filepath.write_text(f'# Original {i}\n')
+                filepath = base_path / f"file{i}.py"
+                filepath.write_text(f"# Original {i}\n")
 
             # Record transaction
-            manifest = manager.begin_transaction('test-session')
+            manifest = manager.begin_transaction("test-session")
             for i in range(3):
-                filepath = base_path / f'file{i}.py'
-                backup = str(filepath) + '.bak'
-                Path(backup).write_text(f'# Original {i}\n')
-                filepath.write_text(f'# Modified {i}\n')
-                manager.record_write(manifest, str(filepath), backup, f'func{i}', 'function', 'python')
+                filepath = base_path / f"file{i}.py"
+                backup = str(filepath) + ".bak"
+                Path(backup).write_text(f"# Original {i}\n")
+                filepath.write_text(f"# Modified {i}\n")
+                manager.record_write(
+                    manifest, str(filepath), backup, f"func{i}", "function", "python"
+                )
 
             # Delete one backup to simulate missing file
-            backup1 = base_path / 'file1.py.bak'
+            backup1 = base_path / "file1.py.bak"
             backup1.unlink()
 
             # Rollback should restore what it can
@@ -99,20 +103,22 @@ class TestFileStateScenarios:
             manager = TransactionManager(base_path=base_path, use_git=True)
 
             # Create empty file
-            filepath = base_path / 'empty.py'
-            filepath.write_text('')
+            filepath = base_path / "empty.py"
+            filepath.write_text("")
 
             # Record transaction
-            manifest = manager.begin_transaction('test-session')
-            backup = str(filepath) + '.bak'
-            Path(backup).write_text('')
-            filepath.write_text('# Now has content\n')
-            manager.record_write(manifest, str(filepath), backup, 'func', 'function', 'python')
+            manifest = manager.begin_transaction("test-session")
+            backup = str(filepath) + ".bak"
+            Path(backup).write_text("")
+            filepath.write_text("# Now has content\n")
+            manager.record_write(
+                manifest, str(filepath), backup, "func", "function", "python"
+            )
 
             # Rollback
             result = manager.rollback_transaction(manifest)
             assert result == 1
-            assert filepath.read_text() == ''
+            assert filepath.read_text() == ""
 
     def test_rollback_large_file(self):
         """Test rollback of large file."""
@@ -123,19 +129,21 @@ class TestFileStateScenarios:
             manager = TransactionManager(base_path=base_path, use_git=True)
 
             # Create file with many lines
-            filepath = base_path / 'large.py'
-            original_lines = [f'# Line {i}\n' for i in range(1000)]
-            original = ''.join(original_lines)
+            filepath = base_path / "large.py"
+            original_lines = [f"# Line {i}\n" for i in range(1000)]
+            original = "".join(original_lines)
             filepath.write_text(original)
 
             # Record transaction
-            manifest = manager.begin_transaction('test-session')
-            backup = str(filepath) + '.bak'
+            manifest = manager.begin_transaction("test-session")
+            backup = str(filepath) + ".bak"
             Path(backup).write_text(original)
             # Add docs at top
             modified = '"""Module docstring"""\n' + original
             filepath.write_text(modified)
-            manager.record_write(manifest, str(filepath), backup, 'module', 'module', 'python')
+            manager.record_write(
+                manifest, str(filepath), backup, "module", "module", "python"
+            )
 
             # Rollback
             result = manager.rollback_transaction(manifest)
@@ -151,17 +159,19 @@ class TestFileStateScenarios:
             manager = TransactionManager(base_path=base_path, use_git=True)
 
             # Create file with unicode
-            filepath = base_path / 'unicode.py'
-            original = '# 你好世界\n# Привет мир\n# مرحبا بالعالم\n'
+            filepath = base_path / "unicode.py"
+            original = "# 你好世界\n# Привет мир\n# مرحبا بالعالم\n"
             filepath.write_text(original)
 
             # Record transaction
-            manifest = manager.begin_transaction('test-session')
-            backup = str(filepath) + '.bak'
+            manifest = manager.begin_transaction("test-session")
+            backup = str(filepath) + ".bak"
             Path(backup).write_text(original)
             modified = '"""Unicode test: 🔥💯🎉"""\n' + original
             filepath.write_text(modified)
-            manager.record_write(manifest, str(filepath), backup, 'func', 'function', 'python')
+            manager.record_write(
+                manifest, str(filepath), backup, "func", "function", "python"
+            )
 
             # Rollback
             result = manager.rollback_transaction(manifest)
@@ -183,20 +193,22 @@ class TestNestedPaths:
             # Create nested structure a/b/c/d/e/
             nested_paths = []
             for depth in range(5):
-                path_parts = ['a'] * (depth + 1)
+                path_parts = ["a"] * (depth + 1)
                 dirpath = base_path.joinpath(*path_parts)
                 dirpath.mkdir(parents=True, exist_ok=True)
-                filepath = dirpath / 'file.py'
-                filepath.write_text(f'# Depth {depth}\n')
-                nested_paths.append((filepath, f'# Depth {depth}\n'))
+                filepath = dirpath / "file.py"
+                filepath.write_text(f"# Depth {depth}\n")
+                nested_paths.append((filepath, f"# Depth {depth}\n"))
 
             # Record transaction for all
-            manifest = manager.begin_transaction('test-session')
+            manifest = manager.begin_transaction("test-session")
             for filepath, original in nested_paths:
-                backup = str(filepath) + '.bak'
+                backup = str(filepath) + ".bak"
                 Path(backup).write_text(original)
-                filepath.write_text('# Modified\n')
-                manager.record_write(manifest, str(filepath), backup, 'func', 'function', 'python')
+                filepath.write_text("# Modified\n")
+                manager.record_write(
+                    manifest, str(filepath), backup, "func", "function", "python"
+                )
 
             # Rollback all
             result = manager.rollback_transaction(manifest)
@@ -219,32 +231,36 @@ class TestSequentialOperations:
             manager = TransactionManager(base_path=base_path, use_git=True)
 
             # Session 1
-            file1 = base_path / 'file1.py'
-            file1.write_text('v1\n')
-            manifest1 = manager.begin_transaction('session-1')
-            backup1 = str(file1) + '.bak'
-            Path(backup1).write_text('v1\n')
-            file1.write_text('v1-modified\n')
-            manager.record_write(manifest1, str(file1), backup1, 'func1', 'function', 'python')
+            file1 = base_path / "file1.py"
+            file1.write_text("v1\n")
+            manifest1 = manager.begin_transaction("session-1")
+            backup1 = str(file1) + ".bak"
+            Path(backup1).write_text("v1\n")
+            file1.write_text("v1-modified\n")
+            manager.record_write(
+                manifest1, str(file1), backup1, "func1", "function", "python"
+            )
 
             # Rollback session 1
             result1 = manager.rollback_transaction(manifest1)
             assert result1 == 1
-            assert file1.read_text() == 'v1\n'
+            assert file1.read_text() == "v1\n"
 
             # Session 2
-            file2 = base_path / 'file2.py'
-            file2.write_text('v2\n')
-            manifest2 = manager.begin_transaction('session-2')
-            backup2 = str(file2) + '.bak'
-            Path(backup2).write_text('v2\n')
-            file2.write_text('v2-modified\n')
-            manager.record_write(manifest2, str(file2), backup2, 'func2', 'function', 'python')
+            file2 = base_path / "file2.py"
+            file2.write_text("v2\n")
+            manifest2 = manager.begin_transaction("session-2")
+            backup2 = str(file2) + ".bak"
+            Path(backup2).write_text("v2\n")
+            file2.write_text("v2-modified\n")
+            manager.record_write(
+                manifest2, str(file2), backup2, "func2", "function", "python"
+            )
 
             # Rollback session 2
             result2 = manager.rollback_transaction(manifest2)
             assert result2 == 1
-            assert file2.read_text() == 'v2\n'
+            assert file2.read_text() == "v2\n"
 
 
 class TestRollbackVerification:
@@ -261,17 +277,24 @@ class TestRollbackVerification:
             # Create files
             files_and_backups = []
             for i in range(3):
-                filepath = base_path / f'file{i}.py'
-                filepath.write_text(f'original {i}\n')
-                backup = str(filepath) + '.bak'
+                filepath = base_path / f"file{i}.py"
+                filepath.write_text(f"original {i}\n")
+                backup = str(filepath) + ".bak"
                 files_and_backups.append((filepath, Path(backup)))
 
             # Record transaction
-            manifest = manager.begin_transaction('test-session')
+            manifest = manager.begin_transaction("test-session")
             for filepath, backup_path in files_and_backups:
                 backup_path.write_text(filepath.read_text())
-                filepath.write_text('modified\n')
-                manager.record_write(manifest, str(filepath), str(backup_path), 'func', 'function', 'python')
+                filepath.write_text("modified\n")
+                manager.record_write(
+                    manifest,
+                    str(filepath),
+                    str(backup_path),
+                    "func",
+                    "function",
+                    "python",
+                )
 
             # Verify backups exist
             for _, backup_path in files_and_backups:
@@ -294,25 +317,27 @@ class TestRollbackVerification:
             manager = TransactionManager(base_path=base_path, use_git=True)
 
             # Create file
-            filepath = base_path / 'file.py'
-            filepath.write_text('original\n')
+            filepath = base_path / "file.py"
+            filepath.write_text("original\n")
 
             # Record transaction
-            manifest = manager.begin_transaction('test-session')
-            backup = str(filepath) + '.bak'
-            Path(backup).write_text('original\n')
-            filepath.write_text('modified\n')
-            manager.record_write(manifest, str(filepath), backup, 'func', 'function', 'python')
+            manifest = manager.begin_transaction("test-session")
+            backup = str(filepath) + ".bak"
+            Path(backup).write_text("original\n")
+            filepath.write_text("modified\n")
+            manager.record_write(
+                manifest, str(filepath), backup, "func", "function", "python"
+            )
 
             # Check initial status
-            assert manifest.status == 'in_progress'
+            assert manifest.status == "in_progress"
 
             # Rollback
             result = manager.rollback_transaction(manifest)
             assert result == 1
 
             # Check status updated
-            assert manifest.status == 'rolled_back'
+            assert manifest.status == "rolled_back"
             assert manifest.completed_at is not None
 
 
@@ -328,14 +353,16 @@ class TestGitSpecificRollback:
             manager = TransactionManager(base_path=base_path, use_git=True)
 
             # Create and rollback transaction
-            filepath = base_path / 'file.py'
-            filepath.write_text('original\n')
+            filepath = base_path / "file.py"
+            filepath.write_text("original\n")
 
-            manifest = manager.begin_transaction('test-session')
-            backup = str(filepath) + '.bak'
-            Path(backup).write_text('original\n')
-            filepath.write_text('modified\n')
-            manager.record_write(manifest, str(filepath), backup, 'func', 'function', 'python')
+            manifest = manager.begin_transaction("test-session")
+            backup = str(filepath) + ".bak"
+            Path(backup).write_text("original\n")
+            filepath.write_text("modified\n")
+            manager.record_write(
+                manifest, str(filepath), backup, "func", "function", "python"
+            )
 
             # Rollback
             manager.rollback_transaction(manifest)
@@ -343,7 +370,7 @@ class TestGitSpecificRollback:
             # Rollback should leave things clean
             # (Implementation may or may not create additional commits)
             # The important thing is it completes successfully
-            assert manifest.status == 'rolled_back'
+            assert manifest.status == "rolled_back"
 
     def test_git_branch_cleaned_on_rollback(self):
         """Test that session branch is cleaned up after rollback."""
@@ -354,27 +381,29 @@ class TestGitSpecificRollback:
             manager = TransactionManager(base_path=base_path, use_git=True)
 
             # Create transaction
-            filepath = base_path / 'file.py'
-            filepath.write_text('original\n')
+            filepath = base_path / "file.py"
+            filepath.write_text("original\n")
 
-            manifest = manager.begin_transaction('test-session')
-            backup = str(filepath) + '.bak'
-            Path(backup).write_text('original\n')
-            filepath.write_text('modified\n')
-            manager.record_write(manifest, str(filepath), backup, 'func', 'function', 'python')
+            manifest = manager.begin_transaction("test-session")
+            backup = str(filepath) + ".bak"
+            Path(backup).write_text("original\n")
+            filepath.write_text("modified\n")
+            manager.record_write(
+                manifest, str(filepath), backup, "func", "function", "python"
+            )
 
             # Rollback
             manager.rollback_transaction(manifest)
 
             # Check branches
-            git_dir = base_path / '.docimp' / 'state' / '.git'
+            git_dir = base_path / ".docimp" / "state" / ".git"
             result = subprocess.run(
-                ['git', '--git-dir', str(git_dir), 'branch', '--list'],
+                ["git", "--git-dir", str(git_dir), "branch", "--list"],
                 capture_output=True,
                 text=True,
-                check=True
+                check=True,
             )
 
             # Should still have main branch but not session branch
-            assert 'main' in result.stdout
+            assert "main" in result.stdout
             # Session branch may or may not be cleaned up - implementation dependent

--- a/analyzer/tests/test_coverage.py
+++ b/analyzer/tests/test_coverage.py
@@ -24,43 +24,43 @@ class TestCoverageCalculator:
         """Return a list of CodeItems with mixed documentation status."""
         return [
             CodeItem(
-                name='documented_func',
-                type='function',
-                filepath='test.py',
+                name="documented_func",
+                type="function",
+                filepath="test.py",
                 line_number=1,
                 end_line=5,
-                language='python',
+                language="python",
                 complexity=5,
                 has_docs=True,
-                export_type='internal',
-                module_system='unknown',
-                impact_score=25.0
+                export_type="internal",
+                module_system="unknown",
+                impact_score=25.0,
             ),
             CodeItem(
-                name='undocumented_func',
-                type='function',
-                filepath='test.py',
+                name="undocumented_func",
+                type="function",
+                filepath="test.py",
                 line_number=10,
                 end_line=15,
-                language='python',
+                language="python",
                 complexity=3,
                 has_docs=False,
-                export_type='internal',
-                module_system='unknown',
-                impact_score=15.0
+                export_type="internal",
+                module_system="unknown",
+                impact_score=15.0,
             ),
             CodeItem(
-                name='another_documented',
-                type='class',
-                filepath='test.py',
+                name="another_documented",
+                type="class",
+                filepath="test.py",
                 line_number=20,
                 end_line=30,
-                language='python',
+                language="python",
                 complexity=10,
                 has_docs=True,
-                export_type='internal',
-                module_system='unknown',
-                impact_score=50.0
+                export_type="internal",
+                module_system="unknown",
+                impact_score=50.0,
             ),
         ]
 
@@ -70,83 +70,83 @@ class TestCoverageCalculator:
         return [
             # Python items (2 documented, 1 undocumented)
             CodeItem(
-                name='py_func1',
-                type='function',
-                filepath='test.py',
+                name="py_func1",
+                type="function",
+                filepath="test.py",
                 line_number=1,
                 end_line=5,
-                language='python',
+                language="python",
                 complexity=5,
                 has_docs=True,
-                export_type='internal',
-                module_system='unknown',
-                impact_score=25.0
+                export_type="internal",
+                module_system="unknown",
+                impact_score=25.0,
             ),
             CodeItem(
-                name='py_func2',
-                type='function',
-                filepath='test.py',
+                name="py_func2",
+                type="function",
+                filepath="test.py",
                 line_number=10,
                 end_line=15,
-                language='python',
+                language="python",
                 complexity=3,
                 has_docs=True,
-                export_type='internal',
-                module_system='unknown',
-                impact_score=15.0
+                export_type="internal",
+                module_system="unknown",
+                impact_score=15.0,
             ),
             CodeItem(
-                name='py_func3',
-                type='function',
-                filepath='test.py',
+                name="py_func3",
+                type="function",
+                filepath="test.py",
                 line_number=20,
                 end_line=25,
-                language='python',
+                language="python",
                 complexity=2,
                 has_docs=False,
-                export_type='internal',
-                module_system='unknown',
-                impact_score=10.0
+                export_type="internal",
+                module_system="unknown",
+                impact_score=10.0,
             ),
             # JavaScript items (1 documented, 2 undocumented)
             CodeItem(
-                name='js_func1',
-                type='function',
-                filepath='test.js',
+                name="js_func1",
+                type="function",
+                filepath="test.js",
                 line_number=1,
                 end_line=5,
-                language='javascript',
+                language="javascript",
                 complexity=4,
                 has_docs=True,
-                export_type='named',
-                module_system='esm',
-                impact_score=20.0
+                export_type="named",
+                module_system="esm",
+                impact_score=20.0,
             ),
             CodeItem(
-                name='js_func2',
-                type='function',
-                filepath='test.js',
+                name="js_func2",
+                type="function",
+                filepath="test.js",
                 line_number=10,
                 end_line=15,
-                language='javascript',
+                language="javascript",
                 complexity=6,
                 has_docs=False,
-                export_type='named',
-                module_system='esm',
-                impact_score=30.0
+                export_type="named",
+                module_system="esm",
+                impact_score=30.0,
             ),
             CodeItem(
-                name='js_func3',
-                type='function',
-                filepath='test.js',
+                name="js_func3",
+                type="function",
+                filepath="test.js",
                 line_number=20,
                 end_line=25,
-                language='javascript',
+                language="javascript",
                 complexity=8,
                 has_docs=False,
-                export_type='named',
-                module_system='esm',
-                impact_score=40.0
+                export_type="named",
+                module_system="esm",
+                impact_score=40.0,
             ),
         ]
 
@@ -159,30 +159,30 @@ class TestCoverageCalculator:
         """Test that all documented items returns 100% coverage."""
         items = [
             CodeItem(
-                name='func1',
-                type='function',
-                filepath='test.py',
+                name="func1",
+                type="function",
+                filepath="test.py",
                 line_number=1,
                 end_line=3,
-                language='python',
+                language="python",
                 complexity=1,
                 has_docs=True,
-                export_type='internal',
-                module_system='unknown',
-                impact_score=5.0
+                export_type="internal",
+                module_system="unknown",
+                impact_score=5.0,
             ),
             CodeItem(
-                name='func2',
-                type='function',
-                filepath='test.py',
+                name="func2",
+                type="function",
+                filepath="test.py",
                 line_number=5,
                 end_line=7,
-                language='python',
+                language="python",
                 complexity=1,
                 has_docs=True,
-                export_type='internal',
-                module_system='unknown',
-                impact_score=5.0
+                export_type="internal",
+                module_system="unknown",
+                impact_score=5.0,
             ),
         ]
 
@@ -193,30 +193,30 @@ class TestCoverageCalculator:
         """Test that no documented items returns 0% coverage."""
         items = [
             CodeItem(
-                name='func1',
-                type='function',
-                filepath='test.py',
+                name="func1",
+                type="function",
+                filepath="test.py",
                 line_number=1,
                 end_line=3,
-                language='python',
+                language="python",
                 complexity=1,
                 has_docs=False,
-                export_type='internal',
-                module_system='unknown',
-                impact_score=5.0
+                export_type="internal",
+                module_system="unknown",
+                impact_score=5.0,
             ),
             CodeItem(
-                name='func2',
-                type='function',
-                filepath='test.py',
+                name="func2",
+                type="function",
+                filepath="test.py",
                 line_number=5,
                 end_line=7,
-                language='python',
+                language="python",
                 complexity=1,
                 has_docs=False,
-                export_type='internal',
-                module_system='unknown',
-                impact_score=5.0
+                export_type="internal",
+                module_system="unknown",
+                impact_score=5.0,
             ),
         ]
 
@@ -248,11 +248,11 @@ class TestCoverageCalculator:
         """Test by-language metrics with single language."""
         metrics = calculator.calculate_by_language(mixed_items)
 
-        assert 'python' in metrics
+        assert "python" in metrics
         assert len(metrics) == 1
 
-        py_metrics = metrics['python']
-        assert py_metrics.language == 'python'
+        py_metrics = metrics["python"]
+        assert py_metrics.language == "python"
         assert py_metrics.total_items == 3
         assert py_metrics.documented_items == 2
         assert abs(py_metrics.coverage_percent - 66.67) < 0.1
@@ -262,18 +262,18 @@ class TestCoverageCalculator:
         metrics = calculator.calculate_by_language(multi_language_items)
 
         # Should have both Python and JavaScript
-        assert 'python' in metrics
-        assert 'javascript' in metrics
+        assert "python" in metrics
+        assert "javascript" in metrics
         assert len(metrics) == 2
 
         # Python: 2/3 documented = 66.67%
-        py_metrics = metrics['python']
+        py_metrics = metrics["python"]
         assert py_metrics.total_items == 3
         assert py_metrics.documented_items == 2
         assert abs(py_metrics.coverage_percent - 66.67) < 0.1
 
         # JavaScript: 1/3 documented = 33.33%
-        js_metrics = metrics['javascript']
+        js_metrics = metrics["javascript"]
         assert js_metrics.total_items == 3
         assert js_metrics.documented_items == 1
         assert abs(js_metrics.coverage_percent - 33.33) < 0.1
@@ -283,11 +283,11 @@ class TestCoverageCalculator:
         metrics = calculator.calculate_by_language(multi_language_items)
 
         # Python avg complexity: (5 + 3 + 2) / 3 = 3.33
-        py_metrics = metrics['python']
+        py_metrics = metrics["python"]
         assert abs(py_metrics.avg_complexity - 3.33) < 0.1
 
         # JavaScript avg complexity: (4 + 6 + 8) / 3 = 6.0
-        js_metrics = metrics['javascript']
+        js_metrics = metrics["javascript"]
         assert abs(js_metrics.avg_complexity - 6.0) < 0.1
 
     def test_by_language_averages_impact_score(self, calculator, multi_language_items):
@@ -295,52 +295,52 @@ class TestCoverageCalculator:
         metrics = calculator.calculate_by_language(multi_language_items)
 
         # Python avg impact: (25 + 15 + 10) / 3 = 16.67
-        py_metrics = metrics['python']
+        py_metrics = metrics["python"]
         assert abs(py_metrics.avg_impact_score - 16.67) < 0.1
 
         # JavaScript avg impact: (20 + 30 + 40) / 3 = 30.0
-        js_metrics = metrics['javascript']
+        js_metrics = metrics["javascript"]
         assert abs(js_metrics.avg_impact_score - 30.0) < 0.1
 
     def test_by_language_handles_skipped_items(self, calculator):
         """Test that skipped items are tracked correctly."""
         items = [
             CodeItem(
-                name='py_func',
-                type='function',
-                filepath='test.py',
+                name="py_func",
+                type="function",
+                filepath="test.py",
                 line_number=1,
                 end_line=5,
-                language='python',
+                language="python",
                 complexity=5,
                 has_docs=True,
-                export_type='internal',
-                module_system='unknown',
-                impact_score=25.0
+                export_type="internal",
+                module_system="unknown",
+                impact_score=25.0,
             ),
             CodeItem(
-                name='skipped_file',
-                type='function',
-                filepath='node_modules/test.js',
+                name="skipped_file",
+                type="function",
+                filepath="node_modules/test.js",
                 line_number=1,
                 end_line=5,
-                language='skipped',
+                language="skipped",
                 complexity=0,
                 has_docs=False,
-                export_type='internal',
-                module_system='unknown',
-                impact_score=0.0
+                export_type="internal",
+                module_system="unknown",
+                impact_score=0.0,
             ),
         ]
 
         metrics = calculator.calculate_by_language(items)
 
         # Should track both Python and skipped
-        assert 'python' in metrics
-        assert 'skipped' in metrics
+        assert "python" in metrics
+        assert "skipped" in metrics
 
         # Skipped should have 1 item, 0 documented
-        skipped_metrics = metrics['skipped']
+        skipped_metrics = metrics["skipped"]
         assert skipped_metrics.total_items == 1
         assert skipped_metrics.documented_items == 0
         assert skipped_metrics.coverage_percent == 0.0

--- a/analyzer/tests/test_di_compliance.py
+++ b/analyzer/tests/test_di_compliance.py
@@ -42,7 +42,7 @@ class TestDocumentationAnalyzerDI:
                 docstring=None,
                 export_type="internal",
                 module_system="unknown",
-                audit_rating=None
+                audit_rating=None,
             )
         ]
         mock_parser.parse_file.return_value = mock_items
@@ -56,8 +56,7 @@ class TestDocumentationAnalyzerDI:
         mock_scorer.calculate_score.return_value = 15.0
 
         analyzer = DocumentationAnalyzer(
-            parsers={'python': mock_parser},
-            scorer=mock_scorer
+            parsers={"python": mock_parser}, scorer=mock_scorer
         )
 
         # Analyze should use the injected mock parser
@@ -92,7 +91,7 @@ class TestDocumentationAnalyzerDI:
                 docstring=None,
                 export_type="internal",
                 module_system="unknown",
-                audit_rating=None
+                audit_rating=None,
             )
         ]
 
@@ -102,8 +101,7 @@ class TestDocumentationAnalyzerDI:
 
         # Create analyzer with injected dependencies
         analyzer = DocumentationAnalyzer(
-            parsers={'python': mock_parser},
-            scorer=mock_scorer
+            parsers={"python": mock_parser}, scorer=mock_scorer
         )
 
         result = analyzer.analyze(str(test_file))
@@ -135,7 +133,7 @@ class TestPlanGeneratorDI:
                 docstring="Existing docs",
                 export_type="internal",
                 module_system="unknown",
-                audit_rating=None  # Will be set by generate_plan
+                audit_rating=None,  # Will be set by generate_plan
             )
         ]
 
@@ -145,19 +143,18 @@ class TestPlanGeneratorDI:
             total_items=1,
             documented_items=1,
             by_language={},
-            parse_failures=[]
+            parse_failures=[],
         )
 
         # Create audit file
         audit_file = tmp_path / "audit.json"
         audit_data = {
             "ratings": {
-                str(tmp_path / "test.py"): {
-                    "documented_func": 1  # Terrible rating
-                }
+                str(tmp_path / "test.py"): {"documented_func": 1}  # Terrible rating
             }
         }
         import json
+
         audit_file.write_text(json.dumps(audit_data))
 
         # Create mock scorer that returns a specific value
@@ -169,7 +166,7 @@ class TestPlanGeneratorDI:
             result=result,
             audit_file=audit_file,
             quality_threshold=2,
-            scorer=mock_scorer
+            scorer=mock_scorer,
         )
 
         # Verify custom scorer was used
@@ -195,7 +192,7 @@ class TestPlanGeneratorDI:
                 docstring=None,
                 export_type="internal",
                 module_system="unknown",
-                audit_rating=None
+                audit_rating=None,
             )
         ]
 
@@ -205,14 +202,14 @@ class TestPlanGeneratorDI:
             total_items=1,
             documented_items=0,
             by_language={},
-            parse_failures=[]
+            parse_failures=[],
         )
 
         # Generate plan without scorer parameter (should use default)
         plan = generate_plan(
             result=result,
             audit_file=None,
-            quality_threshold=2
+            quality_threshold=2,
             # scorer=None is implicit
         )
 

--- a/analyzer/tests/test_git_helper.py
+++ b/analyzer/tests/test_git_helper.py
@@ -24,7 +24,7 @@ class TestGitHelper:
 
     def test_check_git_available_when_missing(self):
         """Test git detection when git is not in PATH."""
-        with patch('shutil.which', return_value=None):
+        with patch("shutil.which", return_value=None):
             assert GitHelper.check_git_available() is False
 
     def test_init_sidecar_repo_creates_structure(self):
@@ -41,11 +41,11 @@ class TestGitHelper:
 
                 # Verify structure was created
                 git_state_dir = StateManager.get_git_state_dir(base_path)
-                git_dir = git_state_dir / '.git'
+                git_dir = git_state_dir / ".git"
 
                 assert git_dir.exists()
-                assert (git_dir / 'HEAD').exists()
-                assert (git_state_dir / '.gitignore').exists()
+                assert (git_dir / "HEAD").exists()
+                assert (git_state_dir / ".gitignore").exists()
             else:
                 assert result is False
 
@@ -66,7 +66,7 @@ class TestGitHelper:
 
             # Should still have valid repo
             git_state_dir = StateManager.get_git_state_dir(base_path)
-            git_dir = git_state_dir / '.git'
+            git_dir = git_state_dir / ".git"
             assert git_dir.exists()
 
     def test_init_sidecar_repo_returns_false_when_git_missing(self):
@@ -74,7 +74,7 @@ class TestGitHelper:
         with tempfile.TemporaryDirectory() as tmpdir:
             base_path = Path(tmpdir)
 
-            with patch.object(GitHelper, 'check_git_available', return_value=False):
+            with patch.object(GitHelper, "check_git_available", return_value=False):
                 result = GitHelper.init_sidecar_repo(base_path)
                 assert result is False
 
@@ -90,7 +90,7 @@ class TestGitHelper:
             GitHelper.init_sidecar_repo(base_path)
 
             # Run a simple git command
-            result = GitHelper.run_git_command(['status'], base_path)
+            result = GitHelper.run_git_command(["status"], base_path)
 
             assert result.returncode == 0
             # Should execute without error
@@ -108,7 +108,7 @@ class TestGitHelper:
 
             # Run invalid command
             with pytest.raises(subprocess.CalledProcessError):
-                GitHelper.run_git_command(['invalid-command'], base_path, check=True)
+                GitHelper.run_git_command(["invalid-command"], base_path, check=True)
 
     def test_run_git_command_does_not_raise_when_check_false(self):
         """Test that run_git_command returns error result when check=False."""
@@ -122,7 +122,9 @@ class TestGitHelper:
             GitHelper.init_sidecar_repo(base_path)
 
             # Run invalid command with check=False
-            result = GitHelper.run_git_command(['invalid-command'], base_path, check=False)
+            result = GitHelper.run_git_command(
+                ["invalid-command"], base_path, check=False
+            )
 
             assert result.returncode != 0
 
@@ -138,7 +140,7 @@ class TestGitHelper:
             GitHelper.init_sidecar_repo(base_path)
 
             # Run command that produces output
-            result = GitHelper.run_git_command(['status'], base_path)
+            result = GitHelper.run_git_command(["status"], base_path)
 
             assert result.stdout is not None
             assert isinstance(result.stdout, str)
@@ -152,13 +154,10 @@ class TestGitHelper:
             base_path = Path(tmpdir)
 
             # Create a user git repo
-            user_git_dir = base_path / '.git'
+            user_git_dir = base_path / ".git"
             user_git_dir.mkdir(parents=True)
             subprocess.run(
-                ['git', 'init'],
-                cwd=base_path,
-                check=True,
-                capture_output=True
+                ["git", "init"], cwd=base_path, check=True, capture_output=True
             )
 
             # Initialize sidecar repo
@@ -169,7 +168,7 @@ class TestGitHelper:
 
             # Check that sidecar repo is separate
             git_state_dir = StateManager.get_git_state_dir(base_path)
-            sidecar_git_dir = git_state_dir / '.git'
+            sidecar_git_dir = git_state_dir / ".git"
 
             assert sidecar_git_dir.exists()
             assert sidecar_git_dir != user_git_dir
@@ -185,52 +184,61 @@ class TestGitHelper:
             GitHelper.init_sidecar_repo(base_path)
 
             git_state_dir = StateManager.get_git_state_dir(base_path)
-            gitignore_path = git_state_dir / '.gitignore'
+            gitignore_path = git_state_dir / ".gitignore"
 
             assert gitignore_path.exists()
             content = gitignore_path.read_text()
-            assert 'ephemeral' in content
-            assert '*' in content  # Ignore everything
+            assert "ephemeral" in content
+            assert "*" in content  # Ignore everything
 
     def test_categorize_operation_fast(self):
         """Test that fast operations are correctly categorized."""
         # Fast operations: status, rev-parse, branch, show, diff
-        assert GitHelper._categorize_operation(['status']) == 'fast'
-        assert GitHelper._categorize_operation(['rev-parse', '--short', 'HEAD']) == 'fast'
-        assert GitHelper._categorize_operation(['branch', '--list']) == 'fast'
-        assert GitHelper._categorize_operation(['show', 'abc123']) == 'fast'
-        assert GitHelper._categorize_operation(['diff', 'HEAD']) == 'fast'
+        assert GitHelper._categorize_operation(["status"]) == "fast"
+        assert (
+            GitHelper._categorize_operation(["rev-parse", "--short", "HEAD"]) == "fast"
+        )
+        assert GitHelper._categorize_operation(["branch", "--list"]) == "fast"
+        assert GitHelper._categorize_operation(["show", "abc123"]) == "fast"
+        assert GitHelper._categorize_operation(["diff", "HEAD"]) == "fast"
 
     def test_categorize_operation_slow(self):
         """Test that slow operations are correctly categorized."""
         # Slow operations: merge, revert, reset, init, clone, rebase
-        assert GitHelper._categorize_operation(['merge', '--squash', 'branch']) == 'slow'
-        assert GitHelper._categorize_operation(['revert', 'abc123']) == 'slow'
-        assert GitHelper._categorize_operation(['reset', '--hard', 'HEAD']) == 'slow'
-        assert GitHelper._categorize_operation(['init']) == 'slow'
-        assert GitHelper._categorize_operation(['clone', 'repo']) == 'slow'
-        assert GitHelper._categorize_operation(['rebase', 'main']) == 'slow'
+        assert (
+            GitHelper._categorize_operation(["merge", "--squash", "branch"]) == "slow"
+        )
+        assert GitHelper._categorize_operation(["revert", "abc123"]) == "slow"
+        assert GitHelper._categorize_operation(["reset", "--hard", "HEAD"]) == "slow"
+        assert GitHelper._categorize_operation(["init"]) == "slow"
+        assert GitHelper._categorize_operation(["clone", "repo"]) == "slow"
+        assert GitHelper._categorize_operation(["rebase", "main"]) == "slow"
 
     def test_categorize_operation_default(self):
         """Test that default operations are correctly categorized."""
         # Default operations: add, commit, checkout, log
-        assert GitHelper._categorize_operation(['add', 'file.py']) == 'default'
-        assert GitHelper._categorize_operation(['commit', '-m', 'message']) == 'default'
-        assert GitHelper._categorize_operation(['checkout', 'main']) == 'default'
-        assert GitHelper._categorize_operation(['log', '--oneline']) == 'default'
+        assert GitHelper._categorize_operation(["add", "file.py"]) == "default"
+        assert GitHelper._categorize_operation(["commit", "-m", "message"]) == "default"
+        assert GitHelper._categorize_operation(["checkout", "main"]) == "default"
+        assert GitHelper._categorize_operation(["log", "--oneline"]) == "default"
 
     def test_categorize_operation_empty(self):
         """Test that empty args default to 'default' category."""
-        assert GitHelper._categorize_operation([]) == 'default'
+        assert GitHelper._categorize_operation([]) == "default"
 
     def test_calculate_timeout_fast(self):
         """Test timeout calculation for fast operations."""
         from src.utils.git_helper import GitTimeoutConfig
 
-        config = GitTimeoutConfig(base_timeout_ms=30000, fast_scale=0.167, slow_scale=4.0, max_timeout_ms=300000)
+        config = GitTimeoutConfig(
+            base_timeout_ms=30000,
+            fast_scale=0.167,
+            slow_scale=4.0,
+            max_timeout_ms=300000,
+        )
 
         # Fast operation: status
-        timeout = GitHelper._calculate_timeout(['status'], config)
+        timeout = GitHelper._calculate_timeout(["status"], config)
         # 30000 * 0.167 = 5010ms = 5.01 seconds
         assert timeout == pytest.approx(5.01, rel=0.01)
 
@@ -238,10 +246,15 @@ class TestGitHelper:
         """Test timeout calculation for default operations."""
         from src.utils.git_helper import GitTimeoutConfig
 
-        config = GitTimeoutConfig(base_timeout_ms=30000, fast_scale=0.167, slow_scale=4.0, max_timeout_ms=300000)
+        config = GitTimeoutConfig(
+            base_timeout_ms=30000,
+            fast_scale=0.167,
+            slow_scale=4.0,
+            max_timeout_ms=300000,
+        )
 
         # Default operation: commit
-        timeout = GitHelper._calculate_timeout(['commit', '-m', 'message'], config)
+        timeout = GitHelper._calculate_timeout(["commit", "-m", "message"], config)
         # base_timeout_ms = 30000ms = 30.0 seconds
         assert timeout == 30.0
 
@@ -249,10 +262,15 @@ class TestGitHelper:
         """Test timeout calculation for slow operations."""
         from src.utils.git_helper import GitTimeoutConfig
 
-        config = GitTimeoutConfig(base_timeout_ms=30000, fast_scale=0.167, slow_scale=4.0, max_timeout_ms=300000)
+        config = GitTimeoutConfig(
+            base_timeout_ms=30000,
+            fast_scale=0.167,
+            slow_scale=4.0,
+            max_timeout_ms=300000,
+        )
 
         # Slow operation: merge
-        timeout = GitHelper._calculate_timeout(['merge', '--squash', 'branch'], config)
+        timeout = GitHelper._calculate_timeout(["merge", "--squash", "branch"], config)
         # 30000 * 4.0 = 120000ms = 120.0 seconds
         assert timeout == 120.0
 
@@ -260,10 +278,15 @@ class TestGitHelper:
         """Test that calculated timeout never exceeds max_timeout_ms."""
         from src.utils.git_helper import GitTimeoutConfig
 
-        config = GitTimeoutConfig(base_timeout_ms=100000, fast_scale=0.167, slow_scale=4.0, max_timeout_ms=200000)
+        config = GitTimeoutConfig(
+            base_timeout_ms=100000,
+            fast_scale=0.167,
+            slow_scale=4.0,
+            max_timeout_ms=200000,
+        )
 
         # Slow operation would be 100000 * 4.0 = 400000ms, but capped at 200000ms
-        timeout = GitHelper._calculate_timeout(['merge', '--squash', 'branch'], config)
+        timeout = GitHelper._calculate_timeout(["merge", "--squash", "branch"], config)
         assert timeout == 200.0  # 200000ms = 200 seconds (capped)
 
     def test_timeout_config_defaults(self):
@@ -288,15 +311,15 @@ class TestGitHelper:
             GitHelper.init_sidecar_repo(base_path)
 
             # Custom config with very short timeouts
-            config = GitTimeoutConfig(base_timeout_ms=10, fast_scale=0.1, slow_scale=1.0, max_timeout_ms=100)
+            config = GitTimeoutConfig(
+                base_timeout_ms=10, fast_scale=0.1, slow_scale=1.0, max_timeout_ms=100
+            )
 
             # Fast operation should work even with short timeout
             # status is fast (10ms * 0.1 = 1ms timeout)
             try:
                 result = GitHelper.run_git_command(
-                    ['status', '--short'],
-                    base_path,
-                    timeout_config=config
+                    ["status", "--short"], base_path, timeout_config=config
                 )
                 # If git is very fast, this might succeed
                 assert result.returncode == 0 or True  # Allow timeout
@@ -316,20 +339,18 @@ class TestGitHelper:
             GitHelper.init_sidecar_repo(base_path)
 
             # Extremely short timeout to force timeout
-            config = GitTimeoutConfig(base_timeout_ms=1, fast_scale=0.001, slow_scale=0.001, max_timeout_ms=1)
+            config = GitTimeoutConfig(
+                base_timeout_ms=1, fast_scale=0.001, slow_scale=0.001, max_timeout_ms=1
+            )
 
             try:
-                GitHelper.run_git_command(
-                    ['status'],
-                    base_path,
-                    timeout_config=config
-                )
+                GitHelper.run_git_command(["status"], base_path, timeout_config=config)
                 # If we get here, git was extremely fast (unlikely with 0.001ms timeout)
                 pytest.skip("Git operation completed faster than minimum timeout")
             except TimeoutError as e:
                 error_msg = str(e)
                 # Verify error message contains helpful information
-                assert 'timed out' in error_msg.lower()
-                assert 'fast' in error_msg.lower()  # Operation category
-                assert 'transaction.git' in error_msg  # Config field hint
-                assert 'docimp.config.js' in error_msg  # Config file
+                assert "timed out" in error_msg.lower()
+                assert "fast" in error_msg.lower()  # Operation category
+                assert "transaction.git" in error_msg  # Config field hint
+                assert "docimp.config.js" in error_msg  # Config file

--- a/analyzer/tests/test_git_integration.py
+++ b/analyzer/tests/test_git_integration.py
@@ -25,7 +25,7 @@ def compute_directory_hash(directory: Path) -> str:
     """Compute a hash of all files in a directory for change detection."""
     hasher = hashlib.sha256()
 
-    for filepath in sorted(directory.rglob('*')):
+    for filepath in sorted(directory.rglob("*")):
         if filepath.is_file():
             # Include file path and contents in hash
             hasher.update(str(filepath.relative_to(directory)).encode())
@@ -36,9 +36,13 @@ def compute_directory_hash(directory: Path) -> str:
 
 def create_user_git_repo(base_path: Path) -> None:
     """Create a real user git repository for testing."""
-    subprocess.run(['git', 'init'], cwd=base_path, check=True, capture_output=True)
-    subprocess.run(['git', 'config', 'user.name', 'Test User'], cwd=base_path, check=True)
-    subprocess.run(['git', 'config', 'user.email', 'test@example.com'], cwd=base_path, check=True)
+    subprocess.run(["git", "init"], cwd=base_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.name", "Test User"], cwd=base_path, check=True
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"], cwd=base_path, check=True
+    )
 
 
 class TestSidecarRepoIsolation:
@@ -53,7 +57,7 @@ class TestSidecarRepoIsolation:
             create_user_git_repo(base_path)
 
             # Compute hash of .git/ directory BEFORE any operations
-            user_git_dir = base_path / '.git'
+            user_git_dir = base_path / ".git"
             hash_before = compute_directory_hash(user_git_dir)
 
             # Initialize side-car repo
@@ -61,13 +65,15 @@ class TestSidecarRepoIsolation:
 
             # Perform transaction operations
             manager = TransactionManager(base_path=base_path, use_git=True)
-            manifest = manager.begin_transaction('test-session')
+            manifest = manager.begin_transaction("test-session")
 
             # Create a test file and record change
-            test_file = base_path / 'test.py'
-            test_file.write_text('def foo():\n    pass\n')
-            backup_path = str(test_file) + '.bak'
-            manager.record_write(manifest, str(test_file), backup_path, 'foo', 'function', 'python')
+            test_file = base_path / "test.py"
+            test_file.write_text("def foo():\n    pass\n")
+            backup_path = str(test_file) + ".bak"
+            manager.record_write(
+                manifest, str(test_file), backup_path, "foo", "function", "python"
+            )
 
             # Commit transaction (now that git init is fixed)
             manager.commit_transaction(manifest)
@@ -89,9 +95,15 @@ class TestSidecarRepoIsolation:
             # Check git config for work-tree setting
             git_state_dir = StateManager.get_git_state_dir(base_path)
             result = subprocess.run(
-                ['git', '--git-dir', str(git_state_dir / '.git'), 'config', 'core.worktree'],
+                [
+                    "git",
+                    "--git-dir",
+                    str(git_state_dir / ".git"),
+                    "config",
+                    "core.worktree",
+                ],
                 capture_output=True,
-                text=True
+                text=True,
             )
 
             # Work-tree should be set to project root
@@ -109,32 +121,36 @@ class TestSidecarRepoIsolation:
             git_commands = []
 
             def mock_run(*args, **kwargs):
-                if args and 'git' in str(args[0]):
+                if args and "git" in str(args[0]):
                     git_commands.append(args[0])
                 return original_run(*args, **kwargs)
 
-            with patch('subprocess.run', side_effect=mock_run):
+            with patch("subprocess.run", side_effect=mock_run):
                 # Initialize and perform operations
                 GitHelper.init_sidecar_repo(base_path)
                 manager = TransactionManager(base_path=base_path, use_git=True)
-                manifest = manager.begin_transaction('test-session')
+                manifest = manager.begin_transaction("test-session")
 
                 # Create and record a change
-                test_file = base_path / 'test.py'
-                test_file.write_text('def foo(): pass')
-                backup_path = str(test_file) + '.bak'
-                manager.record_write(manifest, str(test_file), backup_path, 'foo', 'function', 'python')
+                test_file = base_path / "test.py"
+                test_file.write_text("def foo(): pass")
+                backup_path = str(test_file) + ".bak"
+                manager.record_write(
+                    manifest, str(test_file), backup_path, "foo", "function", "python"
+                )
 
             # Verify all git commands (except init and config) use isolation flags
             for cmd in git_commands:
                 if isinstance(cmd, list) and len(cmd) > 1:
                     # Skip init and config commands
-                    if cmd[1] in ['init', 'config']:
+                    if cmd[1] in ["init", "config"]:
                         continue
 
                     # All other commands must have --git-dir flag
-                    cmd_str = ' '.join(cmd)
-                    assert '--git-dir' in cmd_str, f"Command missing --git-dir: {cmd_str}"
+                    cmd_str = " ".join(cmd)
+                    assert (
+                        "--git-dir" in cmd_str
+                    ), f"Command missing --git-dir: {cmd_str}"
 
     def test_no_git_hook_interference(self):
         """Verify side-car repo never triggers user's git hooks."""
@@ -143,24 +159,26 @@ class TestSidecarRepoIsolation:
 
             # Create user git repo with a pre-commit hook
             create_user_git_repo(base_path)
-            hooks_dir = base_path / '.git' / 'hooks'
+            hooks_dir = base_path / ".git" / "hooks"
             hooks_dir.mkdir(exist_ok=True)
 
             # Create pre-commit hook that creates a marker file
-            marker_file = base_path / 'hook_was_called.txt'
-            pre_commit_hook = hooks_dir / 'pre-commit'
-            pre_commit_hook.write_text(f'#!/bin/sh\ntouch {marker_file}\n')
+            marker_file = base_path / "hook_was_called.txt"
+            pre_commit_hook = hooks_dir / "pre-commit"
+            pre_commit_hook.write_text(f"#!/bin/sh\ntouch {marker_file}\n")
             pre_commit_hook.chmod(0o755)
 
             # Perform transaction operations
             GitHelper.init_sidecar_repo(base_path)
             manager = TransactionManager(base_path=base_path, use_git=True)
-            manifest = manager.begin_transaction('test-session')
+            manifest = manager.begin_transaction("test-session")
 
-            test_file = base_path / 'test.py'
-            test_file.write_text('def foo(): pass')
-            backup_path = str(test_file) + '.bak'
-            manager.record_write(manifest, str(test_file), backup_path, 'foo', 'function', 'python')
+            test_file = base_path / "test.py"
+            test_file.write_text("def foo(): pass")
+            backup_path = str(test_file) + ".bak"
+            manager.record_write(
+                manifest, str(test_file), backup_path, "foo", "function", "python"
+            )
 
             # Commit transaction
             manager.commit_transaction(manifest)
@@ -179,32 +197,34 @@ class TestSidecarRepoIsolation:
             # Perform transaction operations
             GitHelper.init_sidecar_repo(base_path)
             manager = TransactionManager(base_path=base_path, use_git=True)
-            manifest = manager.begin_transaction('test-session')
+            manifest = manager.begin_transaction("test-session")
 
-            test_file = base_path / 'test.py'
-            test_file.write_text('def foo(): pass')
-            backup_path = str(test_file) + '.bak'
-            manager.record_write(manifest, str(test_file), backup_path, 'foo', 'function', 'python')
+            test_file = base_path / "test.py"
+            test_file.write_text("def foo(): pass")
+            backup_path = str(test_file) + ".bak"
+            manager.record_write(
+                manifest, str(test_file), backup_path, "foo", "function", "python"
+            )
 
             # Commit transaction
             manager.commit_transaction(manifest)
 
             # Check user's git status
             result = subprocess.run(
-                ['git', 'status', '--porcelain'],
+                ["git", "status", "--porcelain"],
                 cwd=base_path,
                 capture_output=True,
                 text=True,
-                check=True
+                check=True,
             )
 
             # It's OK for .docimp/ to show as untracked (it's a real directory)
             # But backup files should NOT appear
-            lines = result.stdout.strip().split('\n')
+            lines = result.stdout.strip().split("\n")
             for line in lines:
                 # .docimp/ may appear as untracked directory - that's fine
                 # But no .bak files should leak into user's repo status
-                assert '.bak' not in line, f"User's git status shows .bak file: {line}"
+                assert ".bak" not in line, f"User's git status shows .bak file: {line}"
 
     def test_user_git_log_unaffected(self):
         """Verify git log in user's repo has no docimp commits."""
@@ -213,37 +233,43 @@ class TestSidecarRepoIsolation:
 
             # Create user git repo with a commit
             create_user_git_repo(base_path)
-            initial_file = base_path / 'README.md'
-            initial_file.write_text('# Test Project\n')
-            subprocess.run(['git', 'add', 'README.md'], cwd=base_path, check=True)
-            subprocess.run(['git', 'commit', '-m', 'Initial commit'], cwd=base_path, check=True)
+            initial_file = base_path / "README.md"
+            initial_file.write_text("# Test Project\n")
+            subprocess.run(["git", "add", "README.md"], cwd=base_path, check=True)
+            subprocess.run(
+                ["git", "commit", "-m", "Initial commit"], cwd=base_path, check=True
+            )
 
             # Perform transaction operations
             GitHelper.init_sidecar_repo(base_path)
             manager = TransactionManager(base_path=base_path, use_git=True)
-            manifest = manager.begin_transaction('test-session')
+            manifest = manager.begin_transaction("test-session")
 
-            test_file = base_path / 'test.py'
-            test_file.write_text('def foo(): pass')
-            backup_path = str(test_file) + '.bak'
-            manager.record_write(manifest, str(test_file), backup_path, 'foo', 'function', 'python')
+            test_file = base_path / "test.py"
+            test_file.write_text("def foo(): pass")
+            backup_path = str(test_file) + ".bak"
+            manager.record_write(
+                manifest, str(test_file), backup_path, "foo", "function", "python"
+            )
 
             # Commit transaction
             manager.commit_transaction(manifest)
 
             # Check user's git log
             result = subprocess.run(
-                ['git', 'log', '--all', '--oneline'],
+                ["git", "log", "--all", "--oneline"],
                 cwd=base_path,
                 capture_output=True,
                 text=True,
-                check=True
+                check=True,
             )
 
             # Should only show user's commit, not docimp commits
             log_output = result.stdout
-            assert 'docimp:' not in log_output.lower(), "User's git log shows docimp commits!"
-            assert 'Initial commit' in log_output
+            assert (
+                "docimp:" not in log_output.lower()
+            ), "User's git log shows docimp commits!"
+            assert "Initial commit" in log_output
 
 
 class TestSpecialFilenames:
@@ -256,19 +282,21 @@ class TestSpecialFilenames:
 
             GitHelper.init_sidecar_repo(base_path)
             manager = TransactionManager(base_path=base_path, use_git=True)
-            manifest = manager.begin_transaction('test-session')
+            manifest = manager.begin_transaction("test-session")
 
             # Create file with space in name
-            test_file = base_path / 'my test file.py'
-            test_file.write_text('def foo(): pass')
-            backup_path = str(test_file) + '.bak'
+            test_file = base_path / "my test file.py"
+            test_file.write_text("def foo(): pass")
+            backup_path = str(test_file) + ".bak"
 
             # Should not raise
-            manager.record_write(manifest, str(test_file), backup_path, 'foo', 'function', 'python')
+            manager.record_write(
+                manifest, str(test_file), backup_path, "foo", "function", "python"
+            )
 
             # Commit to verify end-to-end works with special filenames
             manager.commit_transaction(manifest)
-            assert manifest.status == 'committed'
+            assert manifest.status == "committed"
 
     def test_filenames_with_special_chars(self):
         """Test git operations with apostrophes, quotes, unicode."""
@@ -277,30 +305,37 @@ class TestSpecialFilenames:
 
             GitHelper.init_sidecar_repo(base_path)
             manager = TransactionManager(base_path=base_path, use_git=True)
-            manifest = manager.begin_transaction('test-session')
+            manifest = manager.begin_transaction("test-session")
 
             # Test various special characters
             test_cases = [
-                "file's.py",        # Apostrophe
-                'file"name.py',     # Quote
-                'café.py',          # Unicode
-                'file&name.py',     # Ampersand
+                "file's.py",  # Apostrophe
+                'file"name.py',  # Quote
+                "café.py",  # Unicode
+                "file&name.py",  # Ampersand
             ]
 
             for filename in test_cases:
                 test_file = base_path / filename
-                test_file.write_text('def foo(): pass')
-                backup_path = str(test_file) + '.bak'
+                test_file.write_text("def foo(): pass")
+                backup_path = str(test_file) + ".bak"
 
                 # Should not raise
                 try:
-                    manager.record_write(manifest, str(test_file), backup_path, 'foo', 'function', 'python')
+                    manager.record_write(
+                        manifest,
+                        str(test_file),
+                        backup_path,
+                        "foo",
+                        "function",
+                        "python",
+                    )
                 except Exception as e:
                     pytest.fail(f"Failed to record file with name '{filename}': {e}")
 
             # Commit to verify end-to-end works with special characters
             manager.commit_transaction(manifest)
-            assert manifest.status == 'committed'
+            assert manifest.status == "committed"
             assert len(manifest.entries) == len(test_cases)
 
     def test_very_long_filenames(self):
@@ -310,17 +345,19 @@ class TestSpecialFilenames:
 
             GitHelper.init_sidecar_repo(base_path)
             manager = TransactionManager(base_path=base_path, use_git=True)
-            manifest = manager.begin_transaction('test-session')
+            manifest = manager.begin_transaction("test-session")
 
             # Create filename with 255 characters (filesystem limit)
-            long_name = 'a' * 250 + '.py'
+            long_name = "a" * 250 + ".py"
             test_file = base_path / long_name
 
             try:
-                test_file.write_text('def foo(): pass')
-                backup_path = str(test_file) + '.bak'
+                test_file.write_text("def foo(): pass")
+                backup_path = str(test_file) + ".bak"
                 # Attempt to record (may fail gracefully depending on filesystem)
-                manager.record_write(manifest, str(test_file), backup_path, 'foo', 'function', 'python')
+                manager.record_write(
+                    manifest, str(test_file), backup_path, "foo", "function", "python"
+                )
             except (OSError, subprocess.CalledProcessError, ValueError):
                 # Acceptable to fail on very long filenames, but should not crash
                 pass
@@ -339,8 +376,8 @@ class TestGitEdgeCases:
 
             # Corrupt the repo by deleting HEAD
             git_state_dir = StateManager.get_git_state_dir(base_path)
-            git_dir = git_state_dir / '.git'
-            head_file = git_dir / 'HEAD'
+            git_dir = git_state_dir / ".git"
+            head_file = git_dir / "HEAD"
             head_file.unlink()
 
             # Attempt operations (should either recover or fail gracefully)
@@ -349,7 +386,7 @@ class TestGitEdgeCases:
             # This may raise or fall back to non-git mode
             # Either behavior is acceptable, but should not crash
             try:
-                _manifest = manager.begin_transaction('test-session')
+                _manifest = manager.begin_transaction("test-session")
             except (subprocess.CalledProcessError, RuntimeError):
                 pass  # Graceful failure is acceptable
 
@@ -363,39 +400,37 @@ class TestGitEdgeCases:
 
             # Create a commit first
             manager = TransactionManager(base_path=base_path, use_git=True)
-            manifest = manager.begin_transaction('test-session-1')
-            test_file = base_path / 'test.py'
-            test_file.write_text('def foo(): pass')
-            backup_path1 = str(test_file) + '.bak'
-            manager.record_write(manifest, str(test_file), backup_path1, 'foo', 'function', 'python')
+            manifest = manager.begin_transaction("test-session-1")
+            test_file = base_path / "test.py"
+            test_file.write_text("def foo(): pass")
+            backup_path1 = str(test_file) + ".bak"
+            manager.record_write(
+                manifest, str(test_file), backup_path1, "foo", "function", "python"
+            )
             manager.commit_transaction(manifest)
 
             # Get commit SHA and checkout in detached HEAD
             result = GitHelper.run_git_command(
-                ['rev-parse', 'HEAD'],
-                base_path,
-                check=True
+                ["rev-parse", "HEAD"], base_path, check=True
             )
             commit_sha = result.stdout.strip()
 
-            GitHelper.run_git_command(
-                ['checkout', commit_sha],
-                base_path,
-                check=True
-            )
+            GitHelper.run_git_command(["checkout", commit_sha], base_path, check=True)
 
             # Attempt another transaction (should handle detached HEAD gracefully)
-            manifest2 = manager.begin_transaction('test-session-2')
-            test_file2 = base_path / 'test2.py'
-            test_file2.write_text('def bar(): pass')
-            backup_path2 = str(test_file2) + '.bak'
-            manager.record_write(manifest2, str(test_file2), backup_path2, 'bar', 'function', 'python')
+            manifest2 = manager.begin_transaction("test-session-2")
+            test_file2 = base_path / "test2.py"
+            test_file2.write_text("def bar(): pass")
+            backup_path2 = str(test_file2) + ".bak"
+            manager.record_write(
+                manifest2, str(test_file2), backup_path2, "bar", "function", "python"
+            )
 
             # Should either work or fail gracefully
             try:
                 manager.commit_transaction(manifest2)
                 # If it works, verify it committed
-                assert manifest2.status == 'committed'
+                assert manifest2.status == "committed"
             except (subprocess.CalledProcessError, RuntimeError):
                 # Acceptable to fail in detached HEAD - just verify it fails cleanly
                 pass
@@ -405,7 +440,9 @@ class TestConcurrencyAndSafety:
     """Test concurrent session handling and safety."""
 
     def test_concurrent_session_safety(self):
-        """Test that multiple processes don't conflict (document limitation if needed)."""
+        """Test that multiple processes don't conflict (document limitation
+
+        if needed)."""
         with tempfile.TemporaryDirectory() as tmpdir:
             base_path = Path(tmpdir)
 
@@ -415,22 +452,26 @@ class TestConcurrencyAndSafety:
             manager1 = TransactionManager(base_path=base_path, use_git=True)
             manager2 = TransactionManager(base_path=base_path, use_git=True)
 
-            manifest1 = manager1.begin_transaction('session-1')
-            manifest2 = manager2.begin_transaction('session-2')
+            manifest1 = manager1.begin_transaction("session-1")
+            manifest2 = manager2.begin_transaction("session-2")
 
             # Both sessions should get unique IDs
             assert manifest1.session_id != manifest2.session_id
 
             # Both should be able to record changes without conflicts
-            test_file1 = base_path / 'test1.py'
-            test_file1.write_text('def foo(): pass')
-            backup_path1 = str(test_file1) + '.bak'
-            manager1.record_write(manifest1, str(test_file1), backup_path1, 'foo', 'function', 'python')
+            test_file1 = base_path / "test1.py"
+            test_file1.write_text("def foo(): pass")
+            backup_path1 = str(test_file1) + ".bak"
+            manager1.record_write(
+                manifest1, str(test_file1), backup_path1, "foo", "function", "python"
+            )
 
-            test_file2 = base_path / 'test2.py'
-            test_file2.write_text('def bar(): pass')
-            backup_path2 = str(test_file2) + '.bak'
-            manager2.record_write(manifest2, str(test_file2), backup_path2, 'bar', 'function', 'python')
+            test_file2 = base_path / "test2.py"
+            test_file2.write_text("def bar(): pass")
+            backup_path2 = str(test_file2) + ".bak"
+            manager2.record_write(
+                manifest2, str(test_file2), backup_path2, "bar", "function", "python"
+            )
 
             # Commit both (may conflict, which is acceptable)
             try:
@@ -438,8 +479,8 @@ class TestConcurrencyAndSafety:
                 manager2.commit_transaction(manifest2)
 
                 # If both succeed, verify both manifests are marked committed
-                assert manifest1.status == 'committed'
-                assert manifest2.status == 'committed'
+                assert manifest1.status == "committed"
+                assert manifest2.status == "committed"
             except (subprocess.CalledProcessError, RuntimeError):
                 # Acceptable to have conflicts with concurrent commits
                 pass

--- a/analyzer/tests/test_graceful_degradation.py
+++ b/analyzer/tests/test_graceful_degradation.py
@@ -32,24 +32,26 @@ class TestGitUnavailable:
             manager = TransactionManager(base_path=base_path, use_git=False)
 
             # Create file
-            filepath = base_path / 'file.py'
-            original = 'def foo(): pass\n'
+            filepath = base_path / "file.py"
+            original = "def foo(): pass\n"
             filepath.write_text(original)
 
             # Begin transaction
-            manifest = manager.begin_transaction('test-session')
-            backup = str(filepath) + '.bak'
+            manifest = manager.begin_transaction("test-session")
+            backup = str(filepath) + ".bak"
             Path(backup).write_text(original)
             filepath.write_text('def foo():\n    """docs"""\n    pass\n')
-            manager.record_write(manifest, str(filepath), backup, 'foo', 'function', 'python')
+            manager.record_write(
+                manifest, str(filepath), backup, "foo", "function", "python"
+            )
 
             # Commit should work
             manager.commit_transaction(manifest)
-            assert manifest.status == 'committed'
+            assert manifest.status == "committed"
 
     def test_git_helper_check_when_git_missing(self):
         """Test git availability check when git not in PATH."""
-        with patch('shutil.which', return_value=None):
+        with patch("shutil.which", return_value=None):
             assert GitHelper.check_git_available() is False
 
     def test_init_sidecar_repo_when_git_missing(self):
@@ -57,7 +59,7 @@ class TestGitUnavailable:
         with tempfile.TemporaryDirectory() as tmpdir:
             base_path = Path(tmpdir)
 
-            with patch('shutil.which', return_value=None):
+            with patch("shutil.which", return_value=None):
                 result = GitHelper.init_sidecar_repo(base_path)
                 assert result is False
 
@@ -79,7 +81,7 @@ class TestPermissionErrors:
                 # Attempting operations should either fail gracefully or skip
                 # The important thing is no crash
                 try:
-                    _manifest = manager.begin_transaction('test-session')
+                    _manifest = manager.begin_transaction("test-session")
                 except (PermissionError, OSError):
                     pass  # Acceptable to fail with clear error
             finally:
@@ -99,20 +101,22 @@ class TestStateConsistency:
 
             # Create three files
             for i in range(3):
-                filepath = base_path / f'file{i}.py'
-                filepath.write_text(f'original {i}\n')
+                filepath = base_path / f"file{i}.py"
+                filepath.write_text(f"original {i}\n")
 
             # Record transaction
-            manifest = manager.begin_transaction('test-session')
+            manifest = manager.begin_transaction("test-session")
             for i in range(3):
-                filepath = base_path / f'file{i}.py'
-                backup = str(filepath) + '.bak'
-                Path(backup).write_text(f'original {i}\n')
-                filepath.write_text(f'modified {i}\n')
-                manager.record_write(manifest, str(filepath), backup, f'func{i}', 'function', 'python')
+                filepath = base_path / f"file{i}.py"
+                backup = str(filepath) + ".bak"
+                Path(backup).write_text(f"original {i}\n")
+                filepath.write_text(f"modified {i}\n")
+                manager.record_write(
+                    manifest, str(filepath), backup, f"func{i}", "function", "python"
+                )
 
             # Delete one backup to simulate failure
-            (base_path / 'file1.py.bak').unlink()
+            (base_path / "file1.py.bak").unlink()
 
             # Rollback should restore what it can
             restored = manager.rollback_transaction(manifest)
@@ -121,7 +125,7 @@ class TestStateConsistency:
             assert restored == 2
 
             # Manifest should still be marked as rolled_back
-            assert manifest.status == 'rolled_back'
+            assert manifest.status == "rolled_back"
 
     def test_session_state_after_commit_failure(self):
         """Test that session state is consistent after commit failure."""
@@ -130,20 +134,22 @@ class TestStateConsistency:
 
             manager = TransactionManager(base_path=base_path, use_git=False)
 
-            filepath = base_path / 'file.py'
-            filepath.write_text('original\n')
+            filepath = base_path / "file.py"
+            filepath.write_text("original\n")
 
-            manifest = manager.begin_transaction('test-session')
-            backup = str(filepath) + '.bak'
-            Path(backup).write_text('original\n')
-            filepath.write_text('modified\n')
-            manager.record_write(manifest, str(filepath), backup, 'foo', 'function', 'python')
+            manifest = manager.begin_transaction("test-session")
+            backup = str(filepath) + ".bak"
+            Path(backup).write_text("original\n")
+            filepath.write_text("modified\n")
+            manager.record_write(
+                manifest, str(filepath), backup, "foo", "function", "python"
+            )
 
             # Even if commit has issues, manifest should be updated
             manager.commit_transaction(manifest)
 
             # Status should be committed
-            assert manifest.status in ['committed', 'in_progress']
+            assert manifest.status in ["committed", "in_progress"]
 
 
 class TestEdgeCases:
@@ -156,12 +162,12 @@ class TestEdgeCases:
 
             manager = TransactionManager(base_path=base_path, use_git=False)
 
-            manifest = manager.begin_transaction('empty-session')
+            manifest = manager.begin_transaction("empty-session")
             assert len(manifest.entries) == 0
 
             # Should handle empty session gracefully
             manager.commit_transaction(manifest)
-            assert manifest.status == 'committed'
+            assert manifest.status == "committed"
 
     def test_very_long_session_id(self):
         """Test transaction with very long session ID."""
@@ -171,13 +177,13 @@ class TestEdgeCases:
             manager = TransactionManager(base_path=base_path, use_git=False)
 
             # Create very long session ID (255 chars)
-            long_id = 'a' * 255
+            long_id = "a" * 255
 
             manifest = manager.begin_transaction(long_id)
             assert manifest.session_id == long_id
 
             manager.commit_transaction(manifest)
-            assert manifest.status == 'committed'
+            assert manifest.status == "committed"
 
     def test_special_characters_in_session_id(self):
         """Test session IDs with special characters."""
@@ -188,10 +194,10 @@ class TestEdgeCases:
 
             # Test various special characters
             test_ids = [
-                'session-with-dashes',
-                'session_with_underscores',
-                'session.with.dots',
-                'session123with456numbers',
+                "session-with-dashes",
+                "session_with_underscores",
+                "session.with.dots",
+                "session123with456numbers",
             ]
 
             for session_id in test_ids:
@@ -213,7 +219,7 @@ class TestGitStateRecovery:
 
             # Operations should either work or fail gracefully
             try:
-                _manifest = manager.begin_transaction('test-session')
+                _manifest = manager.begin_transaction("test-session")
                 # May succeed or fail depending on implementation
             except (subprocess.CalledProcessError, RuntimeError, FileNotFoundError):
                 pass  # Acceptable to fail with clear error
@@ -230,19 +236,21 @@ class TestBackupManagement:
             manager = TransactionManager(base_path=base_path, use_git=False)
 
             # File with multiple extensions
-            filepath = base_path / 'file.test.py'
-            filepath.write_text('original\n')
+            filepath = base_path / "file.test.py"
+            filepath.write_text("original\n")
 
-            manifest = manager.begin_transaction('test-session')
-            backup = str(filepath) + '.bak'
-            Path(backup).write_text('original\n')
-            filepath.write_text('modified\n')
-            manager.record_write(manifest, str(filepath), backup, 'func', 'function', 'python')
+            manifest = manager.begin_transaction("test-session")
+            backup = str(filepath) + ".bak"
+            Path(backup).write_text("original\n")
+            filepath.write_text("modified\n")
+            manager.record_write(
+                manifest, str(filepath), backup, "func", "function", "python"
+            )
 
             # Rollback should work
             result = manager.rollback_transaction(manifest)
             assert result == 1
-            assert filepath.read_text() == 'original\n'
+            assert filepath.read_text() == "original\n"
 
     def test_backup_cleanup_on_commit(self):
         """Test that backups are cleaned up on successful commit."""
@@ -251,14 +259,16 @@ class TestBackupManagement:
 
             manager = TransactionManager(base_path=base_path, use_git=False)
 
-            filepath = base_path / 'file.py'
-            filepath.write_text('original\n')
+            filepath = base_path / "file.py"
+            filepath.write_text("original\n")
 
-            manifest = manager.begin_transaction('test-session')
-            backup_path = Path(str(filepath) + '.bak')
-            backup_path.write_text('original\n')
-            filepath.write_text('modified\n')
-            manager.record_write(manifest, str(filepath), str(backup_path), 'func', 'function', 'python')
+            manifest = manager.begin_transaction("test-session")
+            backup_path = Path(str(filepath) + ".bak")
+            backup_path.write_text("original\n")
+            filepath.write_text("modified\n")
+            manager.record_write(
+                manifest, str(filepath), str(backup_path), "func", "function", "python"
+            )
 
             # Verify backup exists before commit
             assert backup_path.exists()
@@ -283,18 +293,18 @@ class TestConcurrentAccess:
             manager2 = TransactionManager(base_path=base_path, use_git=False)
 
             # Each should be able to create transactions
-            manifest1 = manager1.begin_transaction('session-1')
-            manifest2 = manager2.begin_transaction('session-2')
+            manifest1 = manager1.begin_transaction("session-1")
+            manifest2 = manager2.begin_transaction("session-2")
 
-            assert manifest1.session_id == 'session-1'
-            assert manifest2.session_id == 'session-2'
+            assert manifest1.session_id == "session-1"
+            assert manifest2.session_id == "session-2"
 
             # Both should be able to commit
             manager1.commit_transaction(manifest1)
             manager2.commit_transaction(manifest2)
 
-            assert manifest1.status == 'committed'
-            assert manifest2.status == 'committed'
+            assert manifest1.status == "committed"
+            assert manifest2.status == "committed"
 
 
 class TestDataIntegrity:
@@ -307,23 +317,25 @@ class TestDataIntegrity:
 
             manager = TransactionManager(base_path=base_path, use_git=False)
 
-            filepath = base_path / 'file.py'
-            filepath.write_text('original\n')
+            filepath = base_path / "file.py"
+            filepath.write_text("original\n")
 
-            manifest = manager.begin_transaction('test-session')
-            backup = str(filepath) + '.bak'
-            Path(backup).write_text('original\n')
-            filepath.write_text('modified\n')
-            manager.record_write(manifest, str(filepath), backup, 'foo', 'function', 'python')
+            manifest = manager.begin_transaction("test-session")
+            backup = str(filepath) + ".bak"
+            Path(backup).write_text("original\n")
+            filepath.write_text("modified\n")
+            manager.record_write(
+                manifest, str(filepath), backup, "foo", "function", "python"
+            )
 
             # Check all fields are present
-            assert manifest.session_id == 'test-session'
-            assert manifest.status == 'in_progress'
+            assert manifest.session_id == "test-session"
+            assert manifest.status == "in_progress"
             assert len(manifest.entries) == 1
             assert manifest.entries[0].filepath == str(filepath)
-            assert manifest.entries[0].item_name == 'foo'
-            assert manifest.entries[0].item_type == 'function'
-            assert manifest.entries[0].language == 'python'
+            assert manifest.entries[0].item_name == "foo"
+            assert manifest.entries[0].item_type == "function"
+            assert manifest.entries[0].language == "python"
 
     def test_entry_timestamps_are_valid(self):
         """Test that entry timestamps are valid ISO format."""
@@ -332,15 +344,17 @@ class TestDataIntegrity:
 
             manager = TransactionManager(base_path=base_path, use_git=False)
 
-            filepath = base_path / 'file.py'
-            filepath.write_text('original\n')
+            filepath = base_path / "file.py"
+            filepath.write_text("original\n")
 
-            manifest = manager.begin_transaction('test-session')
-            backup = str(filepath) + '.bak'
-            Path(backup).write_text('original\n')
-            manager.record_write(manifest, str(filepath), backup, 'foo', 'function', 'python')
+            manifest = manager.begin_transaction("test-session")
+            backup = str(filepath) + ".bak"
+            Path(backup).write_text("original\n")
+            manager.record_write(
+                manifest, str(filepath), backup, "foo", "function", "python"
+            )
 
             # Check timestamp format
             entry = manifest.entries[0]
             assert entry.timestamp is not None
-            assert 'T' in entry.timestamp  # ISO format includes 'T'
+            assert "T" in entry.timestamp  # ISO format includes 'T'

--- a/analyzer/tests/test_improve_integration.py
+++ b/analyzer/tests/test_improve_integration.py
@@ -34,41 +34,51 @@ class TestImproveIntegration:
     """Integration tests for improve workflow with mocked Claude API."""
 
     def test_improve_clean_python_response(self):
-        """Test that clean Python docstrings are inserted correctly without markdown wrappers."""
+        """Test that clean Python docstrings are inserted correctly without
+
+        markdown wrappers."""
         # Mock ClaudeClient to return clean docstring content (no triple quotes)
-        with patch('src.claude.claude_client.ClaudeClient.generate_docstring') as mock_generate:
-            mock_generate.return_value = 'Calculate the sum of two numbers.'
+        with patch(
+            "src.claude.claude_client.ClaudeClient.generate_docstring"
+        ) as mock_generate:
+            mock_generate.return_value = "Calculate the sum of two numbers."
 
             # Create temporary Python file with undocumented function
-            with tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False) as f:
-                f.write('def add(a, b):\n    return a + b\n')
+            with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+                f.write("def add(a, b):\n    return a + b\n")
                 temp_path = f.name
 
             try:
                 # Use DocstringWriter to insert the docstring
-                writer = DocstringWriter(base_path='/')
+                writer = DocstringWriter(base_path="/")
                 success = writer.write_docstring(
                     filepath=temp_path,
-                    item_name='add',
-                    item_type='function',
-                    docstring='Calculate the sum of two numbers.',
-                    language='python',
-                    line_number=1
+                    item_name="add",
+                    item_type="function",
+                    docstring="Calculate the sum of two numbers.",
+                    language="python",
+                    line_number=1,
                 )
 
                 assert success, "DocstringWriter.write_docstring() returned False"
 
                 # Read the result
-                with open(temp_path, 'r') as f:
+                with open(temp_path, "r") as f:
                     result = f.read()
 
                 # Verify docstring is present and wrapped in triple quotes
                 assert '"""' in result, "Triple quotes not found in output"
-                assert 'Calculate the sum of two numbers.' in result, "Docstring content not found"
+                assert (
+                    "Calculate the sum of two numbers." in result
+                ), "Docstring content not found"
 
                 # Verify NO markdown code fences in output
-                assert '```python' not in result, "Found markdown code fence - prompt fix failed!"
-                assert '```' not in result or result.count('```') == 0, "Found backticks - possible markdown wrapper"
+                assert (
+                    "```python" not in result
+                ), "Found markdown code fence - prompt fix failed!"
+                assert (
+                    "```" not in result or result.count("```") == 0
+                ), "Found backticks - possible markdown wrapper"
 
                 # Verify file is syntactically valid
                 py_compile.compile(temp_path, doraise=True)
@@ -76,142 +86,177 @@ class TestImproveIntegration:
             finally:
                 # Clean up
                 Path(temp_path).unlink(missing_ok=True)
-                Path(temp_path + '.bak').unlink(missing_ok=True)
+                Path(temp_path + ".bak").unlink(missing_ok=True)
 
     def test_improve_clean_javascript_response(self):
-        """Test that clean JSDoc comments are inserted correctly without markdown wrappers."""
-        with patch('src.claude.claude_client.ClaudeClient.generate_docstring') as mock_generate:
+        """Test that clean JSDoc comments are inserted correctly without
+        markdown wrappers."""
+        with patch(
+            "src.claude.claude_client.ClaudeClient.generate_docstring"
+        ) as mock_generate:
             # Mock returns JSDoc content (already has /** */)
-            mock_generate.return_value = '/**\n * Add two numbers.\n * @param {number} a - First number\n * @param {number} b - Second number\n * @returns {number} Sum of a and b\n */'
+            mock_generate.return_value = (
+                "/**\n * Add two numbers.\n * @param {number} a - First number\n"
+                " * @param {number} b - Second number\n"
+                " * @returns {number} Sum of a and b\n */"
+            )
 
             # Create temporary JavaScript file
-            with tempfile.NamedTemporaryFile(mode='w', suffix='.js', delete=False) as f:
-                f.write('function add(a, b) {\n  return a + b;\n}\n')
+            with tempfile.NamedTemporaryFile(mode="w", suffix=".js", delete=False) as f:
+                f.write("function add(a, b) {\n  return a + b;\n}\n")
                 temp_path = f.name
 
             try:
-                writer = DocstringWriter(base_path='/')
+                writer = DocstringWriter(base_path="/")
                 success = writer.write_docstring(
                     filepath=temp_path,
-                    item_name='add',
-                    item_type='function',
-                    docstring='/**\n * Add two numbers.\n * @param {number} a - First number\n * @param {number} b - Second number\n * @returns {number} Sum of a and b\n */',
-                    language='javascript',
-                    line_number=1
+                    item_name="add",
+                    item_type="function",
+                    docstring=(
+                        "/**\n * Add two numbers.\n"
+                        " * @param {number} a - First number\n"
+                        " * @param {number} b - Second number\n"
+                        " * @returns {number} Sum of a and b\n */"
+                    ),
+                    language="javascript",
+                    line_number=1,
                 )
 
                 assert success, "DocstringWriter.write_docstring() returned False"
 
                 # Read result
-                with open(temp_path, 'r') as f:
+                with open(temp_path, "r") as f:
                     result = f.read()
 
                 # Verify JSDoc is present
-                assert '/**' in result, "JSDoc opening not found"
-                assert 'Add two numbers' in result, "JSDoc content not found"
-                assert '@param' in result, "JSDoc @param tag not found"
-                assert '@returns' in result, "JSDoc @returns tag not found"
+                assert "/**" in result, "JSDoc opening not found"
+                assert "Add two numbers" in result, "JSDoc content not found"
+                assert "@param" in result, "JSDoc @param tag not found"
+                assert "@returns" in result, "JSDoc @returns tag not found"
 
                 # Verify NO markdown code fences
-                assert '```javascript' not in result, "Found markdown code fence - prompt fix failed!"
-                assert '```js' not in result, "Found markdown code fence - prompt fix failed!"
+                assert (
+                    "```javascript" not in result
+                ), "Found markdown code fence - prompt fix failed!"
+                assert (
+                    "```js" not in result
+                ), "Found markdown code fence - prompt fix failed!"
 
             finally:
                 Path(temp_path).unlink(missing_ok=True)
-                Path(temp_path + '.bak').unlink(missing_ok=True)
+                Path(temp_path + ".bak").unlink(missing_ok=True)
 
     def test_improve_clean_typescript_response(self):
-        """Test that clean TSDoc comments are inserted correctly without markdown wrappers."""
-        with patch('src.claude.claude_client.ClaudeClient.generate_docstring') as mock_generate:
-            mock_generate.return_value = '/**\n * Add two numbers.\n * @param a - First number\n * @param b - Second number\n * @returns Sum of a and b\n */'
+        """Test that clean TSDoc comments are inserted correctly without
+        markdown wrappers."""
+        with patch(
+            "src.claude.claude_client.ClaudeClient.generate_docstring"
+        ) as mock_generate:
+            mock_generate.return_value = (
+                "/**\n * Add two numbers.\n * @param a - First number\n"
+                " * @param b - Second number\n * @returns Sum of a and b\n */"
+            )
 
             # Create temporary TypeScript file
-            with tempfile.NamedTemporaryFile(mode='w', suffix='.ts', delete=False) as f:
-                f.write('function add(a: number, b: number): number {\n  return a + b;\n}\n')
+            with tempfile.NamedTemporaryFile(mode="w", suffix=".ts", delete=False) as f:
+                f.write(
+                    "function add(a: number, b: number): number {\n  return a + b;\n}\n"
+                )
                 temp_path = f.name
 
             try:
-                writer = DocstringWriter(base_path='/')
+                writer = DocstringWriter(base_path="/")
                 success = writer.write_docstring(
                     filepath=temp_path,
-                    item_name='add',
-                    item_type='function',
-                    docstring='/**\n * Add two numbers.\n * @param a - First number\n * @param b - Second number\n * @returns Sum of a and b\n */',
-                    language='typescript',
-                    line_number=1
+                    item_name="add",
+                    item_type="function",
+                    docstring=(
+                        "/**\n * Add two numbers.\n * @param a - First number\n"
+                        " * @param b - Second number\n"
+                        " * @returns Sum of a and b\n */"
+                    ),
+                    language="typescript",
+                    line_number=1,
                 )
 
                 assert success, "DocstringWriter.write_docstring() returned False"
 
                 # Read result
-                with open(temp_path, 'r') as f:
+                with open(temp_path, "r") as f:
                     result = f.read()
 
                 # Verify TSDoc is present
-                assert '/**' in result, "TSDoc opening not found"
-                assert 'Add two numbers' in result, "TSDoc content not found"
+                assert "/**" in result, "TSDoc opening not found"
+                assert "Add two numbers" in result, "TSDoc content not found"
 
                 # Verify NO markdown code fences
-                assert '```typescript' not in result, "Found markdown code fence - prompt fix failed!"
-                assert '```ts' not in result, "Found markdown code fence - prompt fix failed!"
+                assert (
+                    "```typescript" not in result
+                ), "Found markdown code fence - prompt fix failed!"
+                assert (
+                    "```ts" not in result
+                ), "Found markdown code fence - prompt fix failed!"
 
             finally:
                 Path(temp_path).unlink(missing_ok=True)
-                Path(temp_path + '.bak').unlink(missing_ok=True)
+                Path(temp_path + ".bak").unlink(missing_ok=True)
 
     def test_improve_preserves_code_examples_in_docstring(self):
         """Test that code examples WITHIN docstrings are preserved correctly."""
-        with patch('src.claude.claude_client.ClaudeClient.generate_docstring') as mock_generate:
+        with patch(
+            "src.claude.claude_client.ClaudeClient.generate_docstring"
+        ) as mock_generate:
             # Mock response with embedded code example (Python doctest)
-            mock_generate.return_value = '''Calculate sum of two numbers.
+            mock_generate.return_value = """Calculate sum of two numbers.
 
 Examples:
     >>> add(1, 2)
     3
     >>> add(-1, 1)
     0
-'''
+"""
 
             # Create temporary Python file
-            with tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False) as f:
-                f.write('def add(a, b):\n    return a + b\n')
+            with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+                f.write("def add(a, b):\n    return a + b\n")
                 temp_path = f.name
 
             try:
-                writer = DocstringWriter(base_path='/')
+                writer = DocstringWriter(base_path="/")
                 success = writer.write_docstring(
                     filepath=temp_path,
-                    item_name='add',
-                    item_type='function',
+                    item_name="add",
+                    item_type="function",
                     docstring=mock_generate.return_value,
-                    language='python',
-                    line_number=1
+                    language="python",
+                    line_number=1,
                 )
 
                 assert success, "DocstringWriter.write_docstring() returned False"
 
                 # Read result
-                with open(temp_path, 'r') as f:
+                with open(temp_path, "r") as f:
                     result = f.read()
 
                 # Verify docstring with examples is present
-                assert '>>>' in result, "Doctest example not found"
-                assert 'add(1, 2)' in result, "Example code not found"
-                assert 'Examples:' in result, "Examples section not found"
+                assert ">>>" in result, "Doctest example not found"
+                assert "add(1, 2)" in result, "Example code not found"
+                assert "Examples:" in result, "Examples section not found"
 
                 # Verify the ENTIRE response isn't wrapped in markdown
                 # (internal examples are fine, outer wrapper is not)
-                lines = result.split('\n')
+                lines = result.split("\n")
                 # Should not start with ```python
-                assert not any(line.strip().startswith('```python') for line in lines), \
-                    "Found markdown wrapper around entire docstring"
+                assert not any(
+                    line.strip().startswith("```python") for line in lines
+                ), "Found markdown wrapper around entire docstring"
 
                 # Verify file is syntactically valid
                 py_compile.compile(temp_path, doraise=True)
 
             finally:
                 Path(temp_path).unlink(missing_ok=True)
-                Path(temp_path + '.bak').unlink(missing_ok=True)
+                Path(temp_path + ".bak").unlink(missing_ok=True)
 
     def test_improve_markdown_wrapped_response(self):
         """Test handling of markdown-wrapped responses with defensive parser.
@@ -222,36 +267,39 @@ Examples:
 
         This provides defense-in-depth protection against the original bug (#231).
         """
-        with patch('src.claude.claude_client.ClaudeClient.generate_docstring') as mock_generate:
+        with patch(
+            "src.claude.claude_client.ClaudeClient.generate_docstring"
+        ) as mock_generate:
             # Mock returns markdown-wrapped response (the bug we fixed with prompts)
-            mock_generate.return_value = '```python\nCalculate sum.\n```'
+            mock_generate.return_value = "```python\nCalculate sum.\n```"
 
             # Create temporary Python file
-            with tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False) as f:
-                f.write('def add(a, b):\n    return a + b\n')
+            with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+                f.write("def add(a, b):\n    return a + b\n")
                 temp_path = f.name
 
             try:
-                writer = DocstringWriter(base_path='/')
+                writer = DocstringWriter(base_path="/")
                 success = writer.write_docstring(
                     filepath=temp_path,
-                    item_name='add',
-                    item_type='function',
+                    item_name="add",
+                    item_type="function",
                     docstring=mock_generate.return_value,
-                    language='python',
-                    line_number=1
+                    language="python",
+                    line_number=1,
                 )
 
                 assert success, "DocstringWriter.write_docstring() returned False"
 
                 # Read result
-                with open(temp_path, 'r') as f:
+                with open(temp_path, "r") as f:
                     result = f.read()
 
-                # WITHOUT defensive parser, this will fail (markdown gets inserted literally)
-                # WITH defensive parser (Issue #233), it should strip the wrapper first
-                assert '```python' not in result, "Markdown wrapper not stripped"
-                assert 'Calculate sum.' in result, "Docstring content missing"
+                # WITHOUT defensive parser, this will fail (markdown gets
+                # inserted literally). WITH defensive parser (Issue #233), it
+                # should strip the wrapper first
+                assert "```python" not in result, "Markdown wrapper not stripped"
+                assert "Calculate sum." in result, "Docstring content missing"
 
                 # Verify file is syntactically valid
                 # (This will fail if markdown wrapper is present)
@@ -259,7 +307,7 @@ Examples:
 
             finally:
                 Path(temp_path).unlink(missing_ok=True)
-                Path(temp_path + '.bak').unlink(missing_ok=True)
+                Path(temp_path + ".bak").unlink(missing_ok=True)
 
     def test_improve_preserves_code_examples_in_jsdoc(self):
         """Test that code examples with markdown fences WITHIN JSDoc are preserved.
@@ -267,9 +315,11 @@ Examples:
         JSDoc commonly includes code examples using markdown code fences within
         @example tags. These should be preserved while preventing outer wrappers.
         """
-        with patch('src.claude.claude_client.ClaudeClient.generate_docstring') as mock_generate:
+        with patch(
+            "src.claude.claude_client.ClaudeClient.generate_docstring"
+        ) as mock_generate:
             # Mock response with embedded markdown fence in @example
-            mock_generate.return_value = '''/**
+            mock_generate.return_value = """/**
  * Format a number as currency.
  * @param {number} amount - Amount to format
  * @returns {string} Formatted currency
@@ -278,41 +328,55 @@ Examples:
  * formatCurrency(42.5);  // Returns "$42.50"
  * formatCurrency(100);   // Returns "$100.00"
  * ```
- */'''
+ */"""
 
             # Create temporary JavaScript file
-            with tempfile.NamedTemporaryFile(mode='w', suffix='.js', delete=False) as f:
-                f.write('function formatCurrency(amount) {\n  return `$${amount.toFixed(2)}`;\n}\n')
+            with tempfile.NamedTemporaryFile(
+                mode="w", suffix=".js", delete=False
+            ) as f:
+                f.write(
+                    "function formatCurrency(amount) {\n"
+                    "  return `$${amount.toFixed(2)}`;\n}\n"
+                )
                 temp_path = f.name
 
             try:
-                writer = DocstringWriter(base_path='/')
+                writer = DocstringWriter(base_path="/")
                 success = writer.write_docstring(
                     filepath=temp_path,
-                    item_name='formatCurrency',
-                    item_type='function',
+                    item_name="formatCurrency",
+                    item_type="function",
                     docstring=mock_generate.return_value,
-                    language='javascript',
-                    line_number=1
+                    language="javascript",
+                    line_number=1,
                 )
 
                 assert success, "DocstringWriter.write_docstring() returned False"
 
                 # Read result
-                with open(temp_path, 'r') as f:
+                with open(temp_path, "r") as f:
                     result = f.read()
 
                 # Verify JSDoc with example is present
-                assert '@example' in result, "@example tag not found"
-                assert 'formatCurrency(42.5)' in result, "Example code not found"
+                assert "@example" in result, "@example tag not found"
+                assert "formatCurrency(42.5)" in result, "Example code not found"
 
                 # Verify markdown fence is INSIDE the JSDoc, not wrapping it
                 # Pattern should be: /** ... @example ... ```javascript ... ``` ... */
                 # NOT: ```javascript /** ... */ ```
-                lines = result.split('\n')
-                jsdoc_start = next((i for i, line in enumerate(lines) if '/**' in line), None)
-                jsdoc_end = next((i for i, line in enumerate(lines) if '*/' in line and i > (jsdoc_start or 0)), None)
-                code_fence_lines = [i for i, line in enumerate(lines) if '```' in line]
+                lines = result.split("\n")
+                jsdoc_start = next(
+                    (i for i, line in enumerate(lines) if "/**" in line), None
+                )
+                jsdoc_end = next(
+                    (
+                        i
+                        for i, line in enumerate(lines)
+                        if "*/" in line and i > (jsdoc_start or 0)
+                    ),
+                    None,
+                )
+                code_fence_lines = [i for i, line in enumerate(lines) if "```" in line]
 
                 assert jsdoc_start is not None, "JSDoc start not found"
                 assert jsdoc_end is not None, "JSDoc end not found"
@@ -320,12 +384,14 @@ Examples:
 
                 # All code fences should be INSIDE the JSDoc comment
                 for fence_line in code_fence_lines:
-                    assert jsdoc_start < fence_line < jsdoc_end, \
-                        f"Code fence at line {fence_line} should be INSIDE JSDoc (lines {jsdoc_start}-{jsdoc_end})"
+                    assert jsdoc_start < fence_line < jsdoc_end, (
+                        f"Code fence at line {fence_line} should be INSIDE JSDoc "
+                        f"(lines {jsdoc_start}-{jsdoc_end})"
+                    )
 
             finally:
                 Path(temp_path).unlink(missing_ok=True)
-                Path(temp_path + '.bak').unlink(missing_ok=True)
+                Path(temp_path + ".bak").unlink(missing_ok=True)
 
     def test_improve_all_languages_comprehensive(self):
         """Comprehensive test of all three languages in a single test scenario.
@@ -338,19 +404,24 @@ Examples:
             temp_path = Path(temp_dir)
 
             # Create test files for all three languages
-            python_file = temp_path / 'test.py'
-            js_file = temp_path / 'test.js'
-            ts_file = temp_path / 'test.ts'
+            python_file = temp_path / "test.py"
+            js_file = temp_path / "test.js"
+            ts_file = temp_path / "test.ts"
 
-            python_file.write_text('def multiply(a, b):\n    return a * b\n')
-            js_file.write_text('export function divide(a, b) {\n  return a / b;\n}\n')
-            ts_file.write_text('export function power(base: number, exp: number): number {\n  return Math.pow(base, exp);\n}\n')
+            python_file.write_text("def multiply(a, b):\n    return a * b\n")
+            js_file.write_text(
+                "export function divide(a, b) {\n  return a / b;\n}\n"
+            )
+            ts_file.write_text(
+                "export function power(base: number, exp: number): number {\n"
+                "  return Math.pow(base, exp);\n}\n"
+            )
 
             # Create writer
-            writer = DocstringWriter(base_path='/')
+            writer = DocstringWriter(base_path="/")
 
             # Test Python
-            python_docstring = '''Multiply two numbers.
+            python_docstring = """Multiply two numbers.
 
 Parameters
 ----------
@@ -362,49 +433,49 @@ b : int or float
 Returns
 -------
 int or float
-    Product of a and b'''
+    Product of a and b"""
 
             python_success = writer.write_docstring(
                 filepath=str(python_file),
-                item_name='multiply',
-                item_type='function',
+                item_name="multiply",
+                item_type="function",
                 docstring=python_docstring,
-                language='python',
-                line_number=1
+                language="python",
+                line_number=1,
             )
 
             # Test JavaScript
-            js_docstring = '''/**
+            js_docstring = """/**
  * Divide two numbers.
  * @param {number} a - Dividend
  * @param {number} b - Divisor
  * @returns {number} Quotient
- */'''
+ */"""
 
             js_success = writer.write_docstring(
                 filepath=str(js_file),
-                item_name='divide',
-                item_type='function',
+                item_name="divide",
+                item_type="function",
                 docstring=js_docstring,
-                language='javascript',
-                line_number=1
+                language="javascript",
+                line_number=1,
             )
 
             # Test TypeScript
-            ts_docstring = '''/**
+            ts_docstring = """/**
  * Calculate base raised to exponent.
  * @param base - Base number
  * @param exp - Exponent
  * @returns Result of base^exp
- */'''
+ */"""
 
             ts_success = writer.write_docstring(
                 filepath=str(ts_file),
-                item_name='power',
-                item_type='function',
+                item_name="power",
+                item_type="function",
                 docstring=ts_docstring,
-                language='typescript',
-                line_number=1
+                language="typescript",
+                line_number=1,
             )
 
             # Verify all writes succeeded
@@ -418,59 +489,70 @@ int or float
             ts_result = ts_file.read_text()
 
             # Verify Python
-            assert 'Multiply two numbers' in python_result
-            assert '```python' not in python_result, "Python has markdown fence!"
-            assert '```' not in python_result, "Python has backticks!"
+            assert "Multiply two numbers" in python_result
+            assert "```python" not in python_result, "Python has markdown fence!"
+            assert "```" not in python_result, "Python has backticks!"
             py_compile.compile(str(python_file), doraise=True)
 
             # Verify JavaScript
-            assert 'Divide two numbers' in js_result
-            assert '@param' in js_result
-            assert '```javascript' not in js_result, "JavaScript has markdown fence!"
-            assert '```js' not in js_result, "JavaScript has markdown fence!"
+            assert "Divide two numbers" in js_result
+            assert "@param" in js_result
+            assert "```javascript" not in js_result, "JavaScript has markdown fence!"
+            assert "```js" not in js_result, "JavaScript has markdown fence!"
 
             # Verify TypeScript
-            assert 'Calculate base raised to exponent' in ts_result
-            assert '@param' in ts_result
-            assert '```typescript' not in ts_result, "TypeScript has markdown fence!"
-            assert '```ts' not in ts_result, "TypeScript has markdown fence!"
+            assert "Calculate base raised to exponent" in ts_result
+            assert "@param" in ts_result
+            assert "```typescript" not in ts_result, "TypeScript has markdown fence!"
+            assert "```ts" not in ts_result, "TypeScript has markdown fence!"
 
     def test_prompt_builder_contains_markdown_prevention_instructions(self):
-        """Verify PromptBuilder includes instructions to prevent markdown wrappers.
+        """Verify PromptBuilder includes instructions to prevent markdown
+        wrappers.
 
         This test verifies that the fix (Option A from #232) is present in the
         generated prompts by checking that the prompt text explicitly instructs
         Claude NOT to wrap responses in markdown code fences.
         """
         # Create PromptBuilder
-        builder = PromptBuilder(style_guide='google', tone='concise')
+        builder = PromptBuilder(style_guide="google", tone="concise")
 
         # Sample code and context
-        code = 'def sample_function(x, y):\n    if x > 0:\n        return x + y\n    return 0'
-        context = 'class Calculator:\n    pass\n\n' + code
+        code = (
+            "def sample_function(x, y):\n    if x > 0:\n"
+            "        return x + y\n    return 0"
+        )
+        context = "class Calculator:\n    pass\n\n" + code
 
         # Build prompt using correct method signature
         prompt = builder.build_prompt(
             code=code,
-            item_name='sample_function',
-            item_type='function',
-            language='python',
-            context=context
+            item_name="sample_function",
+            item_type="function",
+            language="python",
+            context=context,
         )
 
         # Verify markdown prevention instructions are present
-        # These are the specific lines added in the fix (lines 277-280 of prompt_builder.py)
-        assert 'Do NOT wrap your entire response in markdown code fences' in prompt, \
-            "Prompt missing instruction to NOT use markdown wrappers"
+        # These are the specific lines added in the fix (lines 277-280 of
+        # prompt_builder.py)
+        assert (
+            "Do NOT wrap your entire response in markdown code fences" in prompt
+        ), "Prompt missing instruction to NOT use markdown wrappers"
 
-        assert 'Code examples WITHIN the docstring are fine and encouraged' in prompt, \
-            "Prompt missing clarification about internal code examples"
+        assert (
+            "Code examples WITHIN the docstring are fine and encouraged" in prompt
+        ), "Prompt missing clarification about internal code examples"
 
         # Verify it mentions backticks/code fences explicitly
-        assert '```python' in prompt or '```javascript' in prompt or 'backticks' in prompt.lower(), \
-            "Prompt should mention code fences/backticks as examples"
+        assert (
+            "```python" in prompt
+            or "```javascript" in prompt
+            or "backticks" in prompt.lower()
+        ), "Prompt should mention code fences/backticks as examples"
 
         # Verify Python-specific instruction (line 288)
-        assert 'do NOT include the triple-quote delimiters' in prompt.lower() or \
-               'will be added automatically' in prompt.lower(), \
-            "Prompt should mention that triple-quote delimiters are added automatically"
+        assert (
+            "do NOT include the triple-quote delimiters" in prompt.lower()
+            or "will be added automatically" in prompt.lower()
+        ), "Prompt should mention that triple-quote delimiters are added automatically"

--- a/analyzer/tests/test_individual_rollback.py
+++ b/analyzer/tests/test_individual_rollback.py
@@ -16,30 +16,30 @@ class TestListSessionChanges:
         """Test listing all changes in a session with multiple commits."""
         with tempfile.TemporaryDirectory() as tmpdir:
             manager = TransactionManager(base_path=Path(tmpdir))
-            manifest = manager.begin_transaction('test-session')
+            manifest = manager.begin_transaction("test-session")
 
             # Create and commit 5 changes
             for i in range(5):
-                test_file = Path(tmpdir) / f'file{i}.py'
-                test_file.write_text(f'def func{i}(): pass')
+                test_file = Path(tmpdir) / f"file{i}.py"
+                test_file.write_text(f"def func{i}(): pass")
 
                 manager.record_write(
                     manifest,
                     str(test_file),
-                    f'{test_file}.bak',
-                    f'func{i}',
-                    'function',
-                    'python'
+                    f"{test_file}.bak",
+                    f"func{i}",
+                    "function",
+                    "python",
                 )
 
             # List changes
-            changes = manager.list_session_changes('test-session')
+            changes = manager.list_session_changes("test-session")
 
             assert len(changes) == 5
             for i, change in enumerate(changes):
-                assert change.item_name == f'func{i}'
-                assert change.item_type == 'function'
-                assert change.language == 'python'
+                assert change.item_name == f"func{i}"
+                assert change.item_type == "function"
+                assert change.language == "python"
                 assert change.entry_id is not None
 
     def test_list_changes_empty_session(self):
@@ -50,8 +50,8 @@ class TestListSessionChanges:
             # Create session but don't add any commits
             # Git branch only exists after first commit, so this should raise
             try:
-                manager.begin_transaction('empty-session')
-                changes = manager.list_session_changes('empty-session')
+                manager.begin_transaction("empty-session")
+                changes = manager.list_session_changes("empty-session")
                 # If branch was created, should have 0 changes
                 assert len(changes) == 0
             except ValueError:
@@ -64,7 +64,7 @@ class TestListSessionChanges:
             manager = TransactionManager(base_path=Path(tmpdir))
 
             try:
-                manager.list_session_changes('nonexistent')
+                manager.list_session_changes("nonexistent")
                 assert False, "Should have raised ValueError"
             except ValueError as e:
                 assert "does not exist" in str(e)
@@ -77,29 +77,37 @@ class TestRollbackChange:
         """Test reverting a single change successfully."""
         with tempfile.TemporaryDirectory() as tmpdir:
             manager = TransactionManager(base_path=Path(tmpdir))
-            manifest = manager.begin_transaction('test-session')
+            manifest = manager.begin_transaction("test-session")
 
             # Create first file and commit
-            test_file1 = Path(tmpdir) / 'file1.py'
-            test_file1.write_text('def func1(): pass')
+            test_file1 = Path(tmpdir) / "file1.py"
+            test_file1.write_text("def func1(): pass")
 
             manager.record_write(
-                manifest, str(test_file1), f'{test_file1}.bak',
-                'func1', 'function', 'python'
+                manifest,
+                str(test_file1),
+                f"{test_file1}.bak",
+                "func1",
+                "function",
+                "python",
             )
 
             # Create second independent file and commit
             # This ensures we have something to revert to
-            test_file2 = Path(tmpdir) / 'file2.py'
-            test_file2.write_text('def func2(): pass')
+            test_file2 = Path(tmpdir) / "file2.py"
+            test_file2.write_text("def func2(): pass")
 
             manager.record_write(
-                manifest, str(test_file2), f'{test_file2}.bak',
-                'func2', 'function', 'python'
+                manifest,
+                str(test_file2),
+                f"{test_file2}.bak",
+                "func2",
+                "function",
+                "python",
             )
 
             # Get changes
-            changes = manager.list_session_changes('test-session')
+            changes = manager.list_session_changes("test-session")
             assert len(changes) == 2
 
             # Rollback the second change (should work cleanly)
@@ -111,33 +119,41 @@ class TestRollbackChange:
             assert result.restored_count == 1
             assert result.failed_count == 0
             assert len(result.conflicts) == 0
-            assert result.status == 'completed'
+            assert result.status == "completed"
 
     def test_rollback_change_with_conflict(self):
         """Test rollback when file has been modified (conflict scenario)."""
         with tempfile.TemporaryDirectory() as tmpdir:
             manager = TransactionManager(base_path=Path(tmpdir))
-            manifest = manager.begin_transaction('test-session')
+            manifest = manager.begin_transaction("test-session")
 
             # Create initial file
-            test_file = Path(tmpdir) / 'test.py'
-            test_file.write_text('def func(): pass')
+            test_file = Path(tmpdir) / "test.py"
+            test_file.write_text("def func(): pass")
 
             manager.record_write(
-                manifest, str(test_file), f'{test_file}.bak',
-                'func', 'function', 'python'
+                manifest,
+                str(test_file),
+                f"{test_file}.bak",
+                "func",
+                "function",
+                "python",
             )
 
             # Make another conflicting change
             test_file.write_text('def func():\n    """different docs"""\n    pass')
 
             manager.record_write(
-                manifest, str(test_file), f'{test_file}.bak',
-                'func', 'function', 'python'
+                manifest,
+                str(test_file),
+                f"{test_file}.bak",
+                "func",
+                "function",
+                "python",
             )
 
             # Try to revert the first change (will conflict with second)
-            changes = manager.list_session_changes('test-session')
+            changes = manager.list_session_changes("test-session")
             first_change_id = changes[0].entry_id
 
             result = manager.rollback_change(first_change_id)
@@ -154,20 +170,24 @@ class TestRollbackMultiple:
         """Test reverting multiple changes successfully."""
         with tempfile.TemporaryDirectory() as tmpdir:
             manager = TransactionManager(base_path=Path(tmpdir))
-            manifest = manager.begin_transaction('test-session')
+            manifest = manager.begin_transaction("test-session")
 
             # Create 3 independent changes
             for i in range(3):
-                test_file = Path(tmpdir) / f'file{i}.py'
-                test_file.write_text(f'def func{i}(): pass')
+                test_file = Path(tmpdir) / f"file{i}.py"
+                test_file.write_text(f"def func{i}(): pass")
 
                 manager.record_write(
-                    manifest, str(test_file), f'{test_file}.bak',
-                    f'func{i}', 'function', 'python'
+                    manifest,
+                    str(test_file),
+                    f"{test_file}.bak",
+                    f"func{i}",
+                    "function",
+                    "python",
                 )
 
             # Get all change IDs
-            changes = manager.list_session_changes('test-session')
+            changes = manager.list_session_changes("test-session")
             change_ids = [c.entry_id for c in changes]
 
             # Rollback all changes
@@ -176,32 +196,40 @@ class TestRollbackMultiple:
             assert result.success is True
             assert result.restored_count == 3
             assert result.failed_count == 0
-            assert result.status == 'completed'
+            assert result.status == "completed"
 
     def test_rollback_multiple_partial_success(self):
         """Test partial rollback when some changes succeed and others fail."""
         with tempfile.TemporaryDirectory() as tmpdir:
             manager = TransactionManager(base_path=Path(tmpdir))
-            manifest = manager.begin_transaction('test-session')
+            manifest = manager.begin_transaction("test-session")
 
             # Create 2 changes to same file (will conflict)
-            test_file = Path(tmpdir) / 'test.py'
-            test_file.write_text('v1')
+            test_file = Path(tmpdir) / "test.py"
+            test_file.write_text("v1")
 
             manager.record_write(
-                manifest, str(test_file), f'{test_file}.bak',
-                'func1', 'function', 'python'
+                manifest,
+                str(test_file),
+                f"{test_file}.bak",
+                "func1",
+                "function",
+                "python",
             )
 
-            test_file.write_text('v2')
+            test_file.write_text("v2")
 
             manager.record_write(
-                manifest, str(test_file), f'{test_file}.bak',
-                'func2', 'function', 'python'
+                manifest,
+                str(test_file),
+                f"{test_file}.bak",
+                "func2",
+                "function",
+                "python",
             )
 
             # Try to revert both (at least one should conflict)
-            changes = manager.list_session_changes('test-session')
+            changes = manager.list_session_changes("test-session")
             change_ids = [c.entry_id for c in changes]
 
             result = manager.rollback_multiple(change_ids)
@@ -217,26 +245,32 @@ class TestGetChangeDiff:
         """Test that get_change_diff returns diff output."""
         with tempfile.TemporaryDirectory() as tmpdir:
             manager = TransactionManager(base_path=Path(tmpdir))
-            manifest = manager.begin_transaction('test-session')
+            manifest = manager.begin_transaction("test-session")
 
             # Create a change
-            test_file = Path(tmpdir) / 'test.py'
-            test_file.write_text('def my_function():\n    """A docstring"""\n    pass\n')
+            test_file = Path(tmpdir) / "test.py"
+            test_file.write_text(
+                'def my_function():\n    """A docstring"""\n    pass\n'
+            )
 
             manager.record_write(
-                manifest, str(test_file), f'{test_file}.bak',
-                'my_function', 'function', 'python'
+                manifest,
+                str(test_file),
+                f"{test_file}.bak",
+                "my_function",
+                "function",
+                "python",
             )
 
             # Get change diff
-            changes = manager.list_session_changes('test-session')
+            changes = manager.list_session_changes("test-session")
             change_id = changes[0].entry_id
 
             diff = manager.get_change_diff(change_id)
 
             # Should contain file name and content
-            assert 'test.py' in diff
-            assert 'my_function' in diff or 'A docstring' in diff
+            assert "test.py" in diff
+            assert "my_function" in diff or "A docstring" in diff
 
 
 class TestConflictScenarios:
@@ -246,27 +280,35 @@ class TestConflictScenarios:
         """Test rollback when file has been modified since the change."""
         with tempfile.TemporaryDirectory() as tmpdir:
             manager = TransactionManager(base_path=Path(tmpdir))
-            manifest = manager.begin_transaction('test-session')
+            manifest = manager.begin_transaction("test-session")
 
             # Original change
-            test_file = Path(tmpdir) / 'test.py'
-            test_file.write_text('original content')
+            test_file = Path(tmpdir) / "test.py"
+            test_file.write_text("original content")
 
             manager.record_write(
-                manifest, str(test_file), f'{test_file}.bak',
-                'func', 'function', 'python'
+                manifest,
+                str(test_file),
+                f"{test_file}.bak",
+                "func",
+                "function",
+                "python",
             )
 
             # Subsequent modification (creates conflict scenario)
-            test_file.write_text('completely different content')
+            test_file.write_text("completely different content")
 
             manager.record_write(
-                manifest, str(test_file), f'{test_file}.bak',
-                'func2', 'function', 'python'
+                manifest,
+                str(test_file),
+                f"{test_file}.bak",
+                "func2",
+                "function",
+                "python",
             )
 
             # Try to rollback first change
-            changes = manager.list_session_changes('test-session')
+            changes = manager.list_session_changes("test-session")
             first_change = changes[0].entry_id
 
             result = manager.rollback_change(first_change)
@@ -278,22 +320,26 @@ class TestConflictScenarios:
         """Test rollback when file has been deleted since the change."""
         with tempfile.TemporaryDirectory() as tmpdir:
             manager = TransactionManager(base_path=Path(tmpdir))
-            manifest = manager.begin_transaction('test-session')
+            manifest = manager.begin_transaction("test-session")
 
             # Create and commit a change
-            test_file = Path(tmpdir) / 'test.py'
-            test_file.write_text('content')
+            test_file = Path(tmpdir) / "test.py"
+            test_file.write_text("content")
 
             manager.record_write(
-                manifest, str(test_file), f'{test_file}.bak',
-                'func', 'function', 'python'
+                manifest,
+                str(test_file),
+                f"{test_file}.bak",
+                "func",
+                "function",
+                "python",
             )
 
             # Delete the file (simulates deletion after commit)
             # Note: In real scenario, file would be deleted via git rm
             # For this test, we're just testing the rollback behavior
 
-            changes = manager.list_session_changes('test-session')
+            changes = manager.list_session_changes("test-session")
             change_id = changes[0].entry_id
 
             # Rollback should still work (git revert handles this)
@@ -314,14 +360,14 @@ class TestRollbackResult:
             restored_count=3,
             failed_count=0,
             conflicts=[],
-            status='completed'
+            status="completed",
         )
 
         assert result.success is True
         assert result.restored_count == 3
         assert result.failed_count == 0
         assert len(result.conflicts) == 0
-        assert result.status == 'completed'
+        assert result.status == "completed"
 
     def test_rollback_result_partial(self):
         """Test RollbackResult with partial rollback."""
@@ -329,15 +375,15 @@ class TestRollbackResult:
             success=False,
             restored_count=2,
             failed_count=1,
-            conflicts=['file.py'],
-            status='partial_rollback'
+            conflicts=["file.py"],
+            status="partial_rollback",
         )
 
         assert result.success is False
         assert result.restored_count == 2
         assert result.failed_count == 1
         assert len(result.conflicts) == 1
-        assert result.status == 'partial_rollback'
+        assert result.status == "partial_rollback"
 
     def test_rollback_result_failed(self):
         """Test RollbackResult with complete failure."""
@@ -345,12 +391,12 @@ class TestRollbackResult:
             success=False,
             restored_count=0,
             failed_count=3,
-            conflicts=['file1.py', 'file2.py'],
-            status='failed'
+            conflicts=["file1.py", "file2.py"],
+            status="failed",
         )
 
         assert result.success is False
         assert result.restored_count == 0
         assert result.failed_count == 3
         assert len(result.conflicts) == 2
-        assert result.status == 'failed'
+        assert result.status == "failed"

--- a/analyzer/tests/test_javascript_integration.py
+++ b/analyzer/tests/test_javascript_integration.py
@@ -24,20 +24,20 @@ class TestJavaScriptIntegration:
         """Create a DocumentationAnalyzer with JavaScript support."""
         return DocumentationAnalyzer(
             parsers={
-                'javascript': TypeScriptParser(),
-                'typescript': TypeScriptParser(),
+                "javascript": TypeScriptParser(),
+                "typescript": TypeScriptParser(),
             },
-            scorer=ImpactScorer()
+            scorer=ImpactScorer(),
         )
 
     @pytest.fixture
     def examples_dir(self):
         """Return path to examples directory."""
-        return Path(__file__).parent.parent.parent / 'examples'
+        return Path(__file__).parent.parent.parent / "examples"
 
     def test_analyze_javascript_patterns_file(self, analyzer, examples_dir):
         """Test analyzing the JavaScript patterns example file."""
-        js_file = examples_dir / 'test_javascript_patterns.js'
+        js_file = examples_dir / "test_javascript_patterns.js"
 
         # Skip if file doesn't exist
         if not js_file.exists():
@@ -46,30 +46,34 @@ class TestJavaScriptIntegration:
         result = analyzer.analyze(str(examples_dir))
 
         # Filter to just JavaScript items
-        js_items = [item for item in result.items if item.language == 'javascript']
+        js_items = [item for item in result.items if item.language == "javascript"]
 
         # Should find multiple JavaScript items
         assert len(js_items) > 0, "No JavaScript items found"
 
         # Verify ESM detection
-        assert any(item.module_system == 'esm' for item in js_items), \
-            "ESM module system not detected"
+        assert any(
+            item.module_system == "esm" for item in js_items
+        ), "ESM module system not detected"
 
         # Verify named exports
-        assert any(item.export_type == 'named' for item in js_items), \
-            "Named exports not detected"
+        assert any(
+            item.export_type == "named" for item in js_items
+        ), "Named exports not detected"
 
         # Verify complexity calculation
-        assert all(item.complexity >= 1 for item in js_items), \
-            "Invalid complexity scores"
+        assert all(
+            item.complexity >= 1 for item in js_items
+        ), "Invalid complexity scores"
 
         # Verify impact scores are calculated
-        assert all(item.impact_score > 0 for item in js_items), \
-            "Impact scores not calculated"
+        assert all(
+            item.impact_score > 0 for item in js_items
+        ), "Impact scores not calculated"
 
     def test_analyze_commonjs_file(self, analyzer, examples_dir):
         """Test analyzing CommonJS file."""
-        cjs_file = examples_dir / 'test_commonjs.cjs'
+        cjs_file = examples_dir / "test_commonjs.cjs"
 
         # Skip if file doesn't exist
         if not cjs_file.exists():
@@ -79,30 +83,33 @@ class TestJavaScriptIntegration:
 
         # Filter to just JavaScript items from .cjs file
         cjs_items = [
-            item for item in result.items
-            if item.language == 'javascript' and item.filepath.endswith('.cjs')
+            item
+            for item in result.items
+            if item.language == "javascript" and item.filepath.endswith(".cjs")
         ]
 
         # Should find CommonJS items
         assert len(cjs_items) > 0, "No CommonJS items found"
 
         # Verify CommonJS detection
-        assert all(item.module_system == 'commonjs' for item in cjs_items), \
-            "CommonJS module system not detected"
+        assert all(
+            item.module_system == "commonjs" for item in cjs_items
+        ), "CommonJS module system not detected"
 
         # Verify CommonJS exports
-        assert any(item.export_type == 'commonjs' for item in cjs_items), \
-            "CommonJS exports not detected"
+        assert any(
+            item.export_type == "commonjs" for item in cjs_items
+        ), "CommonJS exports not detected"
 
     def test_javascript_coverage_calculation(self, analyzer, examples_dir):
         """Test that coverage is calculated correctly for JavaScript."""
         result = analyzer.analyze(str(examples_dir))
 
         # Should have language breakdown
-        assert 'by_language' in result.__dict__ or hasattr(result, 'by_language')
+        assert "by_language" in result.__dict__ or hasattr(result, "by_language")
 
         # Filter JavaScript items
-        js_items = [item for item in result.items if item.language == 'javascript']
+        js_items = [item for item in result.items if item.language == "javascript"]
 
         if len(js_items) > 0:
             # Count documented vs undocumented
@@ -117,7 +124,7 @@ class TestJavaScriptIntegration:
 
     def test_jsdoc_detection(self, analyzer, examples_dir):
         """Test that JSDoc comments are detected correctly."""
-        js_file = examples_dir / 'test_javascript_patterns.js'
+        js_file = examples_dir / "test_javascript_patterns.js"
 
         # Skip if file doesn't exist
         if not js_file.exists():
@@ -126,8 +133,9 @@ class TestJavaScriptIntegration:
         result = analyzer.analyze(str(examples_dir))
 
         js_items = [
-            item for item in result.items
-            if item.language == 'javascript' and 'patterns' in item.filepath
+            item
+            for item in result.items
+            if item.language == "javascript" and "patterns" in item.filepath
         ]
 
         # At least some JavaScript items should have documentation
@@ -136,19 +144,22 @@ class TestJavaScriptIntegration:
 
         # Check that docstrings are extracted
         for item in documented_items:
-            assert item.docstring is not None, \
-                f"Documented item {item.name} has no docstring"
+            assert (
+                item.docstring is not None
+            ), f"Documented item {item.name} has no docstring"
 
     @pytest.mark.integration
     def test_mixed_language_project(self, examples_dir):
         """Test analyzing a project with multiple languages."""
         analyzer = DocumentationAnalyzer(
             parsers={
-                'python': __import__('src.parsers.python_parser', fromlist=['PythonParser']).PythonParser(),
-                'javascript': TypeScriptParser(),
-                'typescript': TypeScriptParser(),
+                "python": __import__(
+                    "src.parsers.python_parser", fromlist=["PythonParser"]
+                ).PythonParser(),
+                "javascript": TypeScriptParser(),
+                "typescript": TypeScriptParser(),
             },
-            scorer=ImpactScorer()
+            scorer=ImpactScorer(),
         )
 
         result = analyzer.analyze(str(examples_dir))
@@ -157,18 +168,21 @@ class TestJavaScriptIntegration:
         languages = set(item.language for item in result.items)
 
         # Should have at least Python and JavaScript (or TypeScript)
-        assert 'python' in languages, "No Python items found"
-        assert 'javascript' in languages or 'typescript' in languages, \
-            "No JavaScript/TypeScript items found"
+        assert "python" in languages, "No Python items found"
+        assert (
+            "javascript" in languages or "typescript" in languages
+        ), "No JavaScript/TypeScript items found"
 
         # Verify by_language breakdown exists
-        if hasattr(result, 'by_language'):
-            assert 'python' in result.by_language
-            assert 'javascript' in result.by_language or 'typescript' in result.by_language
+        if hasattr(result, "by_language"):
+            assert "python" in result.by_language
+            assert (
+                "javascript" in result.by_language or "typescript" in result.by_language
+            )
 
     def test_javascript_function_metadata(self, analyzer, examples_dir):
         """Test that JavaScript function metadata is extracted correctly."""
-        js_file = examples_dir / 'test_javascript_patterns.js'
+        js_file = examples_dir / "test_javascript_patterns.js"
 
         # Skip if file doesn't exist
         if not js_file.exists():
@@ -177,22 +191,23 @@ class TestJavaScriptIntegration:
         result = analyzer.analyze(str(examples_dir))
 
         js_items = [
-            item for item in result.items
-            if item.language == 'javascript' and 'patterns' in item.filepath
+            item
+            for item in result.items
+            if item.language == "javascript" and "patterns" in item.filepath
         ]
 
         # Check that functions have names and types
-        functions = [item for item in js_items if item.type == 'function']
+        functions = [item for item in js_items if item.type == "function"]
         assert len(functions) > 0, "No JavaScript functions found"
 
         for func in functions:
             assert func.name, "Function has no name"
-            assert func.type == 'function'
+            assert func.type == "function"
             assert func.line_number > 0
 
     def test_javascript_class_detection(self, analyzer, examples_dir):
         """Test that JavaScript classes are detected."""
-        js_file = examples_dir / 'test_javascript_patterns.js'
+        js_file = examples_dir / "test_javascript_patterns.js"
 
         # Skip if file doesn't exist
         if not js_file.exists():
@@ -201,22 +216,23 @@ class TestJavaScriptIntegration:
         result = analyzer.analyze(str(examples_dir))
 
         js_items = [
-            item for item in result.items
-            if item.language == 'javascript' and 'patterns' in item.filepath
+            item
+            for item in result.items
+            if item.language == "javascript" and "patterns" in item.filepath
         ]
 
         # Check for classes
-        classes = [item for item in js_items if item.type == 'class']
+        classes = [item for item in js_items if item.type == "class"]
 
         # If classes exist in the example, verify they're detected
         if len(classes) > 0:
             for cls in classes:
                 assert cls.name, "Class has no name"
-                assert cls.type == 'class'
+                assert cls.type == "class"
 
     def test_arrow_function_detection(self, analyzer, examples_dir):
         """Test that arrow functions are detected."""
-        js_file = examples_dir / 'test_javascript_patterns.js'
+        js_file = examples_dir / "test_javascript_patterns.js"
 
         # Skip if file doesn't exist
         if not js_file.exists():
@@ -225,10 +241,11 @@ class TestJavaScriptIntegration:
         result = analyzer.analyze(str(examples_dir))
 
         js_items = [
-            item for item in result.items
-            if item.language == 'javascript' and 'patterns' in item.filepath
+            item
+            for item in result.items
+            if item.language == "javascript" and "patterns" in item.filepath
         ]
 
         # Arrow functions should be detected as functions
-        functions = [item for item in js_items if item.type == 'function']
+        functions = [item for item in js_items if item.type == "function"]
         assert len(functions) > 0, "No functions (including arrow functions) found"

--- a/analyzer/tests/test_json_serialization.py
+++ b/analyzer/tests/test_json_serialization.py
@@ -28,40 +28,40 @@ def format_analysis_result_as_json(result: AnalysisResult) -> str:
         JSON string representation.
     """
     data = {
-        'coverage_percent': result.coverage_percent,
-        'total_items': result.total_items,
-        'documented_items': result.documented_items,
-        'by_language': {
+        "coverage_percent": result.coverage_percent,
+        "total_items": result.total_items,
+        "documented_items": result.documented_items,
+        "by_language": {
             lang: {
-                'language': metrics.language,
-                'total_items': metrics.total_items,
-                'documented_items': metrics.documented_items,
-                'coverage_percent': metrics.coverage_percent,
-                'avg_complexity': metrics.avg_complexity,
-                'avg_impact_score': metrics.avg_impact_score
+                "language": metrics.language,
+                "total_items": metrics.total_items,
+                "documented_items": metrics.documented_items,
+                "coverage_percent": metrics.coverage_percent,
+                "avg_complexity": metrics.avg_complexity,
+                "avg_impact_score": metrics.avg_impact_score,
             }
             for lang, metrics in result.by_language.items()
         },
-        'items': [
+        "items": [
             {
-                'name': item.name,
-                'type': item.type,
-                'filepath': item.filepath,
-                'line_number': item.line_number,
-                'end_line': item.end_line,
-                'language': item.language,
-                'complexity': item.complexity,
-                'impact_score': item.impact_score,
-                'has_docs': item.has_docs,
-                'export_type': item.export_type,
-                'module_system': item.module_system,
-                'parameters': item.parameters,
-                'return_type': item.return_type,
-                'docstring': item.docstring,
-                'audit_rating': item.audit_rating
+                "name": item.name,
+                "type": item.type,
+                "filepath": item.filepath,
+                "line_number": item.line_number,
+                "end_line": item.end_line,
+                "language": item.language,
+                "complexity": item.complexity,
+                "impact_score": item.impact_score,
+                "has_docs": item.has_docs,
+                "export_type": item.export_type,
+                "module_system": item.module_system,
+                "parameters": item.parameters,
+                "return_type": item.return_type,
+                "docstring": item.docstring,
+                "audit_rating": item.audit_rating,
             }
             for item in result.items
-        ]
+        ],
     }
     return json.dumps(data, indent=2)
 
@@ -73,19 +73,19 @@ def test_unicode_in_item_names():
     are properly serialized to JSON without encoding errors.
     """
     item = CodeItem(
-        name='函数',  # Chinese characters
-        type='function',
-        filepath='/test/测试.py',  # Chinese characters in path
+        name="函数",  # Chinese characters
+        type="function",
+        filepath="/test/测试.py",  # Chinese characters in path
         line_number=10,
         end_line=15,
-        language='python',
+        language="python",
         complexity=3,
         has_docs=True,
-        export_type='named',
-        module_system='esm',
-        docstring='Documentation with 日本語 and emoji: ✓',  # Japanese + emoji
-        parameters=['param1', 'パラメータ2'],  # Mixed ASCII and Japanese
-        return_type='str'
+        export_type="named",
+        module_system="esm",
+        docstring="Documentation with 日本語 and emoji: ✓",  # Japanese + emoji
+        parameters=["param1", "パラメータ2"],  # Mixed ASCII and Japanese
+        return_type="str",
     )
 
     result = AnalysisResult(
@@ -93,7 +93,7 @@ def test_unicode_in_item_names():
         coverage_percent=100.0,
         total_items=1,
         documented_items=1,
-        by_language={}
+        by_language={},
     )
 
     # Should not raise UnicodeEncodeError
@@ -101,10 +101,10 @@ def test_unicode_in_item_names():
     parsed = json.loads(json_output)
 
     # Verify Unicode characters are preserved
-    assert parsed['items'][0]['name'] == '函数'
-    assert parsed['items'][0]['filepath'] == '/test/测试.py'
-    assert '日本語' in parsed['items'][0]['docstring']
-    assert parsed['items'][0]['parameters'][1] == 'パラメータ2'
+    assert parsed["items"][0]["name"] == "函数"
+    assert parsed["items"][0]["filepath"] == "/test/测试.py"
+    assert "日本語" in parsed["items"][0]["docstring"]
+    assert parsed["items"][0]["parameters"][1] == "パラメータ2"
 
 
 def test_very_high_complexity_values():
@@ -118,17 +118,17 @@ def test_very_high_complexity_values():
     """
     # Test 1: Very high complexity (larger than JS safe integer)
     high_complexity_item = CodeItem(
-        name='very_complex_function',
-        type='function',
-        filepath='/test/complex.py',
+        name="very_complex_function",
+        type="function",
+        filepath="/test/complex.py",
         line_number=1,
         end_line=100,
-        language='python',
+        language="python",
         complexity=999999999999,  # Larger than JavaScript Number.MAX_SAFE_INTEGER
         has_docs=False,
-        export_type='named',
-        module_system='esm',
-        impact_score=100.0  # Normal score
+        export_type="named",
+        module_system="esm",
+        impact_score=100.0,  # Normal score
     )
 
     result = AnalysisResult(
@@ -136,7 +136,7 @@ def test_very_high_complexity_values():
         coverage_percent=0.0,
         total_items=1,
         documented_items=0,
-        by_language={}
+        by_language={},
     )
 
     # Should serialize without error
@@ -144,8 +144,8 @@ def test_very_high_complexity_values():
     parsed = json.loads(json_output)
 
     # Complexity should be serialized as integer (may lose precision in JS)
-    assert isinstance(parsed['items'][0]['complexity'], int)
-    assert parsed['items'][0]['complexity'] > 0
+    assert isinstance(parsed["items"][0]["complexity"], int)
+    assert parsed["items"][0]["complexity"] > 0
 
     # Test 2: Special float values
     # Note: Python's json.dumps() will convert Infinity/NaN to null by default
@@ -155,17 +155,17 @@ def test_very_high_complexity_values():
     # In practice, impact_score should never be Infinity due to min(100, ...)
     # capping, but we test defensive behavior
     normal_item = CodeItem(
-        name='normal_function',
-        type='function',
-        filepath='/test/normal.py',
+        name="normal_function",
+        type="function",
+        filepath="/test/normal.py",
         line_number=1,
         end_line=10,
-        language='python',
+        language="python",
         complexity=10,
         has_docs=False,
-        export_type='named',
-        module_system='esm',
-        impact_score=50.0  # Normal finite value
+        export_type="named",
+        module_system="esm",
+        impact_score=50.0,  # Normal finite value
     )
 
     result2 = AnalysisResult(
@@ -173,15 +173,15 @@ def test_very_high_complexity_values():
         coverage_percent=0.0,
         total_items=1,
         documented_items=0,
-        by_language={}
+        by_language={},
     )
 
     json_output2 = format_analysis_result_as_json(result2)
     parsed2 = json.loads(json_output2)
 
     # impact_score should be a normal float
-    assert isinstance(parsed2['items'][0]['impact_score'], (int, float))
-    assert parsed2['items'][0]['impact_score'] == 50.0
+    assert isinstance(parsed2["items"][0]["impact_score"], (int, float))
+    assert parsed2["items"][0]["impact_score"] == 50.0
 
 
 def test_null_vs_none_fields():
@@ -192,19 +192,19 @@ def test_null_vs_none_fields():
     between missing (.optional()) and null (.nullable()) fields.
     """
     item = CodeItem(
-        name='undocumented_function',
-        type='function',
-        filepath='/test/file.py',
+        name="undocumented_function",
+        type="function",
+        filepath="/test/file.py",
         line_number=10,
         end_line=15,
-        language='python',
+        language="python",
         complexity=5,
         has_docs=False,
-        export_type='named',
-        module_system='esm',
+        export_type="named",
+        module_system="esm",
         docstring=None,  # Should become JSON null
         return_type=None,  # Should become JSON null
-        audit_rating=None  # Should become JSON null
+        audit_rating=None,  # Should become JSON null
     )
 
     result = AnalysisResult(
@@ -212,21 +212,21 @@ def test_null_vs_none_fields():
         coverage_percent=0.0,
         total_items=1,
         documented_items=0,
-        by_language={}
+        by_language={},
     )
 
     json_output = format_analysis_result_as_json(result)
     parsed = json.loads(json_output)
 
     # All None fields should be present as null (not missing)
-    assert 'docstring' in parsed['items'][0]
-    assert parsed['items'][0]['docstring'] is None
+    assert "docstring" in parsed["items"][0]
+    assert parsed["items"][0]["docstring"] is None
 
-    assert 'return_type' in parsed['items'][0]
-    assert parsed['items'][0]['return_type'] is None
+    assert "return_type" in parsed["items"][0]
+    assert parsed["items"][0]["return_type"] is None
 
-    assert 'audit_rating' in parsed['items'][0]
-    assert parsed['items'][0]['audit_rating'] is None
+    assert "audit_rating" in parsed["items"][0]
+    assert parsed["items"][0]["audit_rating"] is None
 
 
 def test_empty_by_language_dict():
@@ -240,19 +240,19 @@ def test_empty_by_language_dict():
         coverage_percent=0.0,
         total_items=0,
         documented_items=0,
-        by_language={}  # Empty dict
+        by_language={},  # Empty dict
     )
 
     json_output = format_analysis_result_as_json(result)
     parsed = json.loads(json_output)
 
     # by_language should be present as an empty object
-    assert 'by_language' in parsed
-    assert isinstance(parsed['by_language'], dict)
-    assert len(parsed['by_language']) == 0
+    assert "by_language" in parsed
+    assert isinstance(parsed["by_language"], dict)
+    assert len(parsed["by_language"]) == 0
 
     # Should be {} in JSON, not null
-    assert parsed['by_language'] == {}
+    assert parsed["by_language"] == {}
 
 
 def test_complete_json_roundtrip():
@@ -263,75 +263,75 @@ def test_complete_json_roundtrip():
     serialization and deserialization preserve all data correctly.
     """
     python_metrics = LanguageMetrics(
-        language='python',
+        language="python",
         total_items=2,
         documented_items=1,
         coverage_percent=50.0,
         avg_complexity=7.5,
-        avg_impact_score=37.5
+        avg_impact_score=37.5,
     )
 
     typescript_metrics = LanguageMetrics(
-        language='typescript',
+        language="typescript",
         total_items=1,
         documented_items=0,
         coverage_percent=0.0,
         avg_complexity=15.0,
-        avg_impact_score=75.0
+        avg_impact_score=75.0,
     )
 
     items = [
         CodeItem(
-            name='documented_function',
-            type='function',
-            filepath='/src/utils.py',
+            name="documented_function",
+            type="function",
+            filepath="/src/utils.py",
             line_number=10,
             end_line=20,
-            language='python',
+            language="python",
             complexity=5,
             has_docs=True,
-            export_type='named',
-            module_system='esm',
+            export_type="named",
+            module_system="esm",
             impact_score=25.0,
-            docstring='This function does something useful.',
-            parameters=['x', 'y'],
-            return_type='int',
-            audit_rating=3  # Good rating
+            docstring="This function does something useful.",
+            parameters=["x", "y"],
+            return_type="int",
+            audit_rating=3,  # Good rating
         ),
         CodeItem(
-            name='undocumented_class',
-            type='class',
-            filepath='/src/models.py',
+            name="undocumented_class",
+            type="class",
+            filepath="/src/models.py",
             line_number=50,
             end_line=100,
-            language='python',
+            language="python",
             complexity=10,
             has_docs=False,
-            export_type='named',
-            module_system='esm',
+            export_type="named",
+            module_system="esm",
             impact_score=50.0,
             docstring=None,
             parameters=[],
             return_type=None,
-            audit_rating=None  # Not audited
+            audit_rating=None,  # Not audited
         ),
         CodeItem(
-            name='ComplexService',
-            type='class',
-            filepath='/src/service.ts',
+            name="ComplexService",
+            type="class",
+            filepath="/src/service.ts",
             line_number=1,
             end_line=200,
-            language='typescript',
+            language="typescript",
             complexity=15,
             has_docs=False,
-            export_type='default',
-            module_system='esm',
+            export_type="default",
+            module_system="esm",
             impact_score=75.0,
             docstring=None,
             parameters=[],
             return_type=None,
-            audit_rating=None
-        )
+            audit_rating=None,
+        ),
     ]
 
     result = AnalysisResult(
@@ -339,10 +339,7 @@ def test_complete_json_roundtrip():
         coverage_percent=33.33,
         total_items=3,
         documented_items=1,
-        by_language={
-            'python': python_metrics,
-            'typescript': typescript_metrics
-        }
+        by_language={"python": python_metrics, "typescript": typescript_metrics},
     )
 
     # Serialize to JSON
@@ -352,41 +349,41 @@ def test_complete_json_roundtrip():
     parsed = json.loads(json_output)
 
     # Validate top-level fields
-    assert parsed['coverage_percent'] == 33.33
-    assert parsed['total_items'] == 3
-    assert parsed['documented_items'] == 1
+    assert parsed["coverage_percent"] == 33.33
+    assert parsed["total_items"] == 3
+    assert parsed["documented_items"] == 1
 
     # Validate by_language metrics
-    assert 'python' in parsed['by_language']
-    assert parsed['by_language']['python']['total_items'] == 2
-    assert parsed['by_language']['python']['documented_items'] == 1
-    assert parsed['by_language']['python']['avg_complexity'] == 7.5
+    assert "python" in parsed["by_language"]
+    assert parsed["by_language"]["python"]["total_items"] == 2
+    assert parsed["by_language"]["python"]["documented_items"] == 1
+    assert parsed["by_language"]["python"]["avg_complexity"] == 7.5
 
-    assert 'typescript' in parsed['by_language']
-    assert parsed['by_language']['typescript']['total_items'] == 1
-    assert parsed['by_language']['typescript']['coverage_percent'] == 0.0
+    assert "typescript" in parsed["by_language"]
+    assert parsed["by_language"]["typescript"]["total_items"] == 1
+    assert parsed["by_language"]["typescript"]["coverage_percent"] == 0.0
 
     # Validate items
-    assert len(parsed['items']) == 3
+    assert len(parsed["items"]) == 3
 
     # First item (documented Python function)
-    item1 = parsed['items'][0]
-    assert item1['name'] == 'documented_function'
-    assert item1['has_docs'] is True
-    assert item1['docstring'] == 'This function does something useful.'
-    assert item1['parameters'] == ['x', 'y']
-    assert item1['return_type'] == 'int'
-    assert item1['audit_rating'] == 3
+    item1 = parsed["items"][0]
+    assert item1["name"] == "documented_function"
+    assert item1["has_docs"] is True
+    assert item1["docstring"] == "This function does something useful."
+    assert item1["parameters"] == ["x", "y"]
+    assert item1["return_type"] == "int"
+    assert item1["audit_rating"] == 3
 
     # Second item (undocumented Python class)
-    item2 = parsed['items'][1]
-    assert item2['name'] == 'undocumented_class'
-    assert item2['has_docs'] is False
-    assert item2['docstring'] is None
-    assert item2['audit_rating'] is None
+    item2 = parsed["items"][1]
+    assert item2["name"] == "undocumented_class"
+    assert item2["has_docs"] is False
+    assert item2["docstring"] is None
+    assert item2["audit_rating"] is None
 
     # Third item (undocumented TypeScript class)
-    item3 = parsed['items'][2]
-    assert item3['name'] == 'ComplexService'
-    assert item3['language'] == 'typescript'
-    assert item3['export_type'] == 'default'
+    item3 = parsed["items"][2]
+    assert item3["name"] == "ComplexService"
+    assert item3["language"] == "typescript"
+    assert item3["export_type"] == "default"

--- a/analyzer/tests/test_models.py
+++ b/analyzer/tests/test_models.py
@@ -14,40 +14,40 @@ from src.models.analysis_result import AnalysisResult, LanguageMetrics
 def test_code_item_creation():
     """Test basic CodeItem creation with required fields."""
     item = CodeItem(
-        name='test_func',
-        type='function',
-        filepath='test.py',
+        name="test_func",
+        type="function",
+        filepath="test.py",
         line_number=10,
         end_line=15,
-        language='python',
+        language="python",
         complexity=5,
         has_docs=False,
-        export_type='named',
-        module_system='esm'
+        export_type="named",
+        module_system="esm",
     )
 
-    assert item.name == 'test_func'
-    assert item.type == 'function'
-    assert item.language == 'python'
+    assert item.name == "test_func"
+    assert item.type == "function"
+    assert item.language == "python"
     assert item.complexity == 5
     assert item.has_docs is False
-    assert item.export_type == 'named'
-    assert item.module_system == 'esm'
+    assert item.export_type == "named"
+    assert item.module_system == "esm"
 
 
 def test_code_item_defaults():
     """Test that optional fields have correct default values."""
     item = CodeItem(
-        name='minimal_func',
-        type='function',
-        filepath='test.py',
+        name="minimal_func",
+        type="function",
+        filepath="test.py",
         line_number=5,
         end_line=10,
-        language='python',
+        language="python",
         complexity=2,
         has_docs=False,
-        export_type='internal',
-        module_system='unknown'
+        export_type="internal",
+        module_system="unknown",
     )
 
     # Test defaults
@@ -61,26 +61,26 @@ def test_code_item_defaults():
 def test_code_item_with_all_fields():
     """Test CodeItem with all optional fields populated."""
     item = CodeItem(
-        name='complete_func',
-        type='function',
-        filepath='test.py',
+        name="complete_func",
+        type="function",
+        filepath="test.py",
         line_number=10,
         end_line=15,
-        language='python',
+        language="python",
         complexity=8,
         has_docs=True,
-        export_type='named',
-        module_system='esm',
-        parameters=['param1', 'param2'],
-        return_type='int',
-        docstring='This function does something.',
+        export_type="named",
+        module_system="esm",
+        parameters=["param1", "param2"],
+        return_type="int",
+        docstring="This function does something.",
         impact_score=60.0,
-        audit_rating=3
+        audit_rating=3,
     )
 
-    assert item.parameters == ['param1', 'param2']
-    assert item.return_type == 'int'
-    assert item.docstring == 'This function does something.'
+    assert item.parameters == ["param1", "param2"]
+    assert item.return_type == "int"
+    assert item.docstring == "This function does something."
     assert item.impact_score == 60.0
     assert item.audit_rating == 3
 
@@ -88,25 +88,25 @@ def test_code_item_with_all_fields():
 def test_code_item_json_serialization():
     """Test that CodeItem serializes to JSON correctly."""
     item = CodeItem(
-        name='test_func',
-        type='function',
-        filepath='test.py',
+        name="test_func",
+        type="function",
+        filepath="test.py",
         line_number=10,
         end_line=15,
-        language='python',
+        language="python",
         complexity=5,
         has_docs=False,
-        export_type='named',
-        module_system='esm',
-        impact_score=75
+        export_type="named",
+        module_system="esm",
+        impact_score=75,
     )
 
     # Convert to dict
     item_dict = item.to_dict()
     assert isinstance(item_dict, dict)
-    assert item_dict['name'] == 'test_func'
-    assert item_dict['complexity'] == 5
-    assert item_dict['impact_score'] == 75
+    assert item_dict["name"] == "test_func"
+    assert item_dict["complexity"] == 5
+    assert item_dict["impact_score"] == 75
 
     # Ensure it's JSON serializable
     item_json = json.dumps(item_dict)
@@ -114,23 +114,23 @@ def test_code_item_json_serialization():
 
     # Deserialize and verify
     parsed = json.loads(item_json)
-    assert parsed['name'] == 'test_func'
-    assert parsed['parameters'] == []
-    assert parsed['return_type'] is None
+    assert parsed["name"] == "test_func"
+    assert parsed["parameters"] == []
+    assert parsed["return_type"] is None
 
 
 def test_language_metrics_creation():
     """Test LanguageMetrics creation and serialization."""
     metrics = LanguageMetrics(
-        language='python',
+        language="python",
         total_items=10,
         documented_items=7,
         coverage_percent=70.0,
         avg_complexity=5.5,
-        avg_impact_score=42.0
+        avg_impact_score=42.0,
     )
 
-    assert metrics.language == 'python'
+    assert metrics.language == "python"
     assert metrics.total_items == 10
     assert metrics.documented_items == 7
     assert metrics.coverage_percent == 70.0
@@ -139,46 +139,43 @@ def test_language_metrics_creation():
 
     # Test serialization
     metrics_dict = metrics.to_dict()
-    assert metrics_dict['language'] == 'python'
-    assert metrics_dict['coverage_percent'] == 70.0
+    assert metrics_dict["language"] == "python"
+    assert metrics_dict["coverage_percent"] == 70.0
 
 
 def test_analysis_result_creation():
     """Test AnalysisResult with items and metrics."""
     items = [
         CodeItem(
-            name='func1',
-            type='function',
-            filepath='test.py',
+            name="func1",
+            type="function",
+            filepath="test.py",
             line_number=10,
             end_line=15,
-            language='python',
+            language="python",
             complexity=5,
             has_docs=True,
-            export_type='internal',
-            module_system='unknown',
-            impact_score=25
+            export_type="internal",
+            module_system="unknown",
+            impact_score=25,
         ),
         CodeItem(
-            name='func2',
-            type='function',
-            filepath='test.js',
+            name="func2",
+            type="function",
+            filepath="test.js",
             line_number=20,
             end_line=25,
-            language='javascript',
+            language="javascript",
             complexity=10,
             has_docs=False,
-            export_type='named',
-            module_system='esm',
-            impact_score=50
+            export_type="named",
+            module_system="esm",
+            impact_score=50,
         ),
     ]
 
     result = AnalysisResult(
-        items=items,
-        coverage_percent=50.0,
-        total_items=2,
-        documented_items=1
+        items=items, coverage_percent=50.0, total_items=2, documented_items=1
     )
 
     assert len(result.items) == 2
@@ -191,143 +188,134 @@ def test_analysis_result_get_undocumented():
     """Test filtering undocumented items."""
     items = [
         CodeItem(
-            name='documented',
-            type='function',
-            filepath='test.py',
+            name="documented",
+            type="function",
+            filepath="test.py",
             line_number=1,
             end_line=5,
-            language='python',
+            language="python",
             complexity=1,
             has_docs=True,
-            export_type='internal',
-            module_system='unknown'
+            export_type="internal",
+            module_system="unknown",
         ),
         CodeItem(
-            name='undocumented',
-            type='function',
-            filepath='test.py',
+            name="undocumented",
+            type="function",
+            filepath="test.py",
             line_number=2,
             end_line=7,
-            language='python',
+            language="python",
             complexity=2,
             has_docs=False,
-            export_type='internal',
-            module_system='unknown'
+            export_type="internal",
+            module_system="unknown",
         ),
     ]
 
     result = AnalysisResult(
-        items=items,
-        coverage_percent=50.0,
-        total_items=2,
-        documented_items=1
+        items=items, coverage_percent=50.0, total_items=2, documented_items=1
     )
 
     undocumented = result.get_undocumented_items()
     assert len(undocumented) == 1
-    assert undocumented[0].name == 'undocumented'
+    assert undocumented[0].name == "undocumented"
 
 
 def test_analysis_result_get_by_language():
     """Test filtering items by language."""
     items = [
         CodeItem(
-            name='py_func',
-            type='function',
-            filepath='test.py',
+            name="py_func",
+            type="function",
+            filepath="test.py",
             line_number=1,
             end_line=5,
-            language='python',
+            language="python",
             complexity=1,
             has_docs=False,
-            export_type='internal',
-            module_system='unknown'
+            export_type="internal",
+            module_system="unknown",
         ),
         CodeItem(
-            name='js_func',
-            type='function',
-            filepath='test.js',
+            name="js_func",
+            type="function",
+            filepath="test.js",
             line_number=1,
             end_line=5,
-            language='javascript',
+            language="javascript",
             complexity=1,
             has_docs=False,
-            export_type='named',
-            module_system='esm'
+            export_type="named",
+            module_system="esm",
         ),
     ]
 
     result = AnalysisResult(
-        items=items,
-        coverage_percent=0.0,
-        total_items=2,
-        documented_items=0
+        items=items, coverage_percent=0.0, total_items=2, documented_items=0
     )
 
-    py_items = result.get_items_by_language('python')
+    py_items = result.get_items_by_language("python")
     assert len(py_items) == 1
-    assert py_items[0].name == 'py_func'
+    assert py_items[0].name == "py_func"
 
-    js_items = result.get_items_by_language('javascript')
+    js_items = result.get_items_by_language("javascript")
     assert len(js_items) == 1
-    assert js_items[0].name == 'js_func'
+    assert js_items[0].name == "js_func"
 
 
 def test_analysis_result_top_priority():
     """Test getting top priority items by impact score."""
     items = [
         CodeItem(
-            name='low_priority',
-            type='function',
-            filepath='test.py',
+            name="low_priority",
+            type="function",
+            filepath="test.py",
             line_number=1,
             end_line=5,
-            language='python',
+            language="python",
             complexity=1,
             has_docs=False,
-            export_type='internal',
-            module_system='unknown',
-            impact_score=10.0
+            export_type="internal",
+            module_system="unknown",
+            impact_score=10.0,
         ),
         CodeItem(
-            name='high_priority',
-            type='function',
-            filepath='test.py',
+            name="high_priority",
+            type="function",
+            filepath="test.py",
             line_number=2,
             end_line=7,
-            language='python',
+            language="python",
             complexity=10,
             has_docs=False,
-            export_type='internal',
-            module_system='unknown',
-            impact_score=90.0
+            export_type="internal",
+            module_system="unknown",
+            impact_score=90.0,
         ),
         CodeItem(
-            name='medium_priority',
-            type='function',
-            filepath='test.py',
+            name="medium_priority",
+            type="function",
+            filepath="test.py",
             line_number=3,
             end_line=8,
-            language='python',
+            language="python",
             complexity=5,
             has_docs=False,
-            export_type='internal',
-            module_system='unknown',
-            impact_score=50.0
+            export_type="internal",
+            module_system="unknown",
+            impact_score=50.0,
         ),
     ]
 
     result = AnalysisResult(
-        items=items,
-        coverage_percent=0.0,
-        total_items=3,
-        documented_items=0
+        items=items, coverage_percent=0.0, total_items=3, documented_items=0
     )
 
     top_items = result.get_top_priority_items(limit=2)
     assert len(top_items) == 2
-    assert top_items[0].name == 'high_priority'
-    assert top_items[1].name == 'medium_priority'
+    assert top_items[0].name == "high_priority"
+    assert top_items[1].name == "medium_priority"
     assert top_items[0].impact_score > top_items[1].impact_score
 
 
@@ -335,27 +323,27 @@ def test_analysis_result_json_serialization():
     """Test full AnalysisResult JSON serialization."""
     items = [
         CodeItem(
-            name='func1',
-            type='function',
-            filepath='test.py',
+            name="func1",
+            type="function",
+            filepath="test.py",
             line_number=1,
             end_line=5,
-            language='python',
+            language="python",
             complexity=5,
             has_docs=True,
-            export_type='internal',
-            module_system='unknown',
-            impact_score=25.0
+            export_type="internal",
+            module_system="unknown",
+            impact_score=25.0,
         ),
     ]
 
     py_metrics = LanguageMetrics(
-        language='python',
+        language="python",
         total_items=1,
         documented_items=1,
         coverage_percent=100.0,
         avg_complexity=5.0,
-        avg_impact_score=25.0
+        avg_impact_score=25.0,
     )
 
     result = AnalysisResult(
@@ -363,7 +351,7 @@ def test_analysis_result_json_serialization():
         coverage_percent=100.0,
         total_items=1,
         documented_items=1,
-        by_language={'python': py_metrics}
+        by_language={"python": py_metrics},
     )
 
     # Serialize to JSON
@@ -372,9 +360,9 @@ def test_analysis_result_json_serialization():
 
     # Deserialize and verify
     parsed = json.loads(result_json)
-    assert parsed['coverage_percent'] == 100.0
-    assert parsed['total_items'] == 1
-    assert len(parsed['items']) == 1
-    assert parsed['items'][0]['name'] == 'func1'
-    assert 'python' in parsed['by_language']
-    assert parsed['by_language']['python']['coverage_percent'] == 100.0
+    assert parsed["coverage_percent"] == 100.0
+    assert parsed["total_items"] == 1
+    assert len(parsed["items"]) == 1
+    assert parsed["items"][0]["name"] == "func1"
+    assert "python" in parsed["by_language"]
+    assert parsed["by_language"]["python"]["coverage_percent"] == 100.0

--- a/analyzer/tests/test_parsers.py
+++ b/analyzer/tests/test_parsers.py
@@ -12,8 +12,8 @@ from src.models.code_item import CodeItem
 
 # Test fixture paths
 PROJECT_ROOT = Path(__file__).parent.parent.parent
-MALFORMED_SAMPLES = PROJECT_ROOT / 'test-samples' / 'malformed'
-EXAMPLES_DIR = PROJECT_ROOT / 'examples'
+MALFORMED_SAMPLES = PROJECT_ROOT / "test-samples" / "malformed"
+EXAMPLES_DIR = PROJECT_ROOT / "examples"
 
 
 class TestPythonParser:
@@ -27,7 +27,7 @@ class TestPythonParser:
     @pytest.fixture
     def test_file(self):
         """Return path to test Python file."""
-        return str(EXAMPLES_DIR / 'test_simple.py')
+        return str(EXAMPLES_DIR / "test_simple.py")
 
     def test_parse_file_returns_code_items(self, parser, test_file):
         """Test that parse_file returns a list of CodeItem objects."""
@@ -41,7 +41,7 @@ class TestPythonParser:
         """Test that all parsed items have language='python'."""
         items = parser.parse_file(test_file)
 
-        assert all(item.language == 'python' for item in items)
+        assert all(item.language == "python" for item in items)
 
     def test_complexity_is_positive(self, parser, test_file):
         """Test that all items have positive complexity."""
@@ -57,7 +57,9 @@ class TestPythonParser:
         assert any(item.has_docs for item in items)
 
         # Check specific items
-        async_func = next((item for item in items if item.name == 'async_function'), None)
+        async_func = next(
+            (item for item in items if item.name == "async_function"), None
+        )
         assert async_func is not None
         assert async_func.has_docs is True
         assert async_func.docstring is not None
@@ -66,39 +68,47 @@ class TestPythonParser:
         """Test that function metadata is extracted correctly."""
         items = parser.parse_file(test_file)
 
-        async_func = next((item for item in items if item.name == 'async_function'), None)
+        async_func = next(
+            (item for item in items if item.name == "async_function"), None
+        )
         assert async_func is not None
-        assert async_func.type == 'function'
-        assert 'param1' in async_func.parameters
-        assert 'param2' in async_func.parameters
-        assert async_func.return_type == 'bool'
+        assert async_func.type == "function"
+        assert "param1" in async_func.parameters
+        assert "param2" in async_func.parameters
+        assert async_func.return_type == "bool"
 
     def test_extracts_class_metadata(self, parser, test_file):
         """Test that class metadata is extracted correctly."""
         items = parser.parse_file(test_file)
 
-        example_class = next((item for item in items if item.name == 'ExampleClass'), None)
+        example_class = next(
+            (item for item in items if item.name == "ExampleClass"), None
+        )
         assert example_class is not None
-        assert example_class.type == 'class'
+        assert example_class.type == "class"
 
     def test_extracts_methods(self, parser, test_file):
         """Test that class methods are extracted."""
         items = parser.parse_file(test_file)
 
         # Should have __init__ and value property
-        init_method = next((item for item in items if item.name == 'ExampleClass.__init__'), None)
+        init_method = next(
+            (item for item in items if item.name == "ExampleClass.__init__"), None
+        )
         assert init_method is not None
-        assert init_method.type == 'method'
+        assert init_method.type == "method"
         assert init_method.has_docs is True
 
-        value_property = next((item for item in items if item.name == 'ExampleClass.value'), None)
+        value_property = next(
+            (item for item in items if item.name == "ExampleClass.value"), None
+        )
         assert value_property is not None
-        assert value_property.type == 'method'
+        assert value_property.type == "method"
 
     def test_file_not_found_raises_error(self, parser):
         """Test that parsing non-existent file raises FileNotFoundError."""
         with pytest.raises(FileNotFoundError):
-            parser.parse_file('nonexistent_file.py')
+            parser.parse_file("nonexistent_file.py")
 
     def test_syntax_error_raises_error(self, parser, tmp_path):
         """Test that parsing invalid Python raises SyntaxError."""
@@ -112,23 +122,23 @@ class TestPythonParser:
         """Test that parser raises SyntaxError for different types of syntax errors."""
         # Test missing colon
         with pytest.raises(SyntaxError):
-            parser.parse_file(str(MALFORMED_SAMPLES / 'python_missing_colon.py'))
+            parser.parse_file(str(MALFORMED_SAMPLES / "python_missing_colon.py"))
 
         # Test unclosed parenthesis
         with pytest.raises(SyntaxError):
-            parser.parse_file(str(MALFORMED_SAMPLES / 'python_unclosed_paren.py'))
+            parser.parse_file(str(MALFORMED_SAMPLES / "python_unclosed_paren.py"))
 
         # Test invalid indentation
         with pytest.raises(SyntaxError):
-            parser.parse_file(str(MALFORMED_SAMPLES / 'python_invalid_indentation.py'))
+            parser.parse_file(str(MALFORMED_SAMPLES / "python_invalid_indentation.py"))
 
         # Test incomplete statement
         with pytest.raises(SyntaxError):
-            parser.parse_file(str(MALFORMED_SAMPLES / 'python_incomplete_statement.py'))
+            parser.parse_file(str(MALFORMED_SAMPLES / "python_incomplete_statement.py"))
 
     def test_syntax_error_message_clarity(self, parser):
         """Test that syntax error messages include file path and are informative."""
-        malformed_file = MALFORMED_SAMPLES / 'python_missing_colon.py'
+        malformed_file = MALFORMED_SAMPLES / "python_missing_colon.py"
 
         try:
             parser.parse_file(str(malformed_file))
@@ -136,8 +146,9 @@ class TestPythonParser:
         except SyntaxError as e:
             error_msg = str(e)
             # Error message should mention the file
-            assert 'python_missing_colon.py' in error_msg, \
-                f"Error message should include filename, got: {error_msg}"
+            assert (
+                "python_missing_colon.py" in error_msg
+            ), f"Error message should include filename, got: {error_msg}"
 
     def test_complexity_calculation(self, parser, tmp_path):
         """Test that cyclomatic complexity is calculated correctly."""
@@ -150,7 +161,8 @@ class TestPythonParser:
 
         # Function with conditionals should have higher complexity
         complex_file = tmp_path / "complex.py"
-        complex_file.write_text("""
+        complex_file.write_text(
+            """
 def complex_func(x):
     if x > 0:
         if x < 10:
@@ -159,7 +171,8 @@ def complex_func(x):
             return 'big'
     else:
         return 'negative'
-""")
+"""
+        )
 
         complex_items = parser.parse_file(str(complex_file))
         assert complex_items[0].complexity > 1
@@ -179,26 +192,31 @@ def complex_func(x):
         item_names = [item.name for item in items]
 
         # Check that we have exactly the expected items
-        assert 'async_function' in item_names
-        assert 'ExampleClass' in item_names
-        assert 'ExampleClass.__init__' in item_names
-        assert 'ExampleClass.value' in item_names
+        assert "async_function" in item_names
+        assert "ExampleClass" in item_names
+        assert "ExampleClass.__init__" in item_names
+        assert "ExampleClass.value" in item_names
 
         # Ensure methods are NOT extracted as plain functions
-        assert '__init__' not in item_names, "Method __init__ should not appear as plain function"
-        assert 'value' not in item_names, "Method value should not appear as plain function"
+        assert (
+            "__init__" not in item_names
+        ), "Method __init__ should not appear as plain function"
+        assert (
+            "value" not in item_names
+        ), "Method value should not appear as plain function"
 
         # Verify item types
         types_by_name = {item.name: item.type for item in items}
-        assert types_by_name['async_function'] == 'function'
-        assert types_by_name['ExampleClass'] == 'class'
-        assert types_by_name['ExampleClass.__init__'] == 'method'
-        assert types_by_name['ExampleClass.value'] == 'method'
+        assert types_by_name["async_function"] == "function"
+        assert types_by_name["ExampleClass"] == "class"
+        assert types_by_name["ExampleClass.__init__"] == "method"
+        assert types_by_name["ExampleClass.value"] == "method"
 
     def test_extracts_nested_functions(self, parser, tmp_path):
         """Test that nested functions are extracted (validates parent-tracking fix)."""
         nested_file = tmp_path / "nested.py"
-        nested_file.write_text("""
+        nested_file.write_text(
+            """
 def outer_function(items):
     '''Process items with validation.'''
     def validate_item(item):
@@ -220,7 +238,8 @@ class DataProcessor:
             '''Internal helper function.'''
             return x * 2
         return _helper(data)
-""")
+"""
+        )
 
         items = parser.parse_file(str(nested_file))
         item_names = [item.name for item in items]
@@ -236,36 +255,39 @@ class DataProcessor:
         assert len(items) == 6, f"Expected 6 items, got {len(items)}: {item_names}"
 
         # Verify nested functions are extracted
-        assert 'outer_function' in item_names, "Top-level function should be extracted"
-        assert 'validate_item' in item_names, "Nested function should be extracted"
-        assert 'transform_item' in item_names, "Nested function should be extracted"
+        assert "outer_function" in item_names, "Top-level function should be extracted"
+        assert "validate_item" in item_names, "Nested function should be extracted"
+        assert "transform_item" in item_names, "Nested function should be extracted"
 
         # Verify class and method are extracted
-        assert 'DataProcessor' in item_names, "Class should be extracted"
-        assert 'DataProcessor.process' in item_names, "Method should be extracted"
+        assert "DataProcessor" in item_names, "Class should be extracted"
+        assert "DataProcessor.process" in item_names, "Method should be extracted"
 
         # Verify nested function in method is extracted
-        assert '_helper' in item_names, "Nested function in method should be extracted"
+        assert "_helper" in item_names, "Nested function in method should be extracted"
 
         # Verify all are marked as functions (except class and method)
         types_by_name = {item.name: item.type for item in items}
-        assert types_by_name['outer_function'] == 'function'
-        assert types_by_name['validate_item'] == 'function'
-        assert types_by_name['transform_item'] == 'function'
-        assert types_by_name['DataProcessor'] == 'class'
-        assert types_by_name['DataProcessor.process'] == 'method'
-        assert types_by_name['_helper'] == 'function'
+        assert types_by_name["outer_function"] == "function"
+        assert types_by_name["validate_item"] == "function"
+        assert types_by_name["transform_item"] == "function"
+        assert types_by_name["DataProcessor"] == "class"
+        assert types_by_name["DataProcessor.process"] == "method"
+        assert types_by_name["_helper"] == "function"
 
         # Verify nested functions have metadata
-        validate = next(item for item in items if item.name == 'validate_item')
+        validate = next(item for item in items if item.name == "validate_item")
         assert validate.has_docs is True
         assert validate.docstring is not None
-        assert 'item' in validate.parameters
+        assert "item" in validate.parameters
 
     def test_complex_nesting_edge_cases(self, parser, tmp_path):
-        """Test edge cases with nested classes, conditionals, and multiple nesting levels."""
+        """Test edge cases with nested classes, conditionals, and multiple
+
+        nesting levels."""
         edge_case_file = tmp_path / "edge_cases.py"
-        edge_case_file.write_text("""
+        edge_case_file.write_text(
+            """
 class Outer:
     '''Outer class with nested structures.'''
     def method(self):
@@ -286,7 +308,8 @@ def function():
         def nested_in_conditional():
             '''Function defined inside conditional.'''
             pass
-""")
+"""
+        )
 
         items = parser.parse_file(str(edge_case_file))
         item_names = [item.name for item in items]
@@ -303,37 +326,41 @@ def function():
         assert len(items) == 7, f"Expected 7 items, got {len(items)}: {item_names}"
 
         # Verify outer class and its method
-        assert 'Outer' in item_names
-        assert 'Outer.method' in item_names
+        assert "Outer" in item_names
+        assert "Outer.method" in item_names
 
         # Verify nested function in method is extracted as function, not method
-        assert 'nested_in_method' in item_names
-        nested_func = next(item for item in items if item.name == 'nested_in_method')
-        assert nested_func.type == 'function', "Function nested in method should be type 'function'"
+        assert "nested_in_method" in item_names
+        nested_func = next(item for item in items if item.name == "nested_in_method")
+        assert (
+            nested_func.type == "function"
+        ), "Function nested in method should be type 'function'"
 
         # Verify nested class
-        assert 'Inner' in item_names
-        inner_class = next(item for item in items if item.name == 'Inner')
-        assert inner_class.type == 'class'
+        assert "Inner" in item_names
+        inner_class = next(item for item in items if item.name == "Inner")
+        assert inner_class.type == "class"
 
         # Verify method in nested class
-        assert 'Inner.inner_method' in item_names
-        inner_method = next(item for item in items if item.name == 'Inner.inner_method')
-        assert inner_method.type == 'method'
+        assert "Inner.inner_method" in item_names
+        inner_method = next(item for item in items if item.name == "Inner.inner_method")
+        assert inner_method.type == "method"
 
         # Verify function with conditional nesting
-        assert 'function' in item_names
-        assert 'nested_in_conditional' in item_names
-        cond_func = next(item for item in items if item.name == 'nested_in_conditional')
-        assert cond_func.type == 'function'
+        assert "function" in item_names
+        assert "nested_in_conditional" in item_names
+        cond_func = next(item for item in items if item.name == "nested_in_conditional")
+        assert cond_func.type == "function"
 
         # Verify all items have documentation
         assert all(item.has_docs for item in items), "All items should have docstrings"
 
     def test_nested_function_complexity_isolation(self, parser, tmp_path):
-        """Test that nested function complexity does not contribute to parent (issue #66)."""
+        """Test that nested function complexity does not contribute to parent
+        (issue #66)."""
         test_file = tmp_path / "nested_complexity.py"
-        test_file.write_text("""
+        test_file.write_text(
+            """
 def parent_function(x):
     '''Parent function with simple logic.'''
     if x > 0:  # Parent complexity: base 1 + this if = 2
@@ -348,30 +375,35 @@ def parent_function(x):
         return True
 
     return False
-""")
+"""
+        )
 
         items = parser.parse_file(str(test_file))
 
         # Should extract both parent and nested function
         assert len(items) == 2, f"Expected 2 items (parent + nested), got {len(items)}"
 
-        parent = next(item for item in items if item.name == 'parent_function')
-        nested = next(item for item in items if item.name == 'nested_helper')
+        parent = next(item for item in items if item.name == "parent_function")
+        nested = next(item for item in items if item.name == "nested_helper")
 
         # Parent should have complexity 2 (base 1 + one if statement)
         # NOT 4 (which would include nested function's two if statements)
-        assert parent.complexity == 2, \
-            f"Parent complexity should be 2, got {parent.complexity}. " \
+        assert parent.complexity == 2, (
+            f"Parent complexity should be 2, got {parent.complexity}. "
             "Nested function complexity should not contribute to parent."
+        )
 
         # Nested function should have complexity 3 (base 1 + two if statements)
-        assert nested.complexity == 3, \
-            f"Nested complexity should be 3, got {nested.complexity}"
+        assert (
+            nested.complexity == 3
+        ), f"Nested complexity should be 3, got {nested.complexity}"
 
     def test_complexity_with_lambdas(self, parser, tmp_path):
-        """Test that lambda functions are correctly traversed in complexity calculation."""
+        """Test that lambda functions are correctly traversed in complexity
+        calculation."""
         test_file = tmp_path / "lambda_complexity.py"
-        test_file.write_text("""
+        test_file.write_text(
+            """
 def parent_with_lambda(x):
     '''Parent with lambda and regular conditional.'''
     # Lambda itself is not a decision point, but it's traversed
@@ -382,7 +414,8 @@ def parent_with_lambda(x):
         return True
 
     return False
-""")
+"""
+        )
 
         items = parser.parse_file(str(test_file))
         assert len(items) == 1
@@ -390,13 +423,15 @@ def parent_with_lambda(x):
         parent = items[0]
         # Expected: base(1) + if(1) = 2
         # Lambda is traversed but doesn't add complexity
-        assert parent.complexity == 2, \
-            f"Expected complexity 2 (base + if), got {parent.complexity}"
+        assert (
+            parent.complexity == 2
+        ), f"Expected complexity 2 (base + if), got {parent.complexity}"
 
     def test_complexity_with_comprehensions(self, parser, tmp_path):
         """Test that comprehensions with conditionals are counted correctly."""
         test_file = tmp_path / "comprehension_complexity.py"
-        test_file.write_text("""
+        test_file.write_text(
+            """
 def parent_with_comprehension(x):
     '''Parent with comprehension.'''
     # List comprehension with conditional - comprehension itself is +1
@@ -407,20 +442,23 @@ def parent_with_comprehension(x):
         return filtered
 
     return []
-""")
+"""
+        )
 
         items = parser.parse_file(str(test_file))
         assert len(items) == 1
 
         parent = items[0]
         # Expected: base(1) + comprehension(1) + if(1) = 3
-        assert parent.complexity == 3, \
-            f"Expected complexity 3 (base + comprehension + if), got {parent.complexity}"
+        assert (
+            parent.complexity == 3
+        ), f"Expected complexity 3 (base + comprehension + if), got {parent.complexity}"
 
     def test_complexity_async_nested_functions(self, parser, tmp_path):
         """Test that async nested functions are isolated from async parent."""
         test_file = tmp_path / "async_nested.py"
-        test_file.write_text("""
+        test_file.write_text(
+            """
 async def parent_async(x):
     '''Async parent function.'''
     if x > 0:
@@ -434,26 +472,30 @@ async def parent_async(x):
             y += 1
 
     return True
-""")
+"""
+        )
 
         items = parser.parse_file(str(test_file))
         assert len(items) == 2
 
-        parent = next(item for item in items if item.name == 'parent_async')
-        nested = next(item for item in items if item.name == 'nested_async')
+        parent = next(item for item in items if item.name == "parent_async")
+        nested = next(item for item in items if item.name == "nested_async")
 
         # Parent: base(1) + if(1) = 2
-        assert parent.complexity == 2, \
-            f"Async parent should have complexity 2, got {parent.complexity}"
+        assert (
+            parent.complexity == 2
+        ), f"Async parent should have complexity 2, got {parent.complexity}"
 
         # Nested: base(1) + if(1) + while(1) = 3
-        assert nested.complexity == 3, \
-            f"Async nested should have complexity 3, got {nested.complexity}"
+        assert (
+            nested.complexity == 3
+        ), f"Async nested should have complexity 3, got {nested.complexity}"
 
     def test_complexity_parent_with_many_branches(self, parser, tmp_path):
         """Test complex parent with multiple decision points and nested function."""
         test_file = tmp_path / "complex_parent.py"
-        test_file.write_text("""
+        test_file.write_text(
+            """
 def complex_parent(x):
     '''Parent with multiple decision points.'''
     if x > 0:
@@ -476,28 +518,32 @@ def complex_parent(x):
                 pass
 
     return True
-""")
+"""
+        )
 
         items = parser.parse_file(str(test_file))
         assert len(items) == 2
 
-        parent = next(item for item in items if item.name == 'complex_parent')
-        nested = next(item for item in items if item.name == 'nested_complex')
+        parent = next(item for item in items if item.name == "complex_parent")
+        nested = next(item for item in items if item.name == "nested_complex")
 
         # Parent: base(1) + if(1) + elif(1) + for(1) + if(1) = 5
         # Should NOT include nested's: if(1) + while(1) + for(1) + if(1) = 4
-        assert parent.complexity == 5, \
-            f"Complex parent should have complexity 5, got {parent.complexity}. " \
+        assert parent.complexity == 5, (
+            f"Complex parent should have complexity 5, got {parent.complexity}. "
             "Nested function complexity should not contribute to parent."
+        )
 
         # Nested: base(1) + if(1) + while(1) + for(1) + if(1) = 5
-        assert nested.complexity == 5, \
-            f"Nested should have complexity 5, got {nested.complexity}"
+        assert (
+            nested.complexity == 5
+        ), f"Nested should have complexity 5, got {nested.complexity}"
 
     def test_complexity_method_with_nested_function(self, parser, tmp_path):
         """Test that nested function in class method has isolated complexity."""
         test_file = tmp_path / "method_nested.py"
-        test_file.write_text("""
+        test_file.write_text(
+            """
 class MyClass:
     def method_with_nested(self, x):
         '''Method with nested function.'''
@@ -512,26 +558,32 @@ class MyClass:
                 y += 1
 
         return True
-""")
+"""
+        )
 
         items = parser.parse_file(str(test_file))
         assert len(items) == 3  # class + method + nested function
 
-        method = next(item for item in items if item.name == 'MyClass.method_with_nested')
-        helper = next(item for item in items if item.name == 'helper')
+        method = next(
+            item for item in items if item.name == "MyClass.method_with_nested"
+        )
+        helper = next(item for item in items if item.name == "helper")
 
         # Method: base(1) + if(1) = 2
-        assert method.complexity == 2, \
-            f"Method should have complexity 2, got {method.complexity}"
+        assert (
+            method.complexity == 2
+        ), f"Method should have complexity 2, got {method.complexity}"
 
         # Helper: base(1) + if(1) + while(1) = 3
-        assert helper.complexity == 3, \
-            f"Helper should have complexity 3, got {helper.complexity}"
+        assert (
+            helper.complexity == 3
+        ), f"Helper should have complexity 3, got {helper.complexity}"
 
     def test_extracts_end_line_for_functions(self, parser, tmp_path):
         """Test that end_line is extracted correctly for functions."""
         test_file = tmp_path / "end_line_func.py"
-        test_file.write_text("""def simple_function():
+        test_file.write_text(
+            """def simple_function():
     '''Simple one-line function.'''
     return 42
 
@@ -541,13 +593,14 @@ def multi_line_function(x, y):
     if result > 10:
         return result * 2
     return result
-""")
+"""
+        )
 
         items = parser.parse_file(str(test_file))
         assert len(items) == 2
 
-        simple = next(item for item in items if item.name == 'simple_function')
-        multi = next(item for item in items if item.name == 'multi_line_function')
+        simple = next(item for item in items if item.name == "simple_function")
+        multi = next(item for item in items if item.name == "multi_line_function")
 
         # simple_function: lines 1-3
         assert simple.line_number == 1
@@ -560,7 +613,8 @@ def multi_line_function(x, y):
     def test_extracts_end_line_for_classes(self, parser, tmp_path):
         """Test that end_line is extracted correctly for classes."""
         test_file = tmp_path / "end_line_class.py"
-        test_file.write_text("""class SimpleClass:
+        test_file.write_text(
+            """class SimpleClass:
     '''Simple class.'''
     pass
 
@@ -574,12 +628,13 @@ class LargerClass:
     def method(self):
         '''A method.'''
         return self.value
-""")
+"""
+        )
 
         items = parser.parse_file(str(test_file))
 
-        simple_class = next(item for item in items if item.name == 'SimpleClass')
-        larger_class = next(item for item in items if item.name == 'LargerClass')
+        simple_class = next(item for item in items if item.name == "SimpleClass")
+        larger_class = next(item for item in items if item.name == "LargerClass")
 
         # SimpleClass: lines 1-3
         assert simple_class.line_number == 1
@@ -592,7 +647,8 @@ class LargerClass:
     def test_extracts_end_line_for_methods(self, parser, tmp_path):
         """Test that end_line is extracted correctly for methods."""
         test_file = tmp_path / "end_line_method.py"
-        test_file.write_text("""class MyClass:
+        test_file.write_text(
+            """class MyClass:
     def method_one(self):
         '''First method.'''
         return 1
@@ -602,12 +658,13 @@ class LargerClass:
         x = 10
         y = 20
         return x + y
-""")
+"""
+        )
 
         items = parser.parse_file(str(test_file))
 
-        method_one = next(item for item in items if item.name == 'MyClass.method_one')
-        method_two = next(item for item in items if item.name == 'MyClass.method_two')
+        method_one = next(item for item in items if item.name == "MyClass.method_one")
+        method_two = next(item for item in items if item.name == "MyClass.method_two")
 
         # method_one: lines 2-4
         assert method_one.line_number == 2
@@ -620,7 +677,8 @@ class LargerClass:
     def test_end_line_with_nested_functions(self, parser, tmp_path):
         """Test that end_line is correct for nested functions."""
         test_file = tmp_path / "end_line_nested.py"
-        test_file.write_text("""def outer():
+        test_file.write_text(
+            """def outer():
     '''Outer function.'''
     x = 1
 
@@ -629,13 +687,14 @@ class LargerClass:
         return x * 2
 
     return inner()
-""")
+"""
+        )
 
         items = parser.parse_file(str(test_file))
         assert len(items) == 2
 
-        outer = next(item for item in items if item.name == 'outer')
-        inner = next(item for item in items if item.name == 'inner')
+        outer = next(item for item in items if item.name == "outer")
+        inner = next(item for item in items if item.name == "inner")
 
         # outer: lines 1-9
         assert outer.line_number == 1
@@ -653,6 +712,7 @@ class TestTypeScriptParserErrorHandling:
     def parser(self):
         """Create a TypeScriptParser instance."""
         from src.parsers.typescript_parser import TypeScriptParser
+
         return TypeScriptParser()
 
     def test_malformed_json_with_nonzero_returncode_raises_runtimeerror(self, parser):
@@ -661,60 +721,62 @@ class TestTypeScriptParserErrorHandling:
         from unittest.mock import patch
         import subprocess
 
-        with tempfile.NamedTemporaryFile(suffix='.ts', delete=False) as tmp:
-            tmp.write(b'function test() {}')
+        with tempfile.NamedTemporaryFile(suffix=".ts", delete=False) as tmp:
+            tmp.write(b"function test() {}")
             tmp_path = tmp.name
 
         try:
             # Mock subprocess.run to return malformed JSON with nonzero returncode
             mock_result = subprocess.CompletedProcess(
-                args=['node', 'parser.js'],
+                args=["node", "parser.js"],
                 returncode=1,
-                stdout='not valid json',
-                stderr='some error'
+                stdout="not valid json",
+                stderr="some error",
             )
 
-            with patch('subprocess.run', return_value=mock_result):
+            with patch("subprocess.run", return_value=mock_result):
                 with pytest.raises(RuntimeError) as exc_info:
                     parser.parse_file(tmp_path)
 
                 # Check error message includes returncode and subprocess output
-                assert 'returncode=1' in str(exc_info.value)
-                assert 'some error' in str(exc_info.value)
-                assert 'not valid json' in str(exc_info.value)
+                assert "returncode=1" in str(exc_info.value)
+                assert "some error" in str(exc_info.value)
+                assert "not valid json" in str(exc_info.value)
         finally:
             Path(tmp_path).unlink()
 
     def test_malformed_json_with_zero_returncode_raises_runtimeerror(self, parser):
-        """Test that malformed JSON with returncode=0 raises RuntimeError (not SyntaxError)."""
+        """Test that malformed JSON with returncode=0 raises RuntimeError (not
+        SyntaxError)."""
         import tempfile
         from unittest.mock import patch
         import subprocess
 
-        with tempfile.NamedTemporaryFile(suffix='.ts', delete=False) as tmp:
-            tmp.write(b'function test() {}')
+        with tempfile.NamedTemporaryFile(suffix=".ts", delete=False) as tmp:
+            tmp.write(b"function test() {}")
             tmp_path = tmp.name
 
         try:
             # Mock subprocess.run to return malformed JSON with returncode=0
             # This simulates a crash or bug in the parser helper
             mock_result = subprocess.CompletedProcess(
-                args=['node', 'parser.js'],
+                args=["node", "parser.js"],
                 returncode=0,
-                stdout='not valid json',
-                stderr=''
+                stdout="not valid json",
+                stderr="",
             )
 
-            with patch('subprocess.run', return_value=mock_result):
-                # Should raise RuntimeError (infrastructure issue), not SyntaxError (user code issue)
+            with patch("subprocess.run", return_value=mock_result):
+                # Should raise RuntimeError (infrastructure issue), not
+                # SyntaxError (user code issue)
                 with pytest.raises(RuntimeError) as exc_info:
                     parser.parse_file(tmp_path)
 
                 # Check error message clearly indicates this is a parser helper issue
-                assert 'returncode=0' in str(exc_info.value)
-                assert 'invalid JSON' in str(exc_info.value)
-                assert 'parser helper' in str(exc_info.value).lower()
-                assert 'not valid json' in str(exc_info.value)
+                assert "returncode=0" in str(exc_info.value)
+                assert "invalid JSON" in str(exc_info.value)
+                assert "parser helper" in str(exc_info.value).lower()
+                assert "not valid json" in str(exc_info.value)
         finally:
             Path(tmp_path).unlink()
 
@@ -724,26 +786,26 @@ class TestTypeScriptParserErrorHandling:
         from unittest.mock import patch
         import subprocess
 
-        with tempfile.NamedTemporaryFile(suffix='.ts', delete=False) as tmp:
-            tmp.write(b'function test() {}')
+        with tempfile.NamedTemporaryFile(suffix=".ts", delete=False) as tmp:
+            tmp.write(b"function test() {}")
             tmp_path = tmp.name
 
         try:
             # Mock subprocess.run to return malformed JSON
             mock_result = subprocess.CompletedProcess(
-                args=['node', 'parser.js'],
+                args=["node", "parser.js"],
                 returncode=1,
-                stdout='stdout content',
-                stderr='stderr content'
+                stdout="stdout content",
+                stderr="stderr content",
             )
 
-            with patch('subprocess.run', return_value=mock_result):
+            with patch("subprocess.run", return_value=mock_result):
                 with pytest.raises(RuntimeError) as exc_info:
                     parser.parse_file(tmp_path)
 
                 # Error message should include both stdout and stderr
                 error_msg = str(exc_info.value)
-                assert 'stdout content' in error_msg
-                assert 'stderr content' in error_msg
+                assert "stdout content" in error_msg
+                assert "stderr content" in error_msg
         finally:
             Path(tmp_path).unlink()

--- a/analyzer/tests/test_plan_generator.py
+++ b/analyzer/tests/test_plan_generator.py
@@ -23,78 +23,78 @@ class TestPlanGenerator:
         """Return a list of sample CodeItems for testing."""
         return [
             CodeItem(
-                name='undocumented_func',
-                type='function',
-                filepath='test.py',
+                name="undocumented_func",
+                type="function",
+                filepath="test.py",
                 line_number=1,
                 end_line=10,
-                language='python',
+                language="python",
                 complexity=10,
                 has_docs=False,
-                export_type='internal',
-                module_system='unknown',
+                export_type="internal",
+                module_system="unknown",
                 impact_score=50.0,
-                audit_rating=None
+                audit_rating=None,
             ),
             CodeItem(
-                name='documented_terrible',
-                type='function',
-                filepath='test.py',
+                name="documented_terrible",
+                type="function",
+                filepath="test.py",
                 line_number=10,
                 end_line=18,
-                language='python',
+                language="python",
                 complexity=8,
                 has_docs=True,
-                export_type='internal',
-                module_system='unknown',
+                export_type="internal",
+                module_system="unknown",
                 impact_score=40.0,
                 audit_rating=None,
-                docstring='Terrible docs'
+                docstring="Terrible docs",
             ),
             CodeItem(
-                name='documented_ok',
-                type='function',
-                filepath='test.py',
+                name="documented_ok",
+                type="function",
+                filepath="test.py",
                 line_number=20,
                 end_line=26,
-                language='python',
+                language="python",
                 complexity=6,
                 has_docs=True,
-                export_type='internal',
-                module_system='unknown',
+                export_type="internal",
+                module_system="unknown",
                 impact_score=30.0,
                 audit_rating=None,
-                docstring='OK docs'
+                docstring="OK docs",
             ),
             CodeItem(
-                name='documented_good',
-                type='function',
-                filepath='test.py',
+                name="documented_good",
+                type="function",
+                filepath="test.py",
                 line_number=30,
                 end_line=35,
-                language='python',
+                language="python",
                 complexity=5,
                 has_docs=True,
-                export_type='internal',
-                module_system='unknown',
+                export_type="internal",
+                module_system="unknown",
                 impact_score=25.0,
                 audit_rating=None,
-                docstring='Good docs'
+                docstring="Good docs",
             ),
             CodeItem(
-                name='documented_excellent',
-                type='function',
-                filepath='test.py',
+                name="documented_excellent",
+                type="function",
+                filepath="test.py",
                 line_number=40,
                 end_line=44,
-                language='python',
+                language="python",
                 complexity=4,
                 has_docs=True,
-                export_type='internal',
-                module_system='unknown',
+                export_type="internal",
+                module_system="unknown",
                 impact_score=20.0,
                 audit_rating=None,
-                docstring='Excellent docs'
+                docstring="Excellent docs",
             ),
         ]
 
@@ -107,25 +107,25 @@ class TestPlanGenerator:
             total_items=5,
             documented_items=4,
             by_language={
-                'python': LanguageMetrics(
-                    language='python',
+                "python": LanguageMetrics(
+                    language="python",
                     total_items=5,
                     documented_items=4,
                     coverage_percent=80.0,
                     avg_complexity=6.6,
-                    avg_impact_score=33.0
+                    avg_impact_score=33.0,
                 )
-            }
+            },
         )
 
     @pytest.fixture
     def sample_audit(self):
         """Return a sample AuditResult for testing."""
         audit = AuditResult(ratings={})
-        audit.set_rating('test.py', 'documented_terrible', 1)  # Terrible
-        audit.set_rating('test.py', 'documented_ok', 2)  # OK
-        audit.set_rating('test.py', 'documented_good', 3)  # Good
-        audit.set_rating('test.py', 'documented_excellent', 4)  # Excellent
+        audit.set_rating("test.py", "documented_terrible", 1)  # Terrible
+        audit.set_rating("test.py", "documented_ok", 2)  # OK
+        audit.set_rating("test.py", "documented_good", 3)  # Good
+        audit.set_rating("test.py", "documented_excellent", 4)  # Excellent
         return audit
 
     def test_generate_plan_with_audit_file_none(self, sample_result):
@@ -133,16 +133,17 @@ class TestPlanGenerator:
         # Call with audit_file=None to test StateManager fallback
         plan = generate_plan(sample_result, audit_file=None)
 
-        # Should include only undocumented items (StateManager default likely doesn't exist)
+        # Should include only undocumented items (StateManager default likely
+        # doesn't exist)
         assert plan.total_items == 1
         assert plan.missing_docs_count == 1
         assert plan.poor_quality_count == 0
-        assert plan.items[0].name == 'undocumented_func'
+        assert plan.items[0].name == "undocumented_func"
 
     def test_generate_plan_with_nonexistent_audit_file(self, sample_result):
         """Test graceful degradation when explicit audit file path doesn't exist."""
         # Use explicit non-existent path (different from None/StateManager fallback)
-        audit_file = Path('/tmp/nonexistent_audit_file_12345.json')
+        audit_file = Path("/tmp/nonexistent_audit_file_12345.json")
         assert not audit_file.exists()
 
         # Should not crash
@@ -152,12 +153,12 @@ class TestPlanGenerator:
         assert plan.total_items == 1
         assert plan.missing_docs_count == 1
         assert plan.poor_quality_count == 0
-        assert plan.items[0].name == 'undocumented_func'
+        assert plan.items[0].name == "undocumented_func"
 
     def test_generate_plan_applies_audit_ratings(self, sample_result, sample_audit):
         """Test that audit ratings are applied to items."""
         # Save audit to temp file
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
             audit_file = Path(tmp.name)
             save_audit_results(sample_audit, audit_file)
 
@@ -166,10 +167,16 @@ class TestPlanGenerator:
             _ = generate_plan(sample_result, audit_file=audit_file)
 
             # Find the items in the original result to verify ratings were applied
-            terrible_item = next(i for i in sample_result.items if i.name == 'documented_terrible')
-            ok_item = next(i for i in sample_result.items if i.name == 'documented_ok')
-            good_item = next(i for i in sample_result.items if i.name == 'documented_good')
-            excellent_item = next(i for i in sample_result.items if i.name == 'documented_excellent')
+            terrible_item = next(
+                i for i in sample_result.items if i.name == "documented_terrible"
+            )
+            ok_item = next(i for i in sample_result.items if i.name == "documented_ok")
+            good_item = next(
+                i for i in sample_result.items if i.name == "documented_good"
+            )
+            excellent_item = next(
+                i for i in sample_result.items if i.name == "documented_excellent"
+            )
 
             # Verify ratings were applied
             assert terrible_item.audit_rating == 1
@@ -179,13 +186,15 @@ class TestPlanGenerator:
         finally:
             audit_file.unlink()
 
-    def test_generate_plan_recalculates_impact_scores(self, sample_result, sample_audit):
+    def test_generate_plan_recalculates_impact_scores(
+        self, sample_result, sample_audit
+    ):
         """Test that impact scores are recalculated with audit ratings."""
         # Save initial scores
         initial_scores = {item.name: item.impact_score for item in sample_result.items}
 
         # Save audit to temp file
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
             audit_file = Path(tmp.name)
             save_audit_results(sample_audit, audit_file)
 
@@ -194,12 +203,15 @@ class TestPlanGenerator:
             _ = generate_plan(sample_result, audit_file=audit_file)
 
             # Verify impact scores changed for items with audit ratings
-            terrible_item = next(i for i in sample_result.items if i.name == 'documented_terrible')
-            ok_item = next(i for i in sample_result.items if i.name == 'documented_ok')
+            terrible_item = next(
+                i for i in sample_result.items if i.name == "documented_terrible"
+            )
+            ok_item = next(i for i in sample_result.items if i.name == "documented_ok")
 
-            # Impact scores should be different from initial (because audit ratings were applied)
-            assert terrible_item.impact_score != initial_scores['documented_terrible']
-            assert ok_item.impact_score != initial_scores['documented_ok']
+            # Impact scores should be different from initial (because audit
+            # ratings were applied)
+            assert terrible_item.impact_score != initial_scores["documented_terrible"]
+            assert ok_item.impact_score != initial_scores["documented_ok"]
 
             # Impact score for terrible docs should be higher than for OK docs
             # (both have audit ratings applied, but terrible gets higher penalty)
@@ -207,16 +219,20 @@ class TestPlanGenerator:
         finally:
             audit_file.unlink()
 
-    def test_generate_plan_filters_by_quality_threshold(self, sample_result, sample_audit):
+    def test_generate_plan_filters_by_quality_threshold(
+        self, sample_result, sample_audit
+    ):
         """Test that only poor quality items are included based on threshold."""
         # Save audit to temp file
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
             audit_file = Path(tmp.name)
             save_audit_results(sample_audit, audit_file)
 
         try:
             # Generate plan with threshold=2 (include Terrible=1 and OK=2)
-            plan = generate_plan(sample_result, audit_file=audit_file, quality_threshold=2)
+            plan = generate_plan(
+                sample_result, audit_file=audit_file, quality_threshold=2
+            )
 
             # Should include: undocumented + terrible + ok
             assert plan.total_items == 3
@@ -225,11 +241,11 @@ class TestPlanGenerator:
 
             # Verify the items
             item_names = {item.name for item in plan.items}
-            assert 'undocumented_func' in item_names
-            assert 'documented_terrible' in item_names
-            assert 'documented_ok' in item_names
-            assert 'documented_good' not in item_names
-            assert 'documented_excellent' not in item_names
+            assert "undocumented_func" in item_names
+            assert "documented_terrible" in item_names
+            assert "documented_ok" in item_names
+            assert "documented_good" not in item_names
+            assert "documented_excellent" not in item_names
         finally:
             audit_file.unlink()
 
@@ -237,12 +253,12 @@ class TestPlanGenerator:
         """Test that ratings are matched correctly by filepath and name."""
         # Create audit with rating for different file
         audit = AuditResult(ratings={})
-        audit.set_rating('other.py', 'documented_terrible', 1)  # Different file
-        audit.set_rating('test.py', 'wrong_name', 1)  # Different name
-        audit.set_rating('test.py', 'documented_terrible', 1)  # Correct match
+        audit.set_rating("other.py", "documented_terrible", 1)  # Different file
+        audit.set_rating("test.py", "wrong_name", 1)  # Different name
+        audit.set_rating("test.py", "documented_terrible", 1)  # Correct match
 
         # Save audit to temp file
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
             audit_file = Path(tmp.name)
             save_audit_results(audit, audit_file)
 
@@ -251,8 +267,10 @@ class TestPlanGenerator:
             _ = generate_plan(sample_result, audit_file=audit_file)
 
             # Only the correct match should have audit rating applied
-            terrible_item = next(i for i in sample_result.items if i.name == 'documented_terrible')
-            ok_item = next(i for i in sample_result.items if i.name == 'documented_ok')
+            terrible_item = next(
+                i for i in sample_result.items if i.name == "documented_terrible"
+            )
+            ok_item = next(i for i in sample_result.items if i.name == "documented_ok")
 
             assert terrible_item.audit_rating == 1
             assert ok_item.audit_rating is None  # No rating in audit
@@ -263,11 +281,11 @@ class TestPlanGenerator:
         """Test that items without audit ratings are handled correctly."""
         # Create audit with only some items rated
         audit = AuditResult(ratings={})
-        audit.set_rating('test.py', 'documented_terrible', 1)
+        audit.set_rating("test.py", "documented_terrible", 1)
         # Don't rate the other items
 
         # Save audit to temp file
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
             audit_file = Path(tmp.name)
             save_audit_results(audit, audit_file)
 
@@ -282,8 +300,8 @@ class TestPlanGenerator:
             assert plan.poor_quality_count == 1
 
             item_names = {item.name for item in plan.items}
-            assert 'undocumented_func' in item_names
-            assert 'documented_terrible' in item_names
+            assert "undocumented_func" in item_names
+            assert "documented_terrible" in item_names
         finally:
             audit_file.unlink()
 
@@ -291,12 +309,12 @@ class TestPlanGenerator:
         """Test that invalid ratings are skipped and valid ratings are applied."""
         # Create audit with mix of valid and invalid ratings
         audit = AuditResult(ratings={})
-        audit.set_rating('test.py', 'documented_terrible', 999)  # Invalid!
-        audit.set_rating('test.py', 'documented_ok', 2)  # Valid
-        audit.set_rating('test.py', 'documented_good', 0)  # Invalid!
+        audit.set_rating("test.py", "documented_terrible", 999)  # Invalid!
+        audit.set_rating("test.py", "documented_ok", 2)  # Valid
+        audit.set_rating("test.py", "documented_good", 0)  # Invalid!
 
         # Save audit to temp file
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
             audit_file = Path(tmp.name)
             save_audit_results(audit, audit_file)
 
@@ -305,9 +323,13 @@ class TestPlanGenerator:
             _ = generate_plan(sample_result, audit_file=audit_file)
 
             # Verify invalid ratings were skipped
-            terrible_item = next(i for i in sample_result.items if i.name == 'documented_terrible')
-            ok_item = next(i for i in sample_result.items if i.name == 'documented_ok')
-            good_item = next(i for i in sample_result.items if i.name == 'documented_good')
+            terrible_item = next(
+                i for i in sample_result.items if i.name == "documented_terrible"
+            )
+            ok_item = next(i for i in sample_result.items if i.name == "documented_ok")
+            good_item = next(
+                i for i in sample_result.items if i.name == "documented_good"
+            )
 
             # Only valid rating should be applied
             assert terrible_item.audit_rating is None  # Invalid rating skipped
@@ -320,12 +342,12 @@ class TestPlanGenerator:
         """Test that invalid_ratings_count is accurate."""
         # Create audit with invalid ratings
         audit = AuditResult(ratings={})
-        audit.set_rating('test.py', 'documented_terrible', 999)  # Invalid
-        audit.set_rating('test.py', 'documented_ok', 0)  # Invalid
-        audit.set_rating('test.py', 'documented_good', -1)  # Invalid
+        audit.set_rating("test.py", "documented_terrible", 999)  # Invalid
+        audit.set_rating("test.py", "documented_ok", 0)  # Invalid
+        audit.set_rating("test.py", "documented_good", -1)  # Invalid
 
         # Save audit to temp file
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
             audit_file = Path(tmp.name)
             save_audit_results(audit, audit_file)
 
@@ -342,12 +364,12 @@ class TestPlanGenerator:
         """Test that invalid_ratings list contains correct details."""
         # Create audit with invalid ratings
         audit = AuditResult(ratings={})
-        audit.set_rating('test.py', 'documented_terrible', 999)
-        audit.set_rating('test.py', 'documented_ok', 2)  # Valid
-        audit.set_rating('test.py', 'documented_good', 5)
+        audit.set_rating("test.py", "documented_terrible", 999)
+        audit.set_rating("test.py", "documented_ok", 2)  # Valid
+        audit.set_rating("test.py", "documented_good", 5)
 
         # Save audit to temp file
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
             audit_file = Path(tmp.name)
             save_audit_results(audit, audit_file)
 
@@ -357,8 +379,16 @@ class TestPlanGenerator:
 
             # Verify details are correct
             assert len(plan.invalid_ratings) == 2
-            assert {'filepath': 'test.py', 'name': 'documented_terrible', 'rating': 999} in plan.invalid_ratings
-            assert {'filepath': 'test.py', 'name': 'documented_good', 'rating': 5} in plan.invalid_ratings
+            assert {
+                "filepath": "test.py",
+                "name": "documented_terrible",
+                "rating": 999,
+            } in plan.invalid_ratings
+            assert {
+                "filepath": "test.py",
+                "name": "documented_good",
+                "rating": 5,
+            } in plan.invalid_ratings
         finally:
             audit_file.unlink()
 
@@ -366,13 +396,13 @@ class TestPlanGenerator:
         """Test edge cases for invalid ratings."""
         # Create audit with boundary invalid ratings
         audit = AuditResult(ratings={})
-        audit.set_rating('test.py', 'documented_terrible', 0)  # Just below valid range
-        audit.set_rating('test.py', 'documented_ok', 5)  # Just above valid range
-        audit.set_rating('test.py', 'documented_good', -1)  # Negative
-        audit.set_rating('test.py', 'documented_excellent', 1)  # Valid
+        audit.set_rating("test.py", "documented_terrible", 0)  # Just below valid range
+        audit.set_rating("test.py", "documented_ok", 5)  # Just above valid range
+        audit.set_rating("test.py", "documented_good", -1)  # Negative
+        audit.set_rating("test.py", "documented_excellent", 1)  # Valid
 
         # Save audit to temp file
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
             audit_file = Path(tmp.name)
             save_audit_results(audit, audit_file)
 
@@ -384,7 +414,9 @@ class TestPlanGenerator:
             assert plan.invalid_ratings_count == 3
 
             # Verify only valid rating was applied
-            excellent_item = next(i for i in sample_result.items if i.name == 'documented_excellent')
+            excellent_item = next(
+                i for i in sample_result.items if i.name == "documented_excellent"
+            )
             assert excellent_item.audit_rating == 1
         finally:
             audit_file.unlink()
@@ -392,12 +424,12 @@ class TestPlanGenerator:
     def test_generate_plan_matches_relative_to_absolute_paths(self, sample_result):
         """Test that relative paths in analysis match absolute paths in audit."""
         # Create audit with absolute path
-        absolute_path = str(Path('test.py').resolve())
+        absolute_path = str(Path("test.py").resolve())
         audit = AuditResult(ratings={})
-        audit.set_rating(absolute_path, 'documented_terrible', 1)
+        audit.set_rating(absolute_path, "documented_terrible", 1)
 
         # Save audit to temp file
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
             audit_file = Path(tmp.name)
             save_audit_results(audit, audit_file)
 
@@ -407,7 +439,9 @@ class TestPlanGenerator:
             _ = generate_plan(sample_result, audit_file=audit_file)
 
             # Verify rating was matched and applied
-            terrible_item = next(i for i in sample_result.items if i.name == 'documented_terrible')
+            terrible_item = next(
+                i for i in sample_result.items if i.name == "documented_terrible"
+            )
             assert terrible_item.audit_rating == 1
         finally:
             audit_file.unlink()
@@ -415,36 +449,36 @@ class TestPlanGenerator:
     def test_generate_plan_matches_absolute_to_relative_paths(self):
         """Test that absolute paths in analysis match relative paths in audit."""
         # Create item with absolute path
-        absolute_path = str(Path('test.py').resolve())
+        absolute_path = str(Path("test.py").resolve())
         item = CodeItem(
-            name='documented_terrible',
-            type='function',
+            name="documented_terrible",
+            type="function",
             filepath=absolute_path,
             line_number=1,
             end_line=10,
-            language='python',
+            language="python",
             complexity=10,
             has_docs=True,
-            export_type='internal',
-            module_system='unknown',
+            export_type="internal",
+            module_system="unknown",
             impact_score=50.0,
             audit_rating=None,
-            docstring='Terrible docs'
+            docstring="Terrible docs",
         )
         result = AnalysisResult(
             items=[item],
             coverage_percent=100.0,
             total_items=1,
             documented_items=1,
-            by_language={}
+            by_language={},
         )
 
         # Create audit with relative path
         audit = AuditResult(ratings={})
-        audit.set_rating('test.py', 'documented_terrible', 1)
+        audit.set_rating("test.py", "documented_terrible", 1)
 
         # Save audit to temp file
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
             audit_file = Path(tmp.name)
             save_audit_results(audit, audit_file)
 
@@ -461,34 +495,34 @@ class TestPlanGenerator:
         """Test that paths with ./ prefix are normalized correctly."""
         # Create item with ./ prefix
         item = CodeItem(
-            name='documented_terrible',
-            type='function',
-            filepath='./test.py',
+            name="documented_terrible",
+            type="function",
+            filepath="./test.py",
             line_number=1,
             end_line=10,
-            language='python',
+            language="python",
             complexity=10,
             has_docs=True,
-            export_type='internal',
-            module_system='unknown',
+            export_type="internal",
+            module_system="unknown",
             impact_score=50.0,
             audit_rating=None,
-            docstring='Terrible docs'
+            docstring="Terrible docs",
         )
         result = AnalysisResult(
             items=[item],
             coverage_percent=100.0,
             total_items=1,
             documented_items=1,
-            by_language={}
+            by_language={},
         )
 
         # Create audit with simple relative path
         audit = AuditResult(ratings={})
-        audit.set_rating('test.py', 'documented_terrible', 1)
+        audit.set_rating("test.py", "documented_terrible", 1)
 
         # Save audit to temp file
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
             audit_file = Path(tmp.name)
             save_audit_results(audit, audit_file)
 
@@ -505,34 +539,34 @@ class TestPlanGenerator:
         """Test that paths with .. components are normalized correctly."""
         # Create item with .. component (e.g., foo/../test.py -> test.py)
         item = CodeItem(
-            name='documented_terrible',
-            type='function',
-            filepath='foo/../test.py',
+            name="documented_terrible",
+            type="function",
+            filepath="foo/../test.py",
             line_number=1,
             end_line=10,
-            language='python',
+            language="python",
             complexity=10,
             has_docs=True,
-            export_type='internal',
-            module_system='unknown',
+            export_type="internal",
+            module_system="unknown",
             impact_score=50.0,
             audit_rating=None,
-            docstring='Terrible docs'
+            docstring="Terrible docs",
         )
         result = AnalysisResult(
             items=[item],
             coverage_percent=100.0,
             total_items=1,
             documented_items=1,
-            by_language={}
+            by_language={},
         )
 
         # Create audit with simple relative path
         audit = AuditResult(ratings={})
-        audit.set_rating('test.py', 'documented_terrible', 1)
+        audit.set_rating("test.py", "documented_terrible", 1)
 
         # Save audit to temp file
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
             audit_file = Path(tmp.name)
             save_audit_results(audit, audit_file)
 
@@ -540,14 +574,15 @@ class TestPlanGenerator:
             # Generate plan (side effect: applies ratings to matching items)
             _ = generate_plan(result, audit_file=audit_file)
 
-            # Verify rating was matched and applied (foo/../test.py should match test.py)
+            # Verify rating was matched and applied (foo/../test.py should
+            # match test.py)
             assert item.audit_rating == 1
         finally:
             audit_file.unlink()
 
     def test_generate_plan_handles_corrupted_audit_json(self, sample_result):
         """Test graceful handling of corrupted audit JSON."""
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
             audit_file = Path(tmp.name)
             tmp.write("{invalid json content")
 
@@ -563,7 +598,7 @@ class TestPlanGenerator:
     def test_generate_plan_handles_empty_audit(self, sample_result):
         """Test handling of audit file with no ratings."""
         audit = AuditResult(ratings={})
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
             audit_file = Path(tmp.name)
             save_audit_results(audit, audit_file)
 
@@ -576,7 +611,7 @@ class TestPlanGenerator:
 
     def test_generate_plan_idempotency(self, sample_result, sample_audit):
         """Test calling generate_plan twice with same result."""
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as tmp:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
             audit_file = Path(tmp.name)
             save_audit_results(sample_audit, audit_file)
 
@@ -590,16 +625,20 @@ class TestPlanGenerator:
         finally:
             audit_file.unlink()
 
-    def test_generate_plan_handles_scorer_exception(self, sample_result, sample_audit, monkeypatch):
+    def test_generate_plan_handles_scorer_exception(
+        self, sample_result, sample_audit, monkeypatch
+    ):
         """Test handling of ImpactScorer exceptions."""
+
         def mock_calculate_score(self, item):
             raise ValueError("Scoring error")
 
         # Mock ImpactScorer.calculate_score to raise exception
         from src.scoring.impact_scorer import ImpactScorer
-        monkeypatch.setattr(ImpactScorer, 'calculate_score', mock_calculate_score)
 
-        with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as tmp:
+        monkeypatch.setattr(ImpactScorer, "calculate_score", mock_calculate_score)
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tmp:
             audit_file = Path(tmp.name)
             save_audit_results(sample_audit, audit_file)
 
@@ -624,7 +663,7 @@ class TestPlanGenerator:
 
         # Check that all plan items have end_line field
         for plan_item in plan.items:
-            assert hasattr(plan_item, 'end_line')
+            assert hasattr(plan_item, "end_line")
             assert isinstance(plan_item.end_line, int)
             assert plan_item.end_line > 0
             # end_line should be >= line_number (inclusive range)
@@ -633,15 +672,13 @@ class TestPlanGenerator:
         # Verify end_line matches the source CodeItem
         # Find the undocumented item in plan
         undoc_plan_item = next(
-            (item for item in plan.items if item.name == 'undocumented_func'),
-            None
+            (item for item in plan.items if item.name == "undocumented_func"), None
         )
         assert undoc_plan_item is not None
 
         # Find the corresponding CodeItem
         undoc_code_item = next(
-            (item for item in sample_items if item.name == 'undocumented_func'),
-            None
+            (item for item in sample_items if item.name == "undocumented_func"), None
         )
         assert undoc_code_item is not None
 

--- a/analyzer/tests/test_post_squash_rollback.py
+++ b/analyzer/tests/test_post_squash_rollback.py
@@ -21,34 +21,31 @@ class TestPostSquashRollback:
         """Test reverting a change after session has been squashed to main."""
         with tempfile.TemporaryDirectory() as tmpdir:
             manager = TransactionManager(base_path=Path(tmpdir))
-            manifest = manager.begin_transaction('test-session')
+            manifest = manager.begin_transaction("test-session")
 
             # Create and commit first change
-            file1 = Path(tmpdir) / 'file1.py'
-            file1.write_text('def func1(): pass')
+            file1 = Path(tmpdir) / "file1.py"
+            file1.write_text("def func1(): pass")
             manager.record_write(
-                manifest, str(file1), f'{file1}.bak',
-                'func1', 'function', 'python'
+                manifest, str(file1), f"{file1}.bak", "func1", "function", "python"
             )
 
             # Create and commit second change
-            file2 = Path(tmpdir) / 'file2.py'
-            file2.write_text('def func2(): pass')
+            file2 = Path(tmpdir) / "file2.py"
+            file2.write_text("def func2(): pass")
             manager.record_write(
-                manifest, str(file2), f'{file2}.bak',
-                'func2', 'function', 'python'
+                manifest, str(file2), f"{file2}.bak", "func2", "function", "python"
             )
 
             # Create and commit third change
-            file3 = Path(tmpdir) / 'file3.py'
-            file3.write_text('def func3(): pass')
+            file3 = Path(tmpdir) / "file3.py"
+            file3.write_text("def func3(): pass")
             manager.record_write(
-                manifest, str(file3), f'{file3}.bak',
-                'func3', 'function', 'python'
+                manifest, str(file3), f"{file3}.bak", "func3", "function", "python"
             )
 
             # Get entry IDs
-            changes = manager.list_session_changes('test-session')
+            changes = manager.list_session_changes("test-session")
             assert len(changes) == 3
             second_change_id = changes[1].entry_id
 
@@ -57,13 +54,14 @@ class TestPostSquashRollback:
 
             # Verify session branch still exists
             from src.utils.git_helper import GitHelper
+
             branch_result = GitHelper.run_git_command(
-                ['branch', '--list', 'docimp/session-test-session'],
+                ["branch", "--list", "docimp/session-test-session"],
                 Path(tmpdir),
-                check=False
+                check=False,
             )
             assert branch_result.returncode == 0
-            assert 'docimp/session-test-session' in branch_result.stdout
+            assert "docimp/session-test-session" in branch_result.stdout
 
             # Now rollback the second change (post-squash)
             result = manager.rollback_change(second_change_id)
@@ -73,42 +71,43 @@ class TestPostSquashRollback:
             assert result.restored_count == 1
             assert result.failed_count == 0
             assert len(result.conflicts) == 0
-            assert result.status == 'completed'
+            assert result.status == "completed"
 
             # Verify main branch has new squash commit with reverted change message
             log_result = GitHelper.run_git_command(
-                ['log', '--oneline', '-1', 'main'],  # Just check most recent commit
-                Path(tmpdir)
+                ["log", "--oneline", "-1", "main"],  # Just check most recent commit
+                Path(tmpdir),
             )
             # Should see new squash commit mentioning the reverted change
-            assert 'squash' in log_result.stdout.lower() and 'revert' in log_result.stdout.lower()
+            assert (
+                "squash" in log_result.stdout.lower()
+                and "revert" in log_result.stdout.lower()
+            )
 
             # Verify session branch still exists (preserved)
             branch_result = GitHelper.run_git_command(
-                ['branch', '--list', 'docimp/session-test-session'],
-                Path(tmpdir)
+                ["branch", "--list", "docimp/session-test-session"], Path(tmpdir)
             )
-            assert 'docimp/session-test-session' in branch_result.stdout
+            assert "docimp/session-test-session" in branch_result.stdout
 
     def test_rollback_multiple_changes_from_committed_session(self):
         """Test reverting multiple changes from a committed session."""
         with tempfile.TemporaryDirectory() as tmpdir:
             manager = TransactionManager(base_path=Path(tmpdir))
-            manifest = manager.begin_transaction('test-session')
+            manifest = manager.begin_transaction("test-session")
 
             # Create three changes
             files = []
             for i in range(3):
-                file = Path(tmpdir) / f'file{i}.py'
-                file.write_text(f'def func{i}(): pass')
+                file = Path(tmpdir) / f"file{i}.py"
+                file.write_text(f"def func{i}(): pass")
                 manager.record_write(
-                    manifest, str(file), f'{file}.bak',
-                    f'func{i}', 'function', 'python'
+                    manifest, str(file), f"{file}.bak", f"func{i}", "function", "python"
                 )
                 files.append(file)
 
             # Get entry IDs
-            changes = manager.list_session_changes('test-session')
+            changes = manager.list_session_changes("test-session")
             assert len(changes) == 3
 
             # Commit the session
@@ -125,17 +124,16 @@ class TestPostSquashRollback:
         """Test error handling when session branch was deleted."""
         with tempfile.TemporaryDirectory() as tmpdir:
             manager = TransactionManager(base_path=Path(tmpdir))
-            manifest = manager.begin_transaction('test-session')
+            manifest = manager.begin_transaction("test-session")
 
             # Create a change
-            file = Path(tmpdir) / 'test.py'
-            file.write_text('def func(): pass')
+            file = Path(tmpdir) / "test.py"
+            file.write_text("def func(): pass")
             manager.record_write(
-                manifest, str(file), f'{file}.bak',
-                'func', 'function', 'python'
+                manifest, str(file), f"{file}.bak", "func", "function", "python"
             )
 
-            changes = manager.list_session_changes('test-session')
+            changes = manager.list_session_changes("test-session")
             change_id = changes[0].entry_id
 
             # Commit session
@@ -143,14 +141,15 @@ class TestPostSquashRollback:
 
             # Manually delete session branch (simulating cleanup)
             from src.utils.git_helper import GitHelper
+
             GitHelper.run_git_command(
-                ['branch', '-D', 'docimp/session-test-session'],
+                ["branch", "-D", "docimp/session-test-session"],
                 Path(tmpdir),
-                check=False
+                check=False,
             )
 
             # Update manifest status to committed (simulate production scenario)
-            manifest.status = 'committed'
+            manifest.status = "committed"
 
             # Try to rollback - should fail when entry not found
             # (Since branch is deleted, _find_entry_by_id won't find it)
@@ -165,24 +164,22 @@ class TestPostSquashRollback:
         """Test conflict handling during post-squash rollback."""
         with tempfile.TemporaryDirectory() as tmpdir:
             manager = TransactionManager(base_path=Path(tmpdir))
-            manifest = manager.begin_transaction('test-session')
+            manifest = manager.begin_transaction("test-session")
 
             # Create first change
-            file = Path(tmpdir) / 'test.py'
-            file.write_text('def func(): pass')
+            file = Path(tmpdir) / "test.py"
+            file.write_text("def func(): pass")
             manager.record_write(
-                manifest, str(file), f'{file}.bak',
-                'func', 'function', 'python'
+                manifest, str(file), f"{file}.bak", "func", "function", "python"
             )
 
             # Create second change to same file
-            file.write_text('def func(): return 42')
+            file.write_text("def func(): return 42")
             manager.record_write(
-                manifest, str(file), f'{file}.bak',
-                'func', 'function', 'python'
+                manifest, str(file), f"{file}.bak", "func", "function", "python"
             )
 
-            changes = manager.list_session_changes('test-session')
+            changes = manager.list_session_changes("test-session")
             first_change_id = changes[0].entry_id
 
             # Commit session
@@ -195,10 +192,9 @@ class TestPostSquashRollback:
             from src.utils.git_helper import GitHelper
 
             # Add and commit the conflicting change directly to main
-            GitHelper.run_git_command(['add', str(file)], Path(tmpdir))
+            GitHelper.run_git_command(["add", str(file)], Path(tmpdir))
             GitHelper.run_git_command(
-                ['commit', '-m', 'Conflicting change'],
-                Path(tmpdir)
+                ["commit", "-m", "Conflicting change"], Path(tmpdir)
             )
 
             # Try to rollback first change - should detect conflict
@@ -207,24 +203,23 @@ class TestPostSquashRollback:
             # Should fail due to conflict
             assert result.success is False
             assert result.failed_count == 1
-            assert result.status == 'failed'
+            assert result.status == "failed"
 
     def test_session_branch_preserved_after_resquash(self):
         """Test that session branch remains after re-squash merge."""
         with tempfile.TemporaryDirectory() as tmpdir:
             manager = TransactionManager(base_path=Path(tmpdir))
-            manifest = manager.begin_transaction('test-session')
+            manifest = manager.begin_transaction("test-session")
 
             # Create changes
             for i in range(2):
-                file = Path(tmpdir) / f'file{i}.py'
-                file.write_text(f'def func{i}(): pass')
+                file = Path(tmpdir) / f"file{i}.py"
+                file.write_text(f"def func{i}(): pass")
                 manager.record_write(
-                    manifest, str(file), f'{file}.bak',
-                    f'func{i}', 'function', 'python'
+                    manifest, str(file), f"{file}.bak", f"func{i}", "function", "python"
                 )
 
-            changes = manager.list_session_changes('test-session')
+            changes = manager.list_session_changes("test-session")
 
             # Commit session
             manager.commit_transaction(manifest)
@@ -234,16 +229,15 @@ class TestPostSquashRollback:
 
             # Verify session branch still exists
             from src.utils.git_helper import GitHelper
+
             branch_result = GitHelper.run_git_command(
-                ['branch', '--list', 'docimp/session-test-session'],
-                Path(tmpdir)
+                ["branch", "--list", "docimp/session-test-session"], Path(tmpdir)
             )
-            assert 'docimp/session-test-session' in branch_result.stdout
+            assert "docimp/session-test-session" in branch_result.stdout
 
             # Verify session branch has revert commit
             log_result = GitHelper.run_git_command(
-                ['log', '--oneline', '--all', '--grep=Revert'],
-                Path(tmpdir)
+                ["log", "--oneline", "--all", "--grep=Revert"], Path(tmpdir)
             )
             # Should have at least one revert commit somewhere
             assert len(log_result.stdout.strip()) > 0, "No revert commits found"
@@ -256,48 +250,50 @@ class TestFindEntryById:
         """Test finding entry by searching git branches when no manifest files exist."""
         with tempfile.TemporaryDirectory() as tmpdir:
             manager = TransactionManager(base_path=Path(tmpdir))
-            manifest = manager.begin_transaction('test-session')
+            manifest = manager.begin_transaction("test-session")
 
             # Create a change
-            file = Path(tmpdir) / 'test.py'
-            file.write_text('def func(): pass')
+            file = Path(tmpdir) / "test.py"
+            file.write_text("def func(): pass")
             manager.record_write(
-                manifest, str(file), f'{file}.bak',
-                'func', 'function', 'python'
+                manifest, str(file), f"{file}.bak", "func", "function", "python"
             )
 
-            changes = manager.list_session_changes('test-session')
+            changes = manager.list_session_changes("test-session")
             entry_id = changes[0].entry_id
 
             # Call _find_entry_by_id (transactions dir doesn't exist)
-            transactions_dir = Path(tmpdir) / '.docimp' / 'transactions'
-            found_manifest, found_entry = manager._find_entry_by_id(entry_id, transactions_dir)
+            transactions_dir = Path(tmpdir) / ".docimp" / "transactions"
+            found_manifest, found_entry = manager._find_entry_by_id(
+                entry_id, transactions_dir
+            )
 
-            assert found_manifest.session_id == 'test-session'
+            assert found_manifest.session_id == "test-session"
             assert found_entry.entry_id == entry_id
-            assert found_entry.item_name == 'func'
+            assert found_entry.item_name == "func"
 
     def test_find_entry_by_partial_sha(self):
         """Test finding entry using partial git SHA."""
         with tempfile.TemporaryDirectory() as tmpdir:
             manager = TransactionManager(base_path=Path(tmpdir))
-            manifest = manager.begin_transaction('test-session')
+            manifest = manager.begin_transaction("test-session")
 
-            file = Path(tmpdir) / 'test.py'
-            file.write_text('def func(): pass')
+            file = Path(tmpdir) / "test.py"
+            file.write_text("def func(): pass")
             manager.record_write(
-                manifest, str(file), f'{file}.bak',
-                'func', 'function', 'python'
+                manifest, str(file), f"{file}.bak", "func", "function", "python"
             )
 
-            changes = manager.list_session_changes('test-session')
+            changes = manager.list_session_changes("test-session")
             full_sha = changes[0].entry_id
 
             # Use first 4 characters of SHA
             partial_sha = full_sha[:4]
 
-            transactions_dir = Path(tmpdir) / '.docimp' / 'transactions'
-            found_manifest, found_entry = manager._find_entry_by_id(partial_sha, transactions_dir)
+            transactions_dir = Path(tmpdir) / ".docimp" / "transactions"
+            found_manifest, found_entry = manager._find_entry_by_id(
+                partial_sha, transactions_dir
+            )
 
             assert found_entry.entry_id == full_sha
 
@@ -306,10 +302,10 @@ class TestFindEntryById:
         with tempfile.TemporaryDirectory() as tmpdir:
             manager = TransactionManager(base_path=Path(tmpdir))
 
-            transactions_dir = Path(tmpdir) / '.docimp' / 'transactions'
+            transactions_dir = Path(tmpdir) / ".docimp" / "transactions"
 
             try:
-                manager._find_entry_by_id('nonexistent-sha', transactions_dir)
+                manager._find_entry_by_id("nonexistent-sha", transactions_dir)
                 assert False, "Should have raised ValueError"
             except ValueError as e:
                 assert "not found" in str(e)

--- a/analyzer/tests/test_prompt_builder.py
+++ b/analyzer/tests/test_prompt_builder.py
@@ -18,24 +18,24 @@ class TestPromptBuilderInitialization:
     def test_default_initialization(self):
         """Test PromptBuilder with default values."""
         builder = PromptBuilder()
-        assert builder.style_guide == 'google'
-        assert builder.tone == 'concise'
+        assert builder.style_guide == "google"
+        assert builder.tone == "concise"
 
     def test_custom_initialization(self):
         """Test PromptBuilder with custom values."""
-        builder = PromptBuilder(style_guide='jsdoc-vanilla', tone='detailed')
-        assert builder.style_guide == 'jsdoc-vanilla'
-        assert builder.tone == 'detailed'
+        builder = PromptBuilder(style_guide="jsdoc-vanilla", tone="detailed")
+        assert builder.style_guide == "jsdoc-vanilla"
+        assert builder.tone == "detailed"
 
     def test_invalid_style_guide_raises_error(self):
         """Test that invalid style guide raises ValueError."""
-        with pytest.raises(ValueError, match='Unsupported style guide'):
-            PromptBuilder(style_guide='invalid-style')
+        with pytest.raises(ValueError, match="Unsupported style guide"):
+            PromptBuilder(style_guide="invalid-style")
 
     def test_invalid_tone_raises_error(self):
         """Test that invalid tone raises ValueError."""
-        with pytest.raises(ValueError, match='Unsupported tone'):
-            PromptBuilder(tone='invalid-tone')
+        with pytest.raises(ValueError, match="Unsupported tone"):
+            PromptBuilder(tone="invalid-tone")
 
 
 class TestPythonStyleGuides:
@@ -43,69 +43,69 @@ class TestPythonStyleGuides:
 
     def test_google_style(self):
         """Test Google style guide for Python."""
-        builder = PromptBuilder(style_guide='google', tone='concise')
+        builder = PromptBuilder(style_guide="google", tone="concise")
         prompt = builder.build_prompt(
-            code='def add(a, b):\n    return a + b',
-            item_name='add',
-            item_type='function',
-            language='python'
+            code="def add(a, b):\n    return a + b",
+            item_name="add",
+            item_type="function",
+            language="python",
         )
 
-        assert 'Google' in prompt
-        assert 'python' in prompt
-        assert 'Args:' in prompt
-        assert 'Returns:' in prompt
-        assert 'do NOT include the triple-quote delimiters' in prompt
+        assert "Google" in prompt
+        assert "python" in prompt
+        assert "Args:" in prompt
+        assert "Returns:" in prompt
+        assert "do NOT include the triple-quote delimiters" in prompt
 
     def test_numpy_rest_style(self):
         """Test NumPy + reST style guide for Python."""
-        builder = PromptBuilder(style_guide='numpy-rest', tone='concise')
+        builder = PromptBuilder(style_guide="numpy-rest", tone="concise")
         prompt = builder.build_prompt(
-            code='def add(a, b):\n    return a + b',
-            item_name='add',
-            item_type='function',
-            language='python'
+            code="def add(a, b):\n    return a + b",
+            item_name="add",
+            item_type="function",
+            language="python",
         )
 
-        assert 'NumPy + reST' in prompt
-        assert 'python' in prompt
-        assert 'Parameters' in prompt
-        assert 'Returns' in prompt
-        assert 'reStructuredText markup' in prompt
-        assert '``code``' in prompt
+        assert "NumPy + reST" in prompt
+        assert "python" in prompt
+        assert "Parameters" in prompt
+        assert "Returns" in prompt
+        assert "reStructuredText markup" in prompt
+        assert "``code``" in prompt
 
     def test_numpy_markdown_style(self):
         """Test NumPy + Markdown style guide for Python."""
-        builder = PromptBuilder(style_guide='numpy-markdown', tone='concise')
+        builder = PromptBuilder(style_guide="numpy-markdown", tone="concise")
         prompt = builder.build_prompt(
-            code='def add(a, b):\n    return a + b',
-            item_name='add',
-            item_type='function',
-            language='python'
+            code="def add(a, b):\n    return a + b",
+            item_name="add",
+            item_type="function",
+            language="python",
         )
 
-        assert 'NumPy + Markdown' in prompt
-        assert 'python' in prompt
-        assert 'Parameters' in prompt
-        assert 'Returns' in prompt
-        assert 'Markdown markup' in prompt
-        assert '`code`' in prompt
+        assert "NumPy + Markdown" in prompt
+        assert "python" in prompt
+        assert "Parameters" in prompt
+        assert "Returns" in prompt
+        assert "Markdown markup" in prompt
+        assert "`code`" in prompt
 
     def test_sphinx_style(self):
         """Test Sphinx/reST style guide for Python."""
-        builder = PromptBuilder(style_guide='sphinx', tone='concise')
+        builder = PromptBuilder(style_guide="sphinx", tone="concise")
         prompt = builder.build_prompt(
-            code='def add(a, b):\n    return a + b',
-            item_name='add',
-            item_type='function',
-            language='python'
+            code="def add(a, b):\n    return a + b",
+            item_name="add",
+            item_type="function",
+            language="python",
         )
 
-        assert 'Pure reST (Sphinx)' in prompt
-        assert 'python' in prompt
-        assert ':param' in prompt
-        assert ':return:' in prompt
-        assert 'do NOT include the triple-quote delimiters' in prompt
+        assert "Pure reST (Sphinx)" in prompt
+        assert "python" in prompt
+        assert ":param" in prompt
+        assert ":return:" in prompt
+        assert "do NOT include the triple-quote delimiters" in prompt
 
 
 class TestJavaScriptStyleGuides:
@@ -113,54 +113,54 @@ class TestJavaScriptStyleGuides:
 
     def test_jsdoc_vanilla_style(self):
         """Test vanilla JSDoc style guide for JavaScript."""
-        builder = PromptBuilder(style_guide='jsdoc-vanilla', tone='concise')
+        builder = PromptBuilder(style_guide="jsdoc-vanilla", tone="concise")
         prompt = builder.build_prompt(
-            code='function add(a, b) { return a + b; }',
-            item_name='add',
-            item_type='function',
-            language='javascript'
+            code="function add(a, b) { return a + b; }",
+            item_name="add",
+            item_type="function",
+            language="javascript",
         )
 
-        assert 'JSDoc (Vanilla)' in prompt
-        assert 'javascript' in prompt
-        assert '@param' in prompt
-        assert '@returns' in prompt
-        assert '@returns (not @return)' in prompt
+        assert "JSDoc (Vanilla)" in prompt
+        assert "javascript" in prompt
+        assert "@param" in prompt
+        assert "@returns" in prompt
+        assert "@returns (not @return)" in prompt
 
     def test_jsdoc_google_style(self):
         """Test Google JSDoc style guide for JavaScript."""
-        builder = PromptBuilder(style_guide='jsdoc-google', tone='concise')
+        builder = PromptBuilder(style_guide="jsdoc-google", tone="concise")
         prompt = builder.build_prompt(
-            code='function add(a, b) { return a + b; }',
-            item_name='add',
-            item_type='function',
-            language='javascript'
+            code="function add(a, b) { return a + b; }",
+            item_name="add",
+            item_type="function",
+            language="javascript",
         )
 
-        assert 'Google JSDoc' in prompt
-        assert 'javascript' in prompt
-        assert '@param' in prompt
-        assert '@return' in prompt
-        assert '@return (not @returns)' in prompt
-        assert 'End descriptions with periods' in prompt
-        assert 'No hyphens after parameter names' in prompt
+        assert "Google JSDoc" in prompt
+        assert "javascript" in prompt
+        assert "@param" in prompt
+        assert "@return" in prompt
+        assert "@return (not @returns)" in prompt
+        assert "End descriptions with periods" in prompt
+        assert "No hyphens after parameter names" in prompt
 
     def test_jsdoc_closure_style(self):
         """Test Closure JSDoc style guide for JavaScript."""
-        builder = PromptBuilder(style_guide='jsdoc-closure', tone='concise')
+        builder = PromptBuilder(style_guide="jsdoc-closure", tone="concise")
         prompt = builder.build_prompt(
-            code='function add(a, b) { return a + b; }',
-            item_name='add',
-            item_type='function',
-            language='javascript'
+            code="function add(a, b) { return a + b; }",
+            item_name="add",
+            item_type="function",
+            language="javascript",
         )
 
-        assert 'Closure (JSDoc/Closure)' in prompt
-        assert 'javascript' in prompt
-        assert '@param' in prompt
-        assert '@return' in prompt
-        assert '@public' in prompt
-        assert '@public, @private, or @protected annotations' in prompt
+        assert "Closure (JSDoc/Closure)" in prompt
+        assert "javascript" in prompt
+        assert "@param" in prompt
+        assert "@return" in prompt
+        assert "@public" in prompt
+        assert "@public, @private, or @protected annotations" in prompt
 
 
 class TestTypeScriptStyleGuides:
@@ -168,56 +168,58 @@ class TestTypeScriptStyleGuides:
 
     def test_tsdoc_typedoc_style(self):
         """Test TSDoc/TypeDoc style guide for TypeScript."""
-        builder = PromptBuilder(style_guide='tsdoc-typedoc', tone='concise')
+        builder = PromptBuilder(style_guide="tsdoc-typedoc", tone="concise")
         prompt = builder.build_prompt(
-            code='function add(a: number, b: number): number { return a + b; }',
-            item_name='add',
-            item_type='function',
-            language='typescript'
+            code="function add(a: number, b: number): number { return a + b; }",
+            item_name="add",
+            item_type="function",
+            language="typescript",
         )
 
-        assert 'TSDoc (TypeDoc)' in prompt
-        assert 'typescript' in prompt
-        assert '@param' in prompt
-        assert '@returns' in prompt
-        assert 'hyphens after parameter names' in prompt
-        assert '@remarks' in prompt
-        assert 'Types are inferred from TypeScript signatures' in prompt
+        assert "TSDoc (TypeDoc)" in prompt
+        assert "typescript" in prompt
+        assert "@param" in prompt
+        assert "@returns" in prompt
+        assert "hyphens after parameter names" in prompt
+        assert "@remarks" in prompt
+        assert "Types are inferred from TypeScript signatures" in prompt
 
     def test_tsdoc_aedoc_style(self):
         """Test TSDoc/AEDoc style guide for TypeScript."""
-        builder = PromptBuilder(style_guide='tsdoc-aedoc', tone='concise')
+        builder = PromptBuilder(style_guide="tsdoc-aedoc", tone="concise")
         prompt = builder.build_prompt(
-            code='function add(a: number, b: number): number { return a + b; }',
-            item_name='add',
-            item_type='function',
-            language='typescript'
+            code="function add(a: number, b: number): number { return a + b; }",
+            item_name="add",
+            item_type="function",
+            language="typescript",
         )
 
-        assert 'TSDoc (API Extractor/AEDoc)' in prompt
-        assert 'typescript' in prompt
-        assert '@param' in prompt
-        assert '@returns' in prompt
-        assert 'hyphens after parameter names' in prompt
-        assert '@public' in prompt
-        assert '@public, @beta, or @internal annotations' in prompt
+        assert "TSDoc (API Extractor/AEDoc)" in prompt
+        assert "typescript" in prompt
+        assert "@param" in prompt
+        assert "@returns" in prompt
+        assert "hyphens after parameter names" in prompt
+        assert "@public" in prompt
+        assert "@public, @beta, or @internal annotations" in prompt
 
     def test_jsdoc_ts_style(self):
         """Test JSDoc-in-TS style guide for TypeScript."""
-        builder = PromptBuilder(style_guide='jsdoc-ts', tone='concise')
+        builder = PromptBuilder(style_guide="jsdoc-ts", tone="concise")
         prompt = builder.build_prompt(
-            code='function add(a: number, b: number): number { return a + b; }',
-            item_name='add',
-            item_type='function',
-            language='typescript'
+            code="function add(a: number, b: number): number { return a + b; }",
+            item_name="add",
+            item_type="function",
+            language="typescript",
         )
 
-        assert 'JSDoc-in-TS' in prompt
-        assert 'typescript' in prompt
-        assert '@param {number}' in prompt
-        assert '@returns {number}' in prompt
-        assert 'explicit type annotations' in prompt
-        assert 'Include {type} annotations even though TypeScript provides types' in prompt
+        assert "JSDoc-in-TS" in prompt
+        assert "typescript" in prompt
+        assert "@param {number}" in prompt
+        assert "@returns {number}" in prompt
+        assert "explicit type annotations" in prompt
+        assert (
+            "Include {type} annotations even though TypeScript provides types" in prompt
+        )
 
 
 class TestToneOptions:
@@ -225,42 +227,42 @@ class TestToneOptions:
 
     def test_concise_tone(self):
         """Test concise tone in prompt."""
-        builder = PromptBuilder(style_guide='google', tone='concise')
+        builder = PromptBuilder(style_guide="google", tone="concise")
         prompt = builder.build_prompt(
-            code='def add(a, b):\n    return a + b',
-            item_name='add',
-            item_type='function',
-            language='python'
+            code="def add(a, b):\n    return a + b",
+            item_name="add",
+            item_type="function",
+            language="python",
         )
 
-        assert 'Concise' in prompt
-        assert 'brief and to the point' in prompt.lower()
+        assert "Concise" in prompt
+        assert "brief and to the point" in prompt.lower()
 
     def test_detailed_tone(self):
         """Test detailed tone in prompt."""
-        builder = PromptBuilder(style_guide='google', tone='detailed')
+        builder = PromptBuilder(style_guide="google", tone="detailed")
         prompt = builder.build_prompt(
-            code='def add(a, b):\n    return a + b',
-            item_name='add',
-            item_type='function',
-            language='python'
+            code="def add(a, b):\n    return a + b",
+            item_name="add",
+            item_type="function",
+            language="python",
         )
 
-        assert 'Detailed' in prompt
-        assert 'comprehensive explanations' in prompt.lower()
+        assert "Detailed" in prompt
+        assert "comprehensive explanations" in prompt.lower()
 
     def test_friendly_tone(self):
         """Test friendly tone in prompt."""
-        builder = PromptBuilder(style_guide='google', tone='friendly')
+        builder = PromptBuilder(style_guide="google", tone="friendly")
         prompt = builder.build_prompt(
-            code='def add(a, b):\n    return a + b',
-            item_name='add',
-            item_type='function',
-            language='python'
+            code="def add(a, b):\n    return a + b",
+            item_name="add",
+            item_type="function",
+            language="python",
         )
 
-        assert 'Friendly' in prompt
-        assert 'conversational' in prompt.lower()
+        assert "Friendly" in prompt
+        assert "conversational" in prompt.lower()
 
 
 class TestPromptStructure:
@@ -268,47 +270,47 @@ class TestPromptStructure:
 
     def test_prompt_includes_code(self):
         """Test that prompt includes the code to document."""
-        builder = PromptBuilder(style_guide='google', tone='concise')
+        builder = PromptBuilder(style_guide="google", tone="concise")
         prompt = builder.build_prompt(
-            code='def add(a, b):\n    return a + b',
-            item_name='add',
-            item_type='function',
-            language='python'
+            code="def add(a, b):\n    return a + b",
+            item_name="add",
+            item_type="function",
+            language="python",
         )
 
-        assert 'def add(a, b):' in prompt
-        assert 'return a + b' in prompt
+        assert "def add(a, b):" in prompt
+        assert "return a + b" in prompt
 
     def test_prompt_includes_context(self):
         """Test that prompt includes surrounding context when provided."""
-        builder = PromptBuilder(style_guide='google', tone='concise')
+        builder = PromptBuilder(style_guide="google", tone="concise")
         prompt = builder.build_prompt(
-            code='def add(a, b):\n    return a + b',
-            item_name='add',
-            item_type='function',
-            language='python',
-            context='# Math utilities\nclass Calculator:\n    ...'
+            code="def add(a, b):\n    return a + b",
+            item_name="add",
+            item_type="function",
+            language="python",
+            context="# Math utilities\nclass Calculator:\n    ...",
         )
 
-        assert 'Surrounding context:' in prompt
-        assert 'Math utilities' in prompt
-        assert 'Calculator' in prompt
+        assert "Surrounding context:" in prompt
+        assert "Math utilities" in prompt
+        assert "Calculator" in prompt
 
     def test_prompt_includes_requirements(self):
         """Test that prompt includes documentation requirements."""
-        builder = PromptBuilder(style_guide='google', tone='concise')
+        builder = PromptBuilder(style_guide="google", tone="concise")
         prompt = builder.build_prompt(
-            code='def add(a, b):\n    return a + b',
-            item_name='add',
-            item_type='function',
-            language='python'
+            code="def add(a, b):\n    return a + b",
+            item_name="add",
+            item_type="function",
+            language="python",
         )
 
-        assert 'Requirements:' in prompt
-        assert 'Return ONLY the documentation for the function' in prompt
-        assert 'The surrounding code is for CONTEXT ONLY' in prompt
-        assert 'Do not include the code itself' in prompt
-        assert 'Use the exact format shown in the example' in prompt
+        assert "Requirements:" in prompt
+        assert "Return ONLY the documentation for the function" in prompt
+        assert "The surrounding code is for CONTEXT ONLY" in prompt
+        assert "Do not include the code itself" in prompt
+        assert "Use the exact format shown in the example" in prompt
 
 
 class TestAllStyleGuidesAvailable:
@@ -316,21 +318,21 @@ class TestAllStyleGuidesAvailable:
 
     def test_all_python_styles_available(self):
         """Test all Python style guides can be instantiated."""
-        python_styles = ['google', 'numpy-rest', 'numpy-markdown', 'sphinx']
+        python_styles = ["google", "numpy-rest", "numpy-markdown", "sphinx"]
         for style in python_styles:
             builder = PromptBuilder(style_guide=style)
             assert builder.style_guide == style
 
     def test_all_javascript_styles_available(self):
         """Test all JavaScript style guides can be instantiated."""
-        js_styles = ['jsdoc-vanilla', 'jsdoc-google', 'jsdoc-closure']
+        js_styles = ["jsdoc-vanilla", "jsdoc-google", "jsdoc-closure"]
         for style in js_styles:
             builder = PromptBuilder(style_guide=style)
             assert builder.style_guide == style
 
     def test_all_typescript_styles_available(self):
         """Test all TypeScript style guides can be instantiated."""
-        ts_styles = ['tsdoc-typedoc', 'tsdoc-aedoc', 'jsdoc-ts']
+        ts_styles = ["tsdoc-typedoc", "tsdoc-aedoc", "jsdoc-ts"]
         for style in ts_styles:
             builder = PromptBuilder(style_guide=style)
             assert builder.style_guide == style
@@ -341,103 +343,108 @@ class TestFeedbackIntegration:
 
     def test_prompt_without_feedback(self):
         """Test that prompt without feedback does not include feedback section."""
-        builder = PromptBuilder(style_guide='google', tone='concise')
+        builder = PromptBuilder(style_guide="google", tone="concise")
         prompt = builder.build_prompt(
-            code='def add(a, b):\n    return a + b',
-            item_name='add',
-            item_type='function',
-            language='python'
+            code="def add(a, b):\n    return a + b",
+            item_name="add",
+            item_type="function",
+            language="python",
         )
 
-        assert 'User Feedback from Previous Attempt:' not in prompt
-        assert 'IMPORTANT: Address the above feedback' not in prompt
+        assert "User Feedback from Previous Attempt:" not in prompt
+        assert "IMPORTANT: Address the above feedback" not in prompt
 
     def test_prompt_with_feedback(self):
         """Test that prompt with feedback includes feedback section."""
-        builder = PromptBuilder(style_guide='google', tone='concise')
-        feedback_text = 'Add more detail about error handling and edge cases'
+        builder = PromptBuilder(style_guide="google", tone="concise")
+        feedback_text = "Add more detail about error handling and edge cases"
         prompt = builder.build_prompt(
-            code='def add(a, b):\n    return a + b',
-            item_name='add',
-            item_type='function',
-            language='python',
-            feedback=feedback_text
+            code="def add(a, b):\n    return a + b",
+            item_name="add",
+            item_type="function",
+            language="python",
+            feedback=feedback_text,
         )
 
-        assert 'User Feedback from Previous Attempt:' in prompt
+        assert "User Feedback from Previous Attempt:" in prompt
         assert feedback_text in prompt
-        assert 'IMPORTANT: Address the above feedback in your revised documentation.' in prompt
+        assert (
+            "IMPORTANT: Address the above feedback in your revised documentation."
+            in prompt
+        )
 
     def test_prompt_with_multiline_feedback(self):
         """Test that prompt correctly handles multiline feedback."""
-        builder = PromptBuilder(style_guide='google', tone='concise')
-        feedback_text = '''Please improve the documentation by:
+        builder = PromptBuilder(style_guide="google", tone="concise")
+        feedback_text = """Please improve the documentation by:
 1. Adding more details about parameters
 2. Including examples of edge cases
-3. Explaining the return value more clearly'''
+3. Explaining the return value more clearly"""
         prompt = builder.build_prompt(
-            code='def add(a, b):\n    return a + b',
-            item_name='add',
-            item_type='function',
-            language='python',
-            feedback=feedback_text
+            code="def add(a, b):\n    return a + b",
+            item_name="add",
+            item_type="function",
+            language="python",
+            feedback=feedback_text,
         )
 
-        assert 'User Feedback from Previous Attempt:' in prompt
-        assert 'Adding more details about parameters' in prompt
-        assert 'Including examples of edge cases' in prompt
-        assert 'Explaining the return value more clearly' in prompt
+        assert "User Feedback from Previous Attempt:" in prompt
+        assert "Adding more details about parameters" in prompt
+        assert "Including examples of edge cases" in prompt
+        assert "Explaining the return value more clearly" in prompt
 
     def test_prompt_with_special_characters_in_feedback(self):
         """Test that prompt handles special characters in feedback."""
-        builder = PromptBuilder(style_guide='google', tone='concise')
-        feedback_text = 'Include @param annotations, use `code` formatting, and add "quotes"'
+        builder = PromptBuilder(style_guide="google", tone="concise")
+        feedback_text = (
+            'Include @param annotations, use `code` formatting, and add "quotes"'
+        )
         prompt = builder.build_prompt(
-            code='def add(a, b):\n    return a + b',
-            item_name='add',
-            item_type='function',
-            language='python',
-            feedback=feedback_text
+            code="def add(a, b):\n    return a + b",
+            item_name="add",
+            item_type="function",
+            language="python",
+            feedback=feedback_text,
         )
 
-        assert 'User Feedback from Previous Attempt:' in prompt
-        assert '@param annotations' in prompt
-        assert '`code` formatting' in prompt
+        assert "User Feedback from Previous Attempt:" in prompt
+        assert "@param annotations" in prompt
+        assert "`code` formatting" in prompt
         assert '"quotes"' in prompt
 
     def test_feedback_stripped_of_whitespace(self):
         """Test that feedback is stripped of leading/trailing whitespace."""
-        builder = PromptBuilder(style_guide='google', tone='concise')
-        feedback_text = '   Add more details   \n\n'
+        builder = PromptBuilder(style_guide="google", tone="concise")
+        feedback_text = "   Add more details   \n\n"
         prompt = builder.build_prompt(
-            code='def add(a, b):\n    return a + b',
-            item_name='add',
-            item_type='function',
-            language='python',
-            feedback=feedback_text
+            code="def add(a, b):\n    return a + b",
+            item_name="add",
+            item_type="function",
+            language="python",
+            feedback=feedback_text,
         )
 
-        assert 'User Feedback from Previous Attempt:' in prompt
-        assert 'Add more details' in prompt
+        assert "User Feedback from Previous Attempt:" in prompt
+        assert "Add more details" in prompt
         # Ensure no extra whitespace around feedback
-        assert '   Add more details   \n\n' not in prompt
+        assert "   Add more details   \n\n" not in prompt
 
     def test_feedback_placement_after_context(self):
         """Test that feedback appears after context but before requirements."""
-        builder = PromptBuilder(style_guide='google', tone='concise')
+        builder = PromptBuilder(style_guide="google", tone="concise")
         prompt = builder.build_prompt(
-            code='def add(a, b):\n    return a + b',
-            item_name='add',
-            item_type='function',
-            language='python',
-            context='# Math utilities',
-            feedback='Add more detail'
+            code="def add(a, b):\n    return a + b",
+            item_name="add",
+            item_type="function",
+            language="python",
+            context="# Math utilities",
+            feedback="Add more detail",
         )
 
         # Find positions of key sections
-        context_pos = prompt.find('Surrounding context:')
-        feedback_pos = prompt.find('User Feedback from Previous Attempt:')
-        requirements_pos = prompt.find('Requirements:')
+        context_pos = prompt.find("Surrounding context:")
+        feedback_pos = prompt.find("User Feedback from Previous Attempt:")
+        requirements_pos = prompt.find("Requirements:")
 
         # Feedback should appear after context and before requirements
         assert context_pos < feedback_pos < requirements_pos
@@ -445,22 +452,22 @@ class TestFeedbackIntegration:
     def test_feedback_works_with_all_style_guides(self):
         """Test that feedback integration works with all style guides."""
         test_styles = [
-            ('google', 'python'),
-            ('numpy-rest', 'python'),
-            ('jsdoc-vanilla', 'javascript'),
-            ('tsdoc-typedoc', 'typescript'),
+            ("google", "python"),
+            ("numpy-rest", "python"),
+            ("jsdoc-vanilla", "javascript"),
+            ("tsdoc-typedoc", "typescript"),
         ]
 
         for style, language in test_styles:
-            builder = PromptBuilder(style_guide=style, tone='concise')
+            builder = PromptBuilder(style_guide=style, tone="concise")
             prompt = builder.build_prompt(
-                code='function test() {}',
-                item_name='test',
-                item_type='function',
+                code="function test() {}",
+                item_name="test",
+                item_type="function",
                 language=language,
-                feedback='Add more detail'
+                feedback="Add more detail",
             )
 
-            assert 'User Feedback from Previous Attempt:' in prompt
-            assert 'Add more detail' in prompt
-            assert 'IMPORTANT: Address the above feedback' in prompt
+            assert "User Feedback from Previous Attempt:" in prompt
+            assert "Add more detail" in prompt
+            assert "IMPORTANT: Address the above feedback" in prompt

--- a/analyzer/tests/test_response_parser.py
+++ b/analyzer/tests/test_response_parser.py
@@ -19,108 +19,108 @@ class TestClaudeResponseParser:
     def test_strips_python_markdown_fence(self):
         """Test that Python markdown fences are stripped correctly."""
         # Markdown-wrapped response
-        wrapped = '''```python
+        wrapped = """```python
 Calculate the sum of two numbers.
 
 Returns the result.
-```'''
+```"""
 
-        result = ClaudeResponseParser.strip_markdown_fences(wrapped, 'python')
+        result = ClaudeResponseParser.strip_markdown_fences(wrapped, "python")
 
         # Should strip the fences
-        assert '```python' not in result
-        assert '```' not in result
-        assert 'Calculate the sum of two numbers.' in result
-        assert 'Returns the result.' in result
+        assert "```python" not in result
+        assert "```" not in result
+        assert "Calculate the sum of two numbers." in result
+        assert "Returns the result." in result
 
     def test_strips_javascript_markdown_fence(self):
         """Test that JavaScript markdown fences are stripped correctly."""
-        wrapped = '''```javascript
+        wrapped = """```javascript
 /**
  * Add two numbers.
  * @param {number} a - First number
  * @returns {number} Sum
  */
-```'''
+```"""
 
-        result = ClaudeResponseParser.strip_markdown_fences(wrapped, 'javascript')
+        result = ClaudeResponseParser.strip_markdown_fences(wrapped, "javascript")
 
         # Should strip the fences
-        assert '```javascript' not in result
+        assert "```javascript" not in result
         # The closing fence should be gone, but JSDoc delimiters remain
-        assert result.count('```') == 0
-        assert '/**' in result
-        assert 'Add two numbers.' in result
+        assert result.count("```") == 0
+        assert "/**" in result
+        assert "Add two numbers." in result
 
     def test_strips_javascript_short_fence(self):
         """Test that 'js' fence specifier is stripped."""
-        wrapped = '''```js
+        wrapped = """```js
 /** Documentation */
-```'''
+```"""
 
-        result = ClaudeResponseParser.strip_markdown_fences(wrapped, 'javascript')
+        result = ClaudeResponseParser.strip_markdown_fences(wrapped, "javascript")
 
-        assert '```' not in result
-        assert '/** Documentation */' in result
+        assert "```" not in result
+        assert "/** Documentation */" in result
 
     def test_strips_typescript_markdown_fence(self):
         """Test that TypeScript markdown fences are stripped correctly."""
-        wrapped = '''```typescript
+        wrapped = """```typescript
 /**
  * Divide two numbers.
  * @param a - Dividend
  * @returns Quotient
  */
-```'''
+```"""
 
-        result = ClaudeResponseParser.strip_markdown_fences(wrapped, 'typescript')
+        result = ClaudeResponseParser.strip_markdown_fences(wrapped, "typescript")
 
-        assert '```typescript' not in result
-        assert result.count('```') == 0
-        assert 'Divide two numbers.' in result
+        assert "```typescript" not in result
+        assert result.count("```") == 0
+        assert "Divide two numbers." in result
 
     def test_strips_typescript_short_fence(self):
         """Test that 'ts' fence specifier is stripped."""
-        wrapped = '''```ts
+        wrapped = """```ts
 /** Documentation */
-```'''
+```"""
 
-        result = ClaudeResponseParser.strip_markdown_fences(wrapped, 'typescript')
+        result = ClaudeResponseParser.strip_markdown_fences(wrapped, "typescript")
 
-        assert '```' not in result
-        assert '/** Documentation */' in result
+        assert "```" not in result
+        assert "/** Documentation */" in result
 
     def test_strips_generic_fence_without_language(self):
         """Test that generic fences (no language specifier) are stripped."""
-        wrapped = '''```
+        wrapped = """```
 Calculate the sum of two numbers.
-```'''
+```"""
 
-        result = ClaudeResponseParser.strip_markdown_fences(wrapped, 'python')
+        result = ClaudeResponseParser.strip_markdown_fences(wrapped, "python")
 
-        assert '```' not in result
-        assert 'Calculate the sum of two numbers.' in result
+        assert "```" not in result
+        assert "Calculate the sum of two numbers." in result
 
     def test_handles_clean_response_no_op(self):
         """Test that clean responses (no fences) are returned unchanged."""
-        clean = '''Calculate the sum of two numbers.
+        clean = """Calculate the sum of two numbers.
 
-Returns the result.'''
+Returns the result."""
 
-        result = ClaudeResponseParser.strip_markdown_fences(clean, 'python')
+        result = ClaudeResponseParser.strip_markdown_fences(clean, "python")
 
         # Should be unchanged
         assert result == clean
 
     def test_handles_jsdoc_clean_response(self):
         """Test that clean JSDoc responses are returned unchanged."""
-        clean = '''/**
+        clean = """/**
  * Add two numbers.
  * @param {number} a - First number
  * @returns {number} Sum
- */'''
+ */"""
 
-        result = ClaudeResponseParser.strip_markdown_fences(clean, 'javascript')
+        result = ClaudeResponseParser.strip_markdown_fences(clean, "javascript")
 
         # Should be unchanged
         assert result == clean
@@ -133,37 +133,41 @@ Returns the result.'''
         """
         # This is a CLEAN response that contains example code
         # (not wrapped in outer fences)
-        clean_with_examples = '''Calculate sum of two numbers.
+        clean_with_examples = """Calculate sum of two numbers.
 
 Examples:
     >>> add(1, 2)
     3
     >>> add(-1, 1)
-    0'''
+    0"""
 
-        result = ClaudeResponseParser.strip_markdown_fences(clean_with_examples, 'python')
+        result = ClaudeResponseParser.strip_markdown_fences(
+            clean_with_examples, "python"
+        )
 
         # Should be unchanged - these aren't markdown fences
         assert result == clean_with_examples
-        assert '>>> add(1, 2)' in result
+        assert ">>> add(1, 2)" in result
 
     def test_preserves_internal_code_examples_jsdoc(self):
         """Test that code examples with markdown fences WITHIN JSDoc are preserved."""
         # Clean JSDoc with embedded code example using markdown fence
-        clean_with_example = '''/**
+        clean_with_example = """/**
  * Format currency.
  * @example
  * ```javascript
  * formatCurrency(42.5);
  * ```
- */'''
+ */"""
 
-        result = ClaudeResponseParser.strip_markdown_fences(clean_with_example, 'javascript')
+        result = ClaudeResponseParser.strip_markdown_fences(
+            clean_with_example, "javascript"
+        )
 
         # Should be unchanged - the fence is INSIDE the docstring, not wrapping it
         assert result == clean_with_example
-        assert '@example' in result
-        assert '```javascript' in result
+        assert "@example" in result
+        assert "```javascript" in result
 
     def test_strips_outer_fence_preserves_inner_examples(self):
         """Test stripping outer fence while preserving inner code examples.
@@ -172,47 +176,49 @@ Examples:
         code examples - should strip outer fence but keep inner examples.
         """
         # Wrapped response that contains internal code examples
-        wrapped_with_examples = '''```python
+        wrapped_with_examples = """```python
 Calculate sum of two numbers.
 
 Examples:
     >>> add(1, 2)
     3
-```'''
+```"""
 
-        result = ClaudeResponseParser.strip_markdown_fences(wrapped_with_examples, 'python')
+        result = ClaudeResponseParser.strip_markdown_fences(
+            wrapped_with_examples, "python"
+        )
 
         # Outer fence should be stripped
-        assert not result.startswith('```python')
-        assert not result.endswith('```')
+        assert not result.startswith("```python")
+        assert not result.endswith("```")
 
         # Inner examples should be preserved
-        assert '>>> add(1, 2)' in result
-        assert 'Examples:' in result
+        assert ">>> add(1, 2)" in result
+        assert "Examples:" in result
 
     def test_handles_fence_with_whitespace(self):
         """Test that fences with extra whitespace are handled correctly."""
-        wrapped = '''  ```python
+        wrapped = """  ```python
 
 Calculate sum.
 
-```  '''
+```  """
 
-        result = ClaudeResponseParser.strip_markdown_fences(wrapped, 'python')
+        result = ClaudeResponseParser.strip_markdown_fences(wrapped, "python")
 
-        assert '```' not in result
-        assert 'Calculate sum.' in result
+        assert "```" not in result
+        assert "Calculate sum." in result
 
     def test_handles_empty_response(self):
         """Test that empty responses don't cause errors."""
-        result = ClaudeResponseParser.strip_markdown_fences('', 'python')
-        assert result == ''
+        result = ClaudeResponseParser.strip_markdown_fences("", "python")
+        assert result == ""
 
     def test_handles_response_with_only_fence(self):
         """Test that malformed responses (only fence, no content) are handled."""
-        malformed = '```python\n```'
+        malformed = "```python\n```"
 
-        result = ClaudeResponseParser.strip_markdown_fences(malformed, 'python')
+        result = ClaudeResponseParser.strip_markdown_fences(malformed, "python")
 
         # Should be left unchanged - no actual content between fences
         # (regex requires at least some content to match)
@@ -224,43 +230,43 @@ Calculate sum.
         If the response has an opening fence but no closing fence,
         it should be left unchanged (considered a malformed response).
         """
-        partial = '''```python
-Calculate sum.'''
+        partial = """```python
+Calculate sum."""
 
-        result = ClaudeResponseParser.strip_markdown_fences(partial, 'python')
+        result = ClaudeResponseParser.strip_markdown_fences(partial, "python")
 
         # Should be unchanged (no match since closing fence is missing)
         assert result == partial
 
     def test_multiline_content_preserved(self):
         """Test that multiline content within fences is fully preserved."""
-        wrapped = '''```python
+        wrapped = """```python
 Line 1
 
 Line 2
 
 Line 3
 With indentation
-```'''
+```"""
 
-        result = ClaudeResponseParser.strip_markdown_fences(wrapped, 'python')
+        result = ClaudeResponseParser.strip_markdown_fences(wrapped, "python")
 
-        assert '```' not in result
-        assert 'Line 1' in result
-        assert 'Line 2' in result
-        assert 'Line 3' in result
-        assert 'With indentation' in result
+        assert "```" not in result
+        assert "Line 1" in result
+        assert "Line 2" in result
+        assert "Line 3" in result
+        assert "With indentation" in result
         # Verify line breaks are preserved
-        assert result.count('\n') >= 5
+        assert result.count("\n") >= 5
 
     def test_case_insensitive_language_matching(self):
         """Test that language matching is case-insensitive."""
-        wrapped = '''```Python
+        wrapped = """```Python
 Calculate sum.
-```'''
+```"""
 
         # Pass lowercase language, should still match
-        result = ClaudeResponseParser.strip_markdown_fences(wrapped, 'python')
+        result = ClaudeResponseParser.strip_markdown_fences(wrapped, "python")
 
         # Pattern in our implementation uses lowercase, so this might not match
         # depending on implementation. Let's verify current behavior.
@@ -269,4 +275,4 @@ Calculate sum.
 
         # This test documents current behavior - we require lowercase fence specifiers
         # If uppercase is found, it won't be stripped (conservative approach)
-        assert result == wrapped or '```' not in result
+        assert result == wrapped or "```" not in result

--- a/analyzer/tests/test_rollback_cli.py
+++ b/analyzer/tests/test_rollback_cli.py
@@ -12,9 +12,13 @@ from src.main import (
     cmd_list_changes,
     cmd_rollback_session,
     cmd_rollback_change,
-    cmd_interactive_rollback
+    cmd_interactive_rollback,
 )
-from src.writer.transaction_manager import TransactionManifest, TransactionEntry, RollbackResult
+from src.writer.transaction_manager import (
+    TransactionManifest,
+    TransactionEntry,
+    RollbackResult,
+)
 
 
 class TestListSessions:
@@ -27,72 +31,72 @@ class TestListSessions:
 
         # Create mock sessions
         session1 = TransactionManifest(
-            session_id='session-1',
-            started_at='2024-01-01T10:00:00',
-            status='in_progress',
+            session_id="session-1",
+            started_at="2024-01-01T10:00:00",
+            status="in_progress",
             entries=[
                 TransactionEntry(
-                    entry_id='abc123',
-                    filepath='/test/file1.py',
-                    backup_path='/test/file1.py.bak',
-                    timestamp='2024-01-01T10:01:00',
-                    item_name='func1',
-                    item_type='function',
-                    language='python',
-                    success=True
+                    entry_id="abc123",
+                    filepath="/test/file1.py",
+                    backup_path="/test/file1.py.bak",
+                    timestamp="2024-01-01T10:01:00",
+                    item_name="func1",
+                    item_type="function",
+                    language="python",
+                    success=True,
                 )
-            ]
+            ],
         )
         session2 = TransactionManifest(
-            session_id='session-2',
-            started_at='2024-01-01T11:00:00',
-            status='in_progress',
-            entries=[]
+            session_id="session-2",
+            started_at="2024-01-01T11:00:00",
+            status="in_progress",
+            entries=[],
         )
 
         manager.list_uncommitted_transactions.return_value = [session1, session2]
 
         # Create mock args
-        args = argparse.Namespace(verbose=False, format='table')
+        args = argparse.Namespace(verbose=False, format="table")
 
         # Mock GitHelper.check_git_available
-        with patch('src.main.GitHelper.check_git_available', return_value=True):
+        with patch("src.main.GitHelper.check_git_available", return_value=True):
             result = cmd_list_sessions(args, manager)
 
         assert result == 0
 
         # Check output
         captured = capsys.readouterr()
-        assert 'Active DocImp Sessions' in captured.out
-        assert 'session-1' in captured.out
-        assert 'session-2' in captured.out
-        assert 'Total: 2 session(s)' in captured.out
+        assert "Active DocImp Sessions" in captured.out
+        assert "session-1" in captured.out
+        assert "session-2" in captured.out
+        assert "Total: 2 session(s)" in captured.out
 
     def test_list_sessions_no_sessions(self, capsys):
         """Test listing sessions when no sessions exist."""
         manager = Mock()
         manager.list_uncommitted_transactions.return_value = []
 
-        args = argparse.Namespace(verbose=False, format='table')
+        args = argparse.Namespace(verbose=False, format="table")
 
-        with patch('src.main.GitHelper.check_git_available', return_value=True):
+        with patch("src.main.GitHelper.check_git_available", return_value=True):
             result = cmd_list_sessions(args, manager)
 
         assert result == 0
         captured = capsys.readouterr()
-        assert 'No active sessions found' in captured.out
+        assert "No active sessions found" in captured.out
 
     def test_list_sessions_git_unavailable(self, capsys):
         """Test listing sessions when git is not available."""
         manager = Mock()
-        args = argparse.Namespace(verbose=False, format='table')
+        args = argparse.Namespace(verbose=False, format="table")
 
-        with patch('src.main.GitHelper.check_git_available', return_value=False):
+        with patch("src.main.GitHelper.check_git_available", return_value=False):
             result = cmd_list_sessions(args, manager)
 
         assert result == 1
         captured = capsys.readouterr()
-        assert 'Git not installed' in captured.err
+        assert "Git not installed" in captured.err
 
 
 class TestListChanges:
@@ -104,54 +108,58 @@ class TestListChanges:
 
         # Create mock changes
         change1 = TransactionEntry(
-            entry_id='abc123',
-            filepath='/test/file1.py',
-            backup_path='/test/file1.py.bak',
-            timestamp='2024-01-01T10:01:00',
-            item_name='func1',
-            item_type='function',
-            language='python',
-            success=True
+            entry_id="abc123",
+            filepath="/test/file1.py",
+            backup_path="/test/file1.py.bak",
+            timestamp="2024-01-01T10:01:00",
+            item_name="func1",
+            item_type="function",
+            language="python",
+            success=True,
         )
         change2 = TransactionEntry(
-            entry_id='def456',
-            filepath='/test/file2.py',
-            backup_path='/test/file2.py.bak',
-            timestamp='2024-01-01T10:02:00',
-            item_name='func2',
-            item_type='function',
-            language='python',
-            success=True
+            entry_id="def456",
+            filepath="/test/file2.py",
+            backup_path="/test/file2.py.bak",
+            timestamp="2024-01-01T10:02:00",
+            item_name="func2",
+            item_type="function",
+            language="python",
+            success=True,
         )
 
         manager.list_session_changes.return_value = [change1, change2]
 
-        args = argparse.Namespace(session_id='test-session', verbose=False, format='table')
+        args = argparse.Namespace(
+            session_id="test-session", verbose=False, format="table"
+        )
 
-        with patch('src.main.GitHelper.check_git_available', return_value=True):
+        with patch("src.main.GitHelper.check_git_available", return_value=True):
             result = cmd_list_changes(args, manager)
 
         assert result == 0
         captured = capsys.readouterr()
-        assert 'Changes in Session: test-session' in captured.out
-        assert 'abc123' in captured.out
-        assert 'def456' in captured.out
-        assert 'Total: 2 change(s)' in captured.out
+        assert "Changes in Session: test-session" in captured.out
+        assert "abc123" in captured.out
+        assert "def456" in captured.out
+        assert "Total: 2 change(s)" in captured.out
 
     def test_list_changes_invalid_session(self, capsys):
         """Test listing changes for invalid session."""
         manager = Mock()
         manager.list_session_changes.side_effect = ValueError("Session does not exist")
 
-        args = argparse.Namespace(session_id='invalid-session', verbose=False, format='table')
+        args = argparse.Namespace(
+            session_id="invalid-session", verbose=False, format="table"
+        )
 
-        with patch('src.main.GitHelper.check_git_available', return_value=True):
+        with patch("src.main.GitHelper.check_git_available", return_value=True):
             result = cmd_list_changes(args, manager)
 
         assert result == 1
         captured = capsys.readouterr()
-        assert 'Session does not exist' in captured.err
-        assert 'docimp list-sessions' in captured.err
+        assert "Session does not exist" in captured.err
+        assert "docimp list-sessions" in captured.err
 
 
 class TestRollbackSession:
@@ -163,38 +171,38 @@ class TestRollbackSession:
 
         # Create two mock sessions with different timestamps
         session1 = TransactionManifest(
-            session_id='session-older',
-            started_at='2024-01-01T10:00:00',
-            status='in_progress',
+            session_id="session-older",
+            started_at="2024-01-01T10:00:00",
+            status="in_progress",
             entries=[
                 TransactionEntry(
-                    entry_id='abc123',
-                    filepath='/test/file1.py',
-                    backup_path='/test/file1.py.bak',
-                    timestamp='2024-01-01T10:01:00',
-                    item_name='func1',
-                    item_type='function',
-                    language='python',
-                    success=True
+                    entry_id="abc123",
+                    filepath="/test/file1.py",
+                    backup_path="/test/file1.py.bak",
+                    timestamp="2024-01-01T10:01:00",
+                    item_name="func1",
+                    item_type="function",
+                    language="python",
+                    success=True,
                 )
-            ]
+            ],
         )
         session2 = TransactionManifest(
-            session_id='session-newer',
-            started_at='2024-01-01T11:00:00',
-            status='in_progress',
+            session_id="session-newer",
+            started_at="2024-01-01T11:00:00",
+            status="in_progress",
             entries=[
                 TransactionEntry(
-                    entry_id='def456',
-                    filepath='/test/file2.py',
-                    backup_path='/test/file2.py.bak',
-                    timestamp='2024-01-01T11:01:00',
-                    item_name='func2',
-                    item_type='function',
-                    language='python',
-                    success=True
+                    entry_id="def456",
+                    filepath="/test/file2.py",
+                    backup_path="/test/file2.py.bak",
+                    timestamp="2024-01-01T11:01:00",
+                    item_name="func2",
+                    item_type="function",
+                    language="python",
+                    success=True,
                 )
-            ]
+            ],
         )
 
         # list_uncommitted_transactions returns both sessions
@@ -202,30 +210,36 @@ class TestRollbackSession:
         manager.load_manifest.return_value = session2  # Most recent
         manager.rollback_transaction.return_value = 1
 
-        args = argparse.Namespace(session_id='last', verbose=False, format='table', no_confirm=True)
+        args = argparse.Namespace(
+            session_id="last", verbose=False, format="table", no_confirm=True
+        )
 
-        with patch('src.main.GitHelper.check_git_available', return_value=True), \
-             patch('src.main.Path.exists', return_value=True):
+        with (
+            patch("src.main.GitHelper.check_git_available", return_value=True),
+            patch("src.main.Path.exists", return_value=True),
+        ):
             result = cmd_rollback_session(args, manager)
 
         assert result == 0
         # Verify the most recent session (session-newer) was loaded
         manager.load_manifest.assert_called_once()
-        assert 'session-newer' in str(manager.load_manifest.call_args)
+        assert "session-newer" in str(manager.load_manifest.call_args)
 
     def test_rollback_session_last_no_sessions(self, capsys):
         """Test 'last' flag when no sessions exist."""
         manager = Mock()
         manager.list_uncommitted_transactions.return_value = []
 
-        args = argparse.Namespace(session_id='last', verbose=False, format='table', no_confirm=False)
+        args = argparse.Namespace(
+            session_id="last", verbose=False, format="table", no_confirm=False
+        )
 
-        with patch('src.main.GitHelper.check_git_available', return_value=True):
+        with patch("src.main.GitHelper.check_git_available", return_value=True):
             result = cmd_rollback_session(args, manager)
 
         assert result == 1
         captured = capsys.readouterr()
-        assert 'No active sessions found' in captured.err
+        assert "No active sessions found" in captured.err
 
     def test_rollback_session_success(self, capsys):
         """Test successful session rollback."""
@@ -233,75 +247,87 @@ class TestRollbackSession:
 
         # Create mock manifest
         manifest = TransactionManifest(
-            session_id='test-session',
-            started_at='2024-01-01T10:00:00',
-            status='in_progress',
+            session_id="test-session",
+            started_at="2024-01-01T10:00:00",
+            status="in_progress",
             entries=[
                 TransactionEntry(
-                    entry_id='abc123',
-                    filepath='/test/file1.py',
-                    backup_path='/test/file1.py.bak',
-                    timestamp='2024-01-01T10:01:00',
-                    item_name='func1',
-                    item_type='function',
-                    language='python',
-                    success=True
+                    entry_id="abc123",
+                    filepath="/test/file1.py",
+                    backup_path="/test/file1.py.bak",
+                    timestamp="2024-01-01T10:01:00",
+                    item_name="func1",
+                    item_type="function",
+                    language="python",
+                    success=True,
                 )
-            ]
+            ],
         )
 
         manager.load_manifest.return_value = manifest
         manager.rollback_transaction.return_value = 1
 
-        args = argparse.Namespace(session_id='test-session', verbose=False, format='table', no_confirm=False)
+        args = argparse.Namespace(
+            session_id="test-session", verbose=False, format="table", no_confirm=False
+        )
 
         # Mock Path.exists to return True for manifest
-        with patch('src.main.GitHelper.check_git_available', return_value=True), \
-             patch('src.main.Path.exists', return_value=True), \
-             patch('builtins.input', return_value='y'):
+        with (
+            patch("src.main.GitHelper.check_git_available", return_value=True),
+            patch("src.main.Path.exists", return_value=True),
+            patch("builtins.input", return_value="y"),
+        ):
             result = cmd_rollback_session(args, manager)
 
         assert result == 0
         captured = capsys.readouterr()
-        assert 'Success! Rolled back 1 file(s)' in captured.out
+        assert "Success! Rolled back 1 file(s)" in captured.out
 
     def test_rollback_session_cancelled(self, capsys):
         """Test cancelling session rollback."""
         manager = Mock()
 
         manifest = TransactionManifest(
-            session_id='test-session',
-            started_at='2024-01-01T10:00:00',
-            status='in_progress',
-            entries=[]
+            session_id="test-session",
+            started_at="2024-01-01T10:00:00",
+            status="in_progress",
+            entries=[],
         )
 
         manager.load_manifest.return_value = manifest
 
-        args = argparse.Namespace(session_id='test-session', verbose=False, format='table', no_confirm=False)
+        args = argparse.Namespace(
+            session_id="test-session", verbose=False, format="table", no_confirm=False
+        )
 
-        with patch('src.main.GitHelper.check_git_available', return_value=True), \
-             patch('src.main.Path.exists', return_value=True), \
-             patch('builtins.input', return_value='n'):
+        with (
+            patch("src.main.GitHelper.check_git_available", return_value=True),
+            patch("src.main.Path.exists", return_value=True),
+            patch("builtins.input", return_value="n"),
+        ):
             result = cmd_rollback_session(args, manager)
 
         assert result == 0
         captured = capsys.readouterr()
-        assert 'Rollback cancelled' in captured.out
+        assert "Rollback cancelled" in captured.out
         manager.rollback_transaction.assert_not_called()
 
     def test_rollback_session_not_found(self, capsys):
         """Test rollback for non-existent session."""
         manager = Mock()
-        args = argparse.Namespace(session_id='nonexistent', verbose=False, format='table', no_confirm=False)
+        args = argparse.Namespace(
+            session_id="nonexistent", verbose=False, format="table", no_confirm=False
+        )
 
-        with patch('src.main.GitHelper.check_git_available', return_value=True), \
-             patch('src.main.Path.exists', return_value=False):
+        with (
+            patch("src.main.GitHelper.check_git_available", return_value=True),
+            patch("src.main.Path.exists", return_value=False),
+        ):
             result = cmd_rollback_session(args, manager)
 
         assert result == 1
         captured = capsys.readouterr()
-        assert 'Session not found: nonexistent' in captured.err
+        assert "Session not found: nonexistent" in captured.err
 
 
 class TestRollbackChange:
@@ -313,107 +339,115 @@ class TestRollbackChange:
 
         # Create mock sessions with changes
         session1 = TransactionManifest(
-            session_id='session-1',
-            started_at='2024-01-01T10:00:00',
-            status='in_progress',
-            entries=[]
+            session_id="session-1",
+            started_at="2024-01-01T10:00:00",
+            status="in_progress",
+            entries=[],
         )
         session2 = TransactionManifest(
-            session_id='session-2',
-            started_at='2024-01-01T11:00:00',
-            status='in_progress',
-            entries=[]
+            session_id="session-2",
+            started_at="2024-01-01T11:00:00",
+            status="in_progress",
+            entries=[],
         )
 
         # Create changes with different timestamps
         change1 = TransactionEntry(
-            entry_id='abc123',
-            filepath='/test/file1.py',
-            backup_path='/test/file1.py.bak',
-            timestamp='2024-01-01T10:01:00',
-            item_name='func1',
-            item_type='function',
-            language='python',
-            success=True
+            entry_id="abc123",
+            filepath="/test/file1.py",
+            backup_path="/test/file1.py.bak",
+            timestamp="2024-01-01T10:01:00",
+            item_name="func1",
+            item_type="function",
+            language="python",
+            success=True,
         )
         change2 = TransactionEntry(
-            entry_id='def456',
-            filepath='/test/file2.py',
-            backup_path='/test/file2.py.bak',
-            timestamp='2024-01-01T11:01:00',  # Most recent
-            item_name='func2',
-            item_type='function',
-            language='python',
-            success=True
+            entry_id="def456",
+            filepath="/test/file2.py",
+            backup_path="/test/file2.py.bak",
+            timestamp="2024-01-01T11:01:00",  # Most recent
+            item_name="func2",
+            item_type="function",
+            language="python",
+            success=True,
         )
         change3 = TransactionEntry(
-            entry_id='ghi789',
-            filepath='/test/file3.py',
-            backup_path='/test/file3.py.bak',
-            timestamp='2024-01-01T10:30:00',
-            item_name='func3',
-            item_type='function',
-            language='python',
-            success=True
+            entry_id="ghi789",
+            filepath="/test/file3.py",
+            backup_path="/test/file3.py.bak",
+            timestamp="2024-01-01T10:30:00",
+            item_name="func3",
+            item_type="function",
+            language="python",
+            success=True,
         )
 
         manager.list_uncommitted_transactions.return_value = [session1, session2]
-        manager.list_session_changes.side_effect = lambda sid: [change1, change3] if sid == 'session-1' else [change2]
+        manager.list_session_changes.side_effect = lambda sid: (
+            [change1, change3] if sid == "session-1" else [change2]
+        )
         manager.get_change_diff.return_value = "diff --git a/file2.py b/file2.py\n..."
         manager.rollback_change.return_value = RollbackResult(
             success=True,
             restored_count=1,
             failed_count=0,
             conflicts=[],
-            status='completed'
+            status="completed",
         )
 
-        args = argparse.Namespace(entry_id='last', verbose=False, format='table', no_confirm=True)
+        args = argparse.Namespace(
+            entry_id="last", verbose=False, format="table", no_confirm=True
+        )
 
-        with patch('src.main.GitHelper.check_git_available', return_value=True):
+        with patch("src.main.GitHelper.check_git_available", return_value=True):
             result = cmd_rollback_change(args, manager)
 
         assert result == 0
         # Verify the most recent change (def456) was used
-        manager.get_change_diff.assert_called_with('def456')
-        manager.rollback_change.assert_called_with('def456')
+        manager.get_change_diff.assert_called_with("def456")
+        manager.rollback_change.assert_called_with("def456")
 
     def test_rollback_change_last_no_sessions(self, capsys):
         """Test 'last' flag when no sessions exist."""
         manager = Mock()
         manager.list_uncommitted_transactions.return_value = []
 
-        args = argparse.Namespace(entry_id='last', verbose=False, format='table', no_confirm=False)
+        args = argparse.Namespace(
+            entry_id="last", verbose=False, format="table", no_confirm=False
+        )
 
-        with patch('src.main.GitHelper.check_git_available', return_value=True):
+        with patch("src.main.GitHelper.check_git_available", return_value=True):
             result = cmd_rollback_change(args, manager)
 
         assert result == 1
         captured = capsys.readouterr()
-        assert 'No active sessions found' in captured.err
+        assert "No active sessions found" in captured.err
 
     def test_rollback_change_last_no_changes(self, capsys):
         """Test 'last' flag when sessions exist but have no changes."""
         manager = Mock()
 
         session = TransactionManifest(
-            session_id='session-1',
-            started_at='2024-01-01T10:00:00',
-            status='in_progress',
-            entries=[]
+            session_id="session-1",
+            started_at="2024-01-01T10:00:00",
+            status="in_progress",
+            entries=[],
         )
 
         manager.list_uncommitted_transactions.return_value = [session]
         manager.list_session_changes.return_value = []
 
-        args = argparse.Namespace(entry_id='last', verbose=False, format='table', no_confirm=False)
+        args = argparse.Namespace(
+            entry_id="last", verbose=False, format="table", no_confirm=False
+        )
 
-        with patch('src.main.GitHelper.check_git_available', return_value=True):
+        with patch("src.main.GitHelper.check_git_available", return_value=True):
             result = cmd_rollback_change(args, manager)
 
         assert result == 1
         captured = capsys.readouterr()
-        assert 'No changes found' in captured.err
+        assert "No changes found" in captured.err
 
     def test_rollback_change_success(self, capsys):
         """Test successful change rollback."""
@@ -424,18 +458,22 @@ class TestRollbackChange:
             restored_count=1,
             failed_count=0,
             conflicts=[],
-            status='completed'
+            status="completed",
         )
 
-        args = argparse.Namespace(entry_id='abc123', verbose=False, format='table', no_confirm=False)
+        args = argparse.Namespace(
+            entry_id="abc123", verbose=False, format="table", no_confirm=False
+        )
 
-        with patch('src.main.GitHelper.check_git_available', return_value=True), \
-             patch('builtins.input', return_value='y'):
+        with (
+            patch("src.main.GitHelper.check_git_available", return_value=True),
+            patch("builtins.input", return_value="y"),
+        ):
             result = cmd_rollback_change(args, manager)
 
         assert result == 0
         captured = capsys.readouterr()
-        assert 'Success! Rolled back 1 file(s)' in captured.out
+        assert "Success! Rolled back 1 file(s)" in captured.out
 
     def test_rollback_change_with_conflicts(self, capsys):
         """Test change rollback with conflicts."""
@@ -445,21 +483,25 @@ class TestRollbackChange:
             success=False,
             restored_count=0,
             failed_count=1,
-            conflicts=['/test/file.py'],
-            status='failed'
+            conflicts=["/test/file.py"],
+            status="failed",
         )
 
-        args = argparse.Namespace(entry_id='abc123', verbose=False, format='table', no_confirm=False)
+        args = argparse.Namespace(
+            entry_id="abc123", verbose=False, format="table", no_confirm=False
+        )
 
-        with patch('src.main.GitHelper.check_git_available', return_value=True), \
-             patch('builtins.input', return_value='y'):
+        with (
+            patch("src.main.GitHelper.check_git_available", return_value=True),
+            patch("builtins.input", return_value="y"),
+        ):
             result = cmd_rollback_change(args, manager)
 
         assert result == 1
         captured = capsys.readouterr()
-        assert 'Rollback failed' in captured.err
-        assert 'Conflict Details' in captured.err
-        assert 'Resolution Options' in captured.err
+        assert "Rollback failed" in captured.err
+        assert "Conflict Details" in captured.err
+        assert "Resolution Options" in captured.err
 
 
 class TestInteractiveRollback:
@@ -471,23 +513,23 @@ class TestInteractiveRollback:
 
         # Mock session data
         session = TransactionManifest(
-            session_id='test-session',
-            started_at='2024-01-01T10:00:00',
-            status='in_progress',
-            entries=[]
+            session_id="test-session",
+            started_at="2024-01-01T10:00:00",
+            status="in_progress",
+            entries=[],
         )
         manager.list_uncommitted_transactions.return_value = [session]
 
         # Mock changes data
         change = TransactionEntry(
-            entry_id='abc123',
-            filepath='/test/file1.py',
-            backup_path='/test/file1.py.bak',
-            timestamp='2024-01-01T10:01:00',
-            item_name='func1',
-            item_type='function',
-            language='python',
-            success=True
+            entry_id="abc123",
+            filepath="/test/file1.py",
+            backup_path="/test/file1.py.bak",
+            timestamp="2024-01-01T10:01:00",
+            item_name="func1",
+            item_type="function",
+            language="python",
+            success=True,
         )
         manager.list_session_changes.return_value = [change]
 
@@ -497,39 +539,43 @@ class TestInteractiveRollback:
             restored_count=1,
             failed_count=0,
             conflicts=[],
-            status='completed'
+            status="completed",
         )
 
         args = argparse.Namespace(verbose=False)
 
         # Simulate user input: select session 1, change 1, confirm yes
-        with patch('src.main.GitHelper.check_git_available', return_value=True), \
-             patch('builtins.input', side_effect=['1', '1', 'y']):
+        with (
+            patch("src.main.GitHelper.check_git_available", return_value=True),
+            patch("builtins.input", side_effect=["1", "1", "y"]),
+        ):
             result = cmd_interactive_rollback(args, manager)
 
         assert result == 0
         captured = capsys.readouterr()
-        assert 'Success! Rolled back' in captured.out
+        assert "Success! Rolled back" in captured.out
 
     def test_interactive_rollback_cancel(self, capsys):
         """Test cancelling interactive rollback."""
         manager = Mock()
 
         session = TransactionManifest(
-            session_id='test-session',
-            started_at='2024-01-01T10:00:00',
-            status='in_progress',
-            entries=[]
+            session_id="test-session",
+            started_at="2024-01-01T10:00:00",
+            status="in_progress",
+            entries=[],
         )
         manager.list_uncommitted_transactions.return_value = [session]
 
         args = argparse.Namespace(verbose=False)
 
         # Simulate user input: quit at session selection
-        with patch('src.main.GitHelper.check_git_available', return_value=True), \
-             patch('builtins.input', return_value='q'):
+        with (
+            patch("src.main.GitHelper.check_git_available", return_value=True),
+            patch("builtins.input", return_value="q"),
+        ):
             result = cmd_interactive_rollback(args, manager)
 
         assert result == 0
         captured = capsys.readouterr()
-        assert 'Cancelled' in captured.out
+        assert "Cancelled" in captured.out

--- a/analyzer/tests/test_schema_versioning.py
+++ b/analyzer/tests/test_schema_versioning.py
@@ -26,19 +26,19 @@ Metadata:
   timestamp: 2024-01-01T10:00:00"""
 
     # Mock git command to return short hash
-    with patch('src.utils.git_helper.GitHelper.run_git_command') as mock_git:
+    with patch("src.utils.git_helper.GitHelper.run_git_command") as mock_git:
         mock_result = Mock()
-        mock_result.stdout = 'abc123'
+        mock_result.stdout = "abc123"
         mock_git.return_value = mock_result
 
-        entry = manager._parse_commit_to_entry('abc123', commit_message)
+        entry = manager._parse_commit_to_entry("abc123", commit_message)
 
     assert entry is not None
-    assert entry.item_name == 'test_function'
-    assert entry.item_type == 'function'
-    assert entry.language == 'python'
-    assert entry.filepath == '/test/file.py'
-    assert entry.entry_id == 'abc123'
+    assert entry.item_name == "test_function"
+    assert entry.item_type == "function"
+    assert entry.language == "python"
+    assert entry.filepath == "/test/file.py"
+    assert entry.entry_id == "abc123"
 
 
 def test_parse_version_0_metadata_backward_compat():
@@ -56,16 +56,16 @@ Metadata:
   backup_path: /test/old.py.bak
   timestamp: 2024-01-01T10:00:00"""
 
-    with patch('src.utils.git_helper.GitHelper.run_git_command') as mock_git:
+    with patch("src.utils.git_helper.GitHelper.run_git_command") as mock_git:
         mock_result = Mock()
-        mock_result.stdout = 'def456'
+        mock_result.stdout = "def456"
         mock_git.return_value = mock_result
 
-        entry = manager._parse_commit_to_entry('def456', commit_message)
+        entry = manager._parse_commit_to_entry("def456", commit_message)
 
     assert entry is not None
-    assert entry.item_name == 'old_function'
-    assert entry.item_type == 'function'
+    assert entry.item_name == "old_function"
+    assert entry.item_type == "function"
 
 
 def test_parse_malformed_version_number():
@@ -83,16 +83,16 @@ Metadata:
   backup_path: /test/file.py.bak
   timestamp: 2024-01-01T10:00:00"""
 
-    with patch('src.utils.git_helper.GitHelper.run_git_command') as mock_git:
+    with patch("src.utils.git_helper.GitHelper.run_git_command") as mock_git:
         mock_result = Mock()
-        mock_result.stdout = 'ghi789'
+        mock_result.stdout = "ghi789"
         mock_git.return_value = mock_result
 
         # Should still parse (defaults to version 0 on error)
-        entry = manager._parse_commit_to_entry('ghi789', commit_message)
+        entry = manager._parse_commit_to_entry("ghi789", commit_message)
 
     assert entry is not None
-    assert entry.item_name == 'test_function'
+    assert entry.item_name == "test_function"
 
 
 def test_parse_missing_required_fields_version_1():
@@ -110,7 +110,7 @@ Metadata:
   backup_path: /test/file.py.bak
   timestamp: 2024-01-01T10:00:00"""
 
-    entry = manager._parse_commit_to_entry('jkl012', commit_message)
+    entry = manager._parse_commit_to_entry("jkl012", commit_message)
 
     # Should return None due to missing required field in version 1
     assert entry is None
@@ -130,17 +130,17 @@ Metadata:
   backup_path: /test/old.py.bak
   timestamp: 2024-01-01T10:00:00"""
 
-    with patch('src.utils.git_helper.GitHelper.run_git_command') as mock_git:
+    with patch("src.utils.git_helper.GitHelper.run_git_command") as mock_git:
         mock_result = Mock()
-        mock_result.stdout = 'mno345'
+        mock_result.stdout = "mno345"
         mock_git.return_value = mock_result
 
-        entry = manager._parse_commit_to_entry('mno345', commit_message)
+        entry = manager._parse_commit_to_entry("mno345", commit_message)
 
     # Should still parse (backward compatibility)
     assert entry is not None
-    assert entry.item_name == 'old_function'
-    assert entry.language == ''  # Empty string for missing field
+    assert entry.item_name == "old_function"
+    assert entry.language == ""  # Empty string for missing field
 
 
 def test_parse_no_metadata_section():
@@ -151,7 +151,7 @@ def test_parse_no_metadata_section():
 
 Some description but no metadata."""
 
-    entry = manager._parse_commit_to_entry('pqr678', commit_message)
+    entry = manager._parse_commit_to_entry("pqr678", commit_message)
 
     # Should return None (no metadata found)
     assert entry is None
@@ -165,7 +165,7 @@ def test_parse_non_docimp_commit():
 
 Added some files"""
 
-    entry = manager._parse_commit_to_entry('stu901', commit_message)
+    entry = manager._parse_commit_to_entry("stu901", commit_message)
 
     # Should return None (not a docimp commit)
     assert entry is None
@@ -187,14 +187,14 @@ Metadata:
   timestamp: 2024-01-01T10:00:00
   extra_field: some_value"""
 
-    with patch('src.utils.git_helper.GitHelper.run_git_command') as mock_git:
+    with patch("src.utils.git_helper.GitHelper.run_git_command") as mock_git:
         mock_result = Mock()
-        mock_result.stdout = 'vwx234'
+        mock_result.stdout = "vwx234"
         mock_git.return_value = mock_result
 
-        entry = manager._parse_commit_to_entry('vwx234', commit_message)
+        entry = manager._parse_commit_to_entry("vwx234", commit_message)
 
     # Should parse successfully with all required fields
     assert entry is not None
-    assert entry.item_name == 'complete_function'
-    assert entry.language == 'typescript'
+    assert entry.item_name == "complete_function"
+    assert entry.language == "typescript"

--- a/analyzer/tests/test_scoring.py
+++ b/analyzer/tests/test_scoring.py
@@ -24,32 +24,32 @@ class TestImpactScorer:
     def simple_item(self):
         """Return a simple CodeItem with low complexity."""
         return CodeItem(
-            name='add',
-            type='function',
-            filepath='test.py',
+            name="add",
+            type="function",
+            filepath="test.py",
             line_number=1,
             end_line=5,
-            language='python',
+            language="python",
             complexity=1,
             has_docs=False,
-            export_type='internal',
-            module_system='unknown'
+            export_type="internal",
+            module_system="unknown",
         )
 
     @pytest.fixture
     def complex_item(self):
         """Return a complex CodeItem with high complexity."""
         return CodeItem(
-            name='process_payment',
-            type='function',
-            filepath='service.py',
+            name="process_payment",
+            type="function",
+            filepath="service.py",
             line_number=10,
             end_line=25,
-            language='python',
+            language="python",
             complexity=15,
             has_docs=False,
-            export_type='internal',
-            module_system='unknown'
+            export_type="internal",
+            module_system="unknown",
         )
 
     def test_scorer_initialization_valid_weights(self):
@@ -129,16 +129,16 @@ class TestImpactScorer:
     def test_max_complexity_capped_at_100(self, scorer):
         """Test that very high complexity is capped at 100."""
         very_complex = CodeItem(
-            name='monster_function',
-            type='function',
-            filepath='legacy.py',
+            name="monster_function",
+            type="function",
+            filepath="legacy.py",
             line_number=1,
             end_line=50,
-            language='python',
+            language="python",
             complexity=50,  # Would be 250 without cap
             has_docs=False,
-            export_type='internal',
-            module_system='unknown'
+            export_type="internal",
+            module_system="unknown",
         )
 
         score = scorer.calculate_score(very_complex)

--- a/analyzer/tests/test_state_manager.py
+++ b/analyzer/tests/test_state_manager.py
@@ -27,46 +27,46 @@ class TestStateManager:
     def test_get_state_dir_returns_correct_path(self, temp_dir):
         """Test that get_state_dir returns correct path."""
         state_dir = StateManager.get_state_dir(temp_dir)
-        expected = temp_dir / '.docimp'
+        expected = temp_dir / ".docimp"
         assert state_dir == expected.resolve()
 
     def test_get_session_reports_dir_returns_correct_path(self, temp_dir):
         """Test that get_session_reports_dir returns correct path."""
         session_dir = StateManager.get_session_reports_dir(temp_dir)
-        expected = temp_dir / '.docimp' / 'session-reports'
+        expected = temp_dir / ".docimp" / "session-reports"
         assert session_dir == expected.resolve()
 
     def test_get_history_dir_returns_correct_path(self, temp_dir):
         """Test that get_history_dir returns correct path."""
         history_dir = StateManager.get_history_dir(temp_dir)
-        expected = temp_dir / '.docimp' / 'history'
+        expected = temp_dir / ".docimp" / "history"
         assert history_dir == expected.resolve()
 
     def test_get_audit_file_returns_correct_path(self, temp_dir):
         """Test that get_audit_file returns correct path."""
         audit_file = StateManager.get_audit_file(temp_dir)
-        expected = temp_dir / '.docimp' / 'session-reports' / 'audit.json'
+        expected = temp_dir / ".docimp" / "session-reports" / "audit.json"
         assert audit_file == expected.resolve()
 
     def test_get_plan_file_returns_correct_path(self, temp_dir):
         """Test that get_plan_file returns correct path."""
         plan_file = StateManager.get_plan_file(temp_dir)
-        expected = temp_dir / '.docimp' / 'session-reports' / 'plan.json'
+        expected = temp_dir / ".docimp" / "session-reports" / "plan.json"
         assert plan_file == expected.resolve()
 
     def test_get_analyze_file_returns_correct_path(self, temp_dir):
         """Test that get_analyze_file returns correct path."""
         analyze_file = StateManager.get_analyze_file(temp_dir)
-        expected = temp_dir / '.docimp' / 'session-reports' / 'analyze-latest.json'
+        expected = temp_dir / ".docimp" / "session-reports" / "analyze-latest.json"
         assert analyze_file == expected.resolve()
 
     def test_ensure_state_dir_creates_directories(self, temp_dir):
         """Test that ensure_state_dir creates all required directories."""
         StateManager.ensure_state_dir(temp_dir)
 
-        state_dir = temp_dir / '.docimp'
-        session_dir = temp_dir / '.docimp' / 'session-reports'
-        history_dir = temp_dir / '.docimp' / 'history'
+        state_dir = temp_dir / ".docimp"
+        session_dir = temp_dir / ".docimp" / "session-reports"
+        history_dir = temp_dir / ".docimp" / "history"
 
         assert state_dir.exists()
         assert state_dir.is_dir()
@@ -82,7 +82,7 @@ class TestStateManager:
         StateManager.ensure_state_dir(temp_dir)  # And again
 
         # Should still work fine
-        state_dir = temp_dir / '.docimp'
+        state_dir = temp_dir / ".docimp"
         assert state_dir.exists()
 
     def test_clear_session_reports_removes_files(self, temp_dir):
@@ -92,23 +92,23 @@ class TestStateManager:
         session_dir = StateManager.get_session_reports_dir(temp_dir)
 
         # Create some test files
-        (session_dir / 'audit.json').write_text('{"test": "data"}')
-        (session_dir / 'plan.json').write_text('{"test": "data"}')
-        (session_dir / 'analyze-latest.json').write_text('{"test": "data"}')
+        (session_dir / "audit.json").write_text('{"test": "data"}')
+        (session_dir / "plan.json").write_text('{"test": "data"}')
+        (session_dir / "analyze-latest.json").write_text('{"test": "data"}')
 
         # Verify files exist
-        assert (session_dir / 'audit.json').exists()
-        assert (session_dir / 'plan.json').exists()
-        assert (session_dir / 'analyze-latest.json').exists()
+        assert (session_dir / "audit.json").exists()
+        assert (session_dir / "plan.json").exists()
+        assert (session_dir / "analyze-latest.json").exists()
 
         # Clear
         files_removed = StateManager.clear_session_reports(temp_dir)
 
         # Verify files removed
         assert files_removed == 3
-        assert not (session_dir / 'audit.json').exists()
-        assert not (session_dir / 'plan.json').exists()
-        assert not (session_dir / 'analyze-latest.json').exists()
+        assert not (session_dir / "audit.json").exists()
+        assert not (session_dir / "plan.json").exists()
+        assert not (session_dir / "analyze-latest.json").exists()
 
         # Verify directory still exists
         assert session_dir.exists()
@@ -121,19 +121,19 @@ class TestStateManager:
         history_dir = StateManager.get_history_dir(temp_dir)
 
         # Create files in session-reports
-        (session_dir / 'audit.json').write_text('{"test": "data"}')
+        (session_dir / "audit.json").write_text('{"test": "data"}')
 
         # Create files in history
-        (history_dir / 'old-audit.json').write_text('{"test": "old"}')
+        (history_dir / "old-audit.json").write_text('{"test": "old"}')
 
         # Clear session reports
         StateManager.clear_session_reports(temp_dir)
 
         # Verify session file removed
-        assert not (session_dir / 'audit.json').exists()
+        assert not (session_dir / "audit.json").exists()
 
         # Verify history file preserved
-        assert (history_dir / 'old-audit.json').exists()
+        assert (history_dir / "old-audit.json").exists()
 
     def test_clear_session_reports_creates_dir_if_missing(self, temp_dir):
         """Test that clear_session_reports creates directory if it doesn't exist."""
@@ -172,30 +172,33 @@ class TestStateManager:
         # Should not raise an error
         state_dir = StateManager.get_state_dir()
         assert state_dir.is_absolute()
-        assert state_dir.name == '.docimp'
+        assert state_dir.name == ".docimp"
 
     def test_validate_write_permission_succeeds_for_writable_file(self, temp_dir):
         """Test that validate_write_permission succeeds for writable files."""
         # Create a writable file
-        test_file = temp_dir / 'writable.json'
+        test_file = temp_dir / "writable.json"
         test_file.write_text('{"test": "data"}')
 
         # Should not raise an exception
         StateManager.validate_write_permission(test_file)
 
     def test_validate_write_permission_succeeds_for_writable_directory(self, temp_dir):
-        """Test that validate_write_permission succeeds when file doesn't exist but directory is writable."""
+        """Test that validate_write_permission succeeds when file doesn't
+
+        exist but directory is writable."""
         # File doesn't exist yet, but temp_dir is writable
-        test_file = temp_dir / 'new-file.json'
+        test_file = temp_dir / "new-file.json"
         assert not test_file.exists()
 
         # Should not raise an exception
         StateManager.validate_write_permission(test_file)
 
     def test_validate_write_permission_fails_for_readonly_file(self, temp_dir):
-        """Test that validate_write_permission raises PermissionError for read-only files."""
+        """Test that validate_write_permission raises PermissionError for
+        read-only files."""
         # Create a read-only file
-        test_file = temp_dir / 'readonly.json'
+        test_file = temp_dir / "readonly.json"
         test_file.write_text('{"test": "data"}')
         test_file.chmod(0o444)  # Read-only
 
@@ -204,20 +207,21 @@ class TestStateManager:
             StateManager.validate_write_permission(test_file)
 
         error_message = str(exc_info.value).lower()
-        assert 'permission' in error_message
-        assert 'write' in error_message or 'read-only' in error_message
+        assert "permission" in error_message
+        assert "write" in error_message or "read-only" in error_message
 
         # Cleanup: restore permissions for deletion
         test_file.chmod(0o644)
 
     def test_validate_write_permission_fails_for_readonly_directory(self, temp_dir):
-        """Test that validate_write_permission raises PermissionError when directory is read-only."""
+        """Test that validate_write_permission raises PermissionError when
+        directory is read-only."""
         # Create a read-only directory
-        readonly_dir = temp_dir / 'readonly'
+        readonly_dir = temp_dir / "readonly"
         readonly_dir.mkdir()
         readonly_dir.chmod(0o555)  # Read and execute only, no write
 
-        test_file = readonly_dir / 'new-file.json'
+        test_file = readonly_dir / "new-file.json"
         assert not test_file.exists()
 
         # Should raise PermissionError with helpful message
@@ -225,16 +229,17 @@ class TestStateManager:
             StateManager.validate_write_permission(test_file)
 
         error_message = str(exc_info.value).lower()
-        assert 'permission' in error_message
-        assert 'write' in error_message or 'access' in error_message
+        assert "permission" in error_message
+        assert "write" in error_message or "access" in error_message
 
         # Cleanup: restore permissions for deletion
         readonly_dir.chmod(0o755)
 
     def test_validate_write_permission_fails_for_nonexistent_directory(self, temp_dir):
-        """Test that validate_write_permission raises PermissionError when parent directory doesn't exist."""
+        """Test that validate_write_permission raises PermissionError when
+        parent directory doesn't exist."""
         # Parent directory doesn't exist
-        test_file = temp_dir / 'nonexistent' / 'new-file.json'
+        test_file = temp_dir / "nonexistent" / "new-file.json"
         assert not test_file.parent.exists()
 
         # Should raise PermissionError with helpful message
@@ -242,20 +247,26 @@ class TestStateManager:
             StateManager.validate_write_permission(test_file)
 
         error_message = str(exc_info.value).lower()
-        assert 'permission' in error_message
-        assert 'does not exist' in error_message or 'directory' in error_message
+        assert "permission" in error_message
+        assert "does not exist" in error_message or "directory" in error_message
 
     def test_get_transactions_dir_returns_correct_path(self, temp_dir):
         """Test that get_transactions_dir returns correct path."""
         transactions_dir = StateManager.get_transactions_dir(temp_dir)
-        expected = temp_dir / '.docimp' / 'session-reports' / 'transactions'
+        expected = temp_dir / ".docimp" / "session-reports" / "transactions"
         assert transactions_dir == expected.resolve()
 
     def test_get_transaction_file_returns_correct_path(self, temp_dir):
         """Test that get_transaction_file returns correct path for session ID."""
-        session_id = 'abc-123-def'
+        session_id = "abc-123-def"
         transaction_file = StateManager.get_transaction_file(session_id, temp_dir)
-        expected = temp_dir / '.docimp' / 'session-reports' / 'transactions' / 'transaction-abc-123-def.json'
+        expected = (
+            temp_dir
+            / ".docimp"
+            / "session-reports"
+            / "transactions"
+            / "transaction-abc-123-def.json"
+        )
         assert transaction_file == expected.resolve()
 
     def test_list_transaction_files_empty_directory(self, temp_dir):
@@ -264,31 +275,32 @@ class TestStateManager:
         assert files == []
 
     def test_list_transaction_files_returns_sorted_files(self, temp_dir):
-        """Test that list_transaction_files returns files sorted by modification time."""
+        """Test that list_transaction_files returns files sorted by
+        modification time."""
         import time
 
         transactions_dir = StateManager.get_transactions_dir(temp_dir)
         transactions_dir.mkdir(parents=True)
 
         # Create files with delays to ensure different timestamps
-        file1 = transactions_dir / 'transaction-1.json'
-        file1.write_text('{}')
+        file1 = transactions_dir / "transaction-1.json"
+        file1.write_text("{}")
         time.sleep(0.01)
 
-        file2 = transactions_dir / 'transaction-2.json'
-        file2.write_text('{}')
+        file2 = transactions_dir / "transaction-2.json"
+        file2.write_text("{}")
         time.sleep(0.01)
 
-        file3 = transactions_dir / 'transaction-3.json'
-        file3.write_text('{}')
+        file3 = transactions_dir / "transaction-3.json"
+        file3.write_text("{}")
 
         files = StateManager.list_transaction_files(temp_dir)
 
         # Should be sorted newest first
         assert len(files) == 3
-        assert files[0].name == 'transaction-3.json'
-        assert files[1].name == 'transaction-2.json'
-        assert files[2].name == 'transaction-1.json'
+        assert files[0].name == "transaction-3.json"
+        assert files[1].name == "transaction-2.json"
+        assert files[2].name == "transaction-1.json"
 
     def test_list_transaction_files_ignores_non_transaction_files(self, temp_dir):
         """Test that list_transaction_files only returns transaction-*.json files."""
@@ -296,15 +308,15 @@ class TestStateManager:
         transactions_dir.mkdir(parents=True)
 
         # Create transaction files
-        (transactions_dir / 'transaction-1.json').write_text('{}')
-        (transactions_dir / 'transaction-2.json').write_text('{}')
+        (transactions_dir / "transaction-1.json").write_text("{}")
+        (transactions_dir / "transaction-2.json").write_text("{}")
 
         # Create non-transaction files (should be ignored)
-        (transactions_dir / 'other-file.json').write_text('{}')
-        (transactions_dir / 'README.md').write_text('# Transactions')
+        (transactions_dir / "other-file.json").write_text("{}")
+        (transactions_dir / "README.md").write_text("# Transactions")
 
         files = StateManager.list_transaction_files(temp_dir)
 
         # Should only return transaction-* files
         assert len(files) == 2
-        assert all('transaction-' in f.name for f in files)
+        assert all("transaction-" in f.name for f in files)

--- a/analyzer/tests/test_suggest_command.py
+++ b/analyzer/tests/test_suggest_command.py
@@ -30,17 +30,17 @@ class TestSuggestCommandFeedbackIntegration:
         mock_client.generate_docstring.return_value = "Test docstring"
 
         args = argparse.Namespace(
-            target='test.py:test_function',
-            style_guide='google',
-            tone='concise',
+            target="test.py:test_function",
+            style_guide="google",
+            tone="concise",
             verbose=False,
-            feedback=None  # No feedback
+            feedback=None,  # No feedback
         )
 
         # Mock file reading
-        test_code = 'def test_function():\n    pass'
-        with patch('builtins.open', mock_open(read_data=test_code)):
-            with patch('pathlib.Path.exists', return_value=True):
+        test_code = "def test_function():\n    pass"
+        with patch("builtins.open", mock_open(read_data=test_code)):
+            with patch("pathlib.Path.exists", return_value=True):
                 # Execute
                 exit_code = cmd_suggest(args, mock_client, mock_builder)
 
@@ -48,7 +48,7 @@ class TestSuggestCommandFeedbackIntegration:
         assert exit_code == 0
         mock_builder.build_prompt.assert_called_once()
         call_kwargs = mock_builder.build_prompt.call_args.kwargs
-        assert call_kwargs['feedback'] is None
+        assert call_kwargs["feedback"] is None
         mock_client.generate_docstring.assert_called_once_with("Test prompt")
 
     def test_suggest_with_feedback(self):
@@ -61,17 +61,17 @@ class TestSuggestCommandFeedbackIntegration:
 
         feedback_text = "Add more detail about error handling"
         args = argparse.Namespace(
-            target='test.py:test_function',
-            style_guide='google',
-            tone='concise',
+            target="test.py:test_function",
+            style_guide="google",
+            tone="concise",
             verbose=False,
-            feedback=feedback_text
+            feedback=feedback_text,
         )
 
         # Mock file reading
-        test_code = 'def test_function():\n    pass'
-        with patch('builtins.open', mock_open(read_data=test_code)):
-            with patch('pathlib.Path.exists', return_value=True):
+        test_code = "def test_function():\n    pass"
+        with patch("builtins.open", mock_open(read_data=test_code)):
+            with patch("pathlib.Path.exists", return_value=True):
                 # Execute
                 exit_code = cmd_suggest(args, mock_client, mock_builder)
 
@@ -79,8 +79,10 @@ class TestSuggestCommandFeedbackIntegration:
         assert exit_code == 0
         mock_builder.build_prompt.assert_called_once()
         call_kwargs = mock_builder.build_prompt.call_args.kwargs
-        assert call_kwargs['feedback'] == feedback_text
-        mock_client.generate_docstring.assert_called_once_with("Test prompt with feedback")
+        assert call_kwargs["feedback"] == feedback_text
+        mock_client.generate_docstring.assert_called_once_with(
+            "Test prompt with feedback"
+        )
 
     def test_suggest_with_multiline_feedback(self):
         """Test suggest command handles multiline feedback correctly."""
@@ -96,26 +98,26 @@ class TestSuggestCommandFeedbackIntegration:
 3. Explaining return value"""
 
         args = argparse.Namespace(
-            target='test.py:test_function',
-            style_guide='google',
-            tone='concise',
+            target="test.py:test_function",
+            style_guide="google",
+            tone="concise",
             verbose=False,
-            feedback=multiline_feedback
+            feedback=multiline_feedback,
         )
 
         # Mock file reading
-        test_code = 'def test_function(a, b):\n    return a + b'
-        with patch('builtins.open', mock_open(read_data=test_code)):
-            with patch('pathlib.Path.exists', return_value=True):
+        test_code = "def test_function(a, b):\n    return a + b"
+        with patch("builtins.open", mock_open(read_data=test_code)):
+            with patch("pathlib.Path.exists", return_value=True):
                 # Execute
                 exit_code = cmd_suggest(args, mock_client, mock_builder)
 
         # Verify
         assert exit_code == 0
         call_kwargs = mock_builder.build_prompt.call_args.kwargs
-        assert call_kwargs['feedback'] == multiline_feedback
-        assert 'Adding parameter descriptions' in call_kwargs['feedback']
-        assert 'Including examples' in call_kwargs['feedback']
+        assert call_kwargs["feedback"] == multiline_feedback
+        assert "Adding parameter descriptions" in call_kwargs["feedback"]
+        assert "Including examples" in call_kwargs["feedback"]
 
     def test_suggest_with_special_characters_in_feedback(self):
         """Test suggest command handles special characters in feedback."""
@@ -125,29 +127,31 @@ class TestSuggestCommandFeedbackIntegration:
         mock_builder.build_prompt.return_value = "Test prompt"
         mock_client.generate_docstring.return_value = "Docstring"
 
-        feedback_with_special_chars = 'Use @param tags, add `code` formatting, and "quotes"'
+        feedback_with_special_chars = (
+            'Use @param tags, add `code` formatting, and "quotes"'
+        )
         args = argparse.Namespace(
-            target='test.py:test_function',
-            style_guide='google',
-            tone='concise',
+            target="test.py:test_function",
+            style_guide="google",
+            tone="concise",
             verbose=False,
-            feedback=feedback_with_special_chars
+            feedback=feedback_with_special_chars,
         )
 
         # Mock file reading
-        test_code = 'def test_function():\n    pass'
-        with patch('builtins.open', mock_open(read_data=test_code)):
-            with patch('pathlib.Path.exists', return_value=True):
+        test_code = "def test_function():\n    pass"
+        with patch("builtins.open", mock_open(read_data=test_code)):
+            with patch("pathlib.Path.exists", return_value=True):
                 # Execute
                 exit_code = cmd_suggest(args, mock_client, mock_builder)
 
         # Verify
         assert exit_code == 0
         call_kwargs = mock_builder.build_prompt.call_args.kwargs
-        assert call_kwargs['feedback'] == feedback_with_special_chars
-        assert '@param' in call_kwargs['feedback']
-        assert '`code`' in call_kwargs['feedback']
-        assert '"quotes"' in call_kwargs['feedback']
+        assert call_kwargs["feedback"] == feedback_with_special_chars
+        assert "@param" in call_kwargs["feedback"]
+        assert "`code`" in call_kwargs["feedback"]
+        assert '"quotes"' in call_kwargs["feedback"]
 
     def test_suggest_feedback_passed_for_python_file(self):
         """Test feedback is passed correctly for Python files."""
@@ -158,25 +162,25 @@ class TestSuggestCommandFeedbackIntegration:
         mock_client.generate_docstring.return_value = "Python docstring"
 
         args = argparse.Namespace(
-            target='module.py:my_function',
-            style_guide='google',
-            tone='concise',
+            target="module.py:my_function",
+            style_guide="google",
+            tone="concise",
             verbose=False,
-            feedback='Add examples'
+            feedback="Add examples",
         )
 
         # Mock file reading
-        test_code = 'def my_function(x):\n    return x * 2'
-        with patch('builtins.open', mock_open(read_data=test_code)):
-            with patch('pathlib.Path.exists', return_value=True):
+        test_code = "def my_function(x):\n    return x * 2"
+        with patch("builtins.open", mock_open(read_data=test_code)):
+            with patch("pathlib.Path.exists", return_value=True):
                 # Execute
                 exit_code = cmd_suggest(args, mock_client, mock_builder)
 
         # Verify
         assert exit_code == 0
         call_kwargs = mock_builder.build_prompt.call_args.kwargs
-        assert call_kwargs['language'] == 'python'
-        assert call_kwargs['feedback'] == 'Add examples'
+        assert call_kwargs["language"] == "python"
+        assert call_kwargs["feedback"] == "Add examples"
 
     def test_suggest_feedback_passed_for_typescript_file(self):
         """Test feedback is passed correctly for TypeScript files."""
@@ -187,25 +191,25 @@ class TestSuggestCommandFeedbackIntegration:
         mock_client.generate_docstring.return_value = "TS docstring"
 
         args = argparse.Namespace(
-            target='module.ts:myFunction',
-            style_guide='tsdoc-typedoc',
-            tone='concise',
+            target="module.ts:myFunction",
+            style_guide="tsdoc-typedoc",
+            tone="concise",
             verbose=False,
-            feedback='Use TSDoc format'
+            feedback="Use TSDoc format",
         )
 
         # Mock file reading
-        test_code = 'function myFunction(x: number): number { return x * 2; }'
-        with patch('builtins.open', mock_open(read_data=test_code)):
-            with patch('pathlib.Path.exists', return_value=True):
+        test_code = "function myFunction(x: number): number { return x * 2; }"
+        with patch("builtins.open", mock_open(read_data=test_code)):
+            with patch("pathlib.Path.exists", return_value=True):
                 # Execute
                 exit_code = cmd_suggest(args, mock_client, mock_builder)
 
         # Verify
         assert exit_code == 0
         call_kwargs = mock_builder.build_prompt.call_args.kwargs
-        assert call_kwargs['language'] == 'typescript'
-        assert call_kwargs['feedback'] == 'Use TSDoc format'
+        assert call_kwargs["language"] == "typescript"
+        assert call_kwargs["feedback"] == "Use TSDoc format"
 
     def test_suggest_feedback_passed_for_javascript_file(self):
         """Test feedback is passed correctly for JavaScript files."""
@@ -216,25 +220,25 @@ class TestSuggestCommandFeedbackIntegration:
         mock_client.generate_docstring.return_value = "JS docstring"
 
         args = argparse.Namespace(
-            target='module.js:myFunction',
-            style_guide='jsdoc-vanilla',
-            tone='concise',
+            target="module.js:myFunction",
+            style_guide="jsdoc-vanilla",
+            tone="concise",
             verbose=False,
-            feedback='Add type annotations'
+            feedback="Add type annotations",
         )
 
         # Mock file reading
-        test_code = 'function myFunction(x) { return x * 2; }'
-        with patch('builtins.open', mock_open(read_data=test_code)):
-            with patch('pathlib.Path.exists', return_value=True):
+        test_code = "function myFunction(x) { return x * 2; }"
+        with patch("builtins.open", mock_open(read_data=test_code)):
+            with patch("pathlib.Path.exists", return_value=True):
                 # Execute
                 exit_code = cmd_suggest(args, mock_client, mock_builder)
 
         # Verify
         assert exit_code == 0
         call_kwargs = mock_builder.build_prompt.call_args.kwargs
-        assert call_kwargs['language'] == 'javascript'
-        assert call_kwargs['feedback'] == 'Add type annotations'
+        assert call_kwargs["language"] == "javascript"
+        assert call_kwargs["feedback"] == "Add type annotations"
 
     def test_suggest_verbose_mode_with_feedback(self):
         """Test verbose output doesn't interfere with feedback."""
@@ -245,29 +249,31 @@ class TestSuggestCommandFeedbackIntegration:
         mock_client.generate_docstring.return_value = "Verbose docstring"
 
         args = argparse.Namespace(
-            target='test.py:test_function',
-            style_guide='google',
-            tone='detailed',
+            target="test.py:test_function",
+            style_guide="google",
+            tone="detailed",
             verbose=True,  # Verbose mode
-            feedback='Make it more detailed'
+            feedback="Make it more detailed",
         )
 
         # Mock file reading and stderr
-        test_code = 'def test_function():\n    pass'
-        with patch('builtins.open', mock_open(read_data=test_code)):
-            with patch('pathlib.Path.exists', return_value=True):
-                with patch('sys.stderr'):  # Suppress stderr output in tests
+        test_code = "def test_function():\n    pass"
+        with patch("builtins.open", mock_open(read_data=test_code)):
+            with patch("pathlib.Path.exists", return_value=True):
+                with patch("sys.stderr"):  # Suppress stderr output in tests
                     # Execute
                     exit_code = cmd_suggest(args, mock_client, mock_builder)
 
         # Verify
         assert exit_code == 0
         call_kwargs = mock_builder.build_prompt.call_args.kwargs
-        assert call_kwargs['feedback'] == 'Make it more detailed'
-        # Note: tone is set during PromptBuilder initialization, not in build_prompt call
+        assert call_kwargs["feedback"] == "Make it more detailed"
+        # Note: tone is set during PromptBuilder initialization, not in build_prompt
+        # call
 
     def test_suggest_empty_feedback_treated_as_none(self):
-        """Test that empty string feedback is passed as empty string (not converted to None)."""
+        """Test that empty string feedback is passed as empty string (not
+        converted to None)."""
         # Setup
         mock_client = Mock(spec=ClaudeClient)
         mock_builder = Mock(spec=PromptBuilder)
@@ -275,17 +281,17 @@ class TestSuggestCommandFeedbackIntegration:
         mock_client.generate_docstring.return_value = "Docstring"
 
         args = argparse.Namespace(
-            target='test.py:test_function',
-            style_guide='google',
-            tone='concise',
+            target="test.py:test_function",
+            style_guide="google",
+            tone="concise",
             verbose=False,
-            feedback=''  # Empty string
+            feedback="",  # Empty string
         )
 
         # Mock file reading
-        test_code = 'def test_function():\n    pass'
-        with patch('builtins.open', mock_open(read_data=test_code)):
-            with patch('pathlib.Path.exists', return_value=True):
+        test_code = "def test_function():\n    pass"
+        with patch("builtins.open", mock_open(read_data=test_code)):
+            with patch("pathlib.Path.exists", return_value=True):
                 # Execute
                 exit_code = cmd_suggest(args, mock_client, mock_builder)
 
@@ -293,4 +299,4 @@ class TestSuggestCommandFeedbackIntegration:
         assert exit_code == 0
         call_kwargs = mock_builder.build_prompt.call_args.kwargs
         # Empty string is passed as-is (PromptBuilder will handle stripping)
-        assert call_kwargs['feedback'] == ''
+        assert call_kwargs["feedback"] == ""

--- a/analyzer/tests/test_transaction_lifecycle.py
+++ b/analyzer/tests/test_transaction_lifecycle.py
@@ -27,24 +27,19 @@ class TestFullLifecycle:
             manager = TransactionManager(base_path=base_path, use_git=False)
 
             # Begin transaction
-            manifest = manager.begin_transaction('lifecycle-test')
-            assert manifest.session_id == 'lifecycle-test'
-            assert manifest.status == 'in_progress'
+            manifest = manager.begin_transaction("lifecycle-test")
+            assert manifest.session_id == "lifecycle-test"
+            assert manifest.status == "in_progress"
 
             # Record 3 writes
             for i in range(3):
-                filepath = base_path / f'file{i}.py'
-                filepath.write_text(f'def func{i}(): pass')
-                backup = str(filepath) + '.bak'
-                Path(backup).write_text('')  # Create backup
+                filepath = base_path / f"file{i}.py"
+                filepath.write_text(f"def func{i}(): pass")
+                backup = str(filepath) + ".bak"
+                Path(backup).write_text("")  # Create backup
 
                 manager.record_write(
-                    manifest,
-                    str(filepath),
-                    backup,
-                    f'func{i}',
-                    'function',
-                    'python'
+                    manifest, str(filepath), backup, f"func{i}", "function", "python"
                 )
 
             # Verify entries recorded
@@ -52,12 +47,12 @@ class TestFullLifecycle:
 
             # Commit transaction
             manager.commit_transaction(manifest)
-            assert manifest.status == 'committed'
+            assert manifest.status == "committed"
             assert manifest.completed_at is not None
 
             # Verify backups deleted
             for i in range(3):
-                backup = base_path / f'file{i}.py.bak'
+                backup = base_path / f"file{i}.py.bak"
                 assert not backup.exists()
 
     def test_full_lifecycle_begin_record_rollback(self):
@@ -69,32 +64,32 @@ class TestFullLifecycle:
             # Create original files
             originals = {}
             for i in range(3):
-                filepath = base_path / f'file{i}.py'
-                original_content = f'# Original content {i}\n'
+                filepath = base_path / f"file{i}.py"
+                original_content = f"# Original content {i}\n"
                 filepath.write_text(original_content)
                 originals[str(filepath)] = original_content
 
             # Begin transaction
-            manifest = manager.begin_transaction('rollback-test')
+            manifest = manager.begin_transaction("rollback-test")
 
             # Record changes (create backups and modify files)
             for i in range(3):
-                filepath = base_path / f'file{i}.py'
-                backup = str(filepath) + '.bak'
+                filepath = base_path / f"file{i}.py"
+                backup = str(filepath) + ".bak"
 
                 # Create backup
                 Path(backup).write_text(originals[str(filepath)])
 
                 # Modify file
-                filepath.write_text(f'def new_func{i}(): pass')
+                filepath.write_text(f"def new_func{i}(): pass")
 
                 manager.record_write(
                     manifest,
                     str(filepath),
                     backup,
-                    f'new_func{i}',
-                    'function',
-                    'python'
+                    f"new_func{i}",
+                    "function",
+                    "python",
                 )
 
             # Rollback transaction
@@ -104,7 +99,7 @@ class TestFullLifecycle:
 
             # Verify files restored
             for i in range(3):
-                filepath = base_path / f'file{i}.py'
+                filepath = base_path / f"file{i}.py"
                 assert filepath.read_text() == originals[str(filepath)]
 
     def test_session_with_no_changes(self):
@@ -114,14 +109,14 @@ class TestFullLifecycle:
             manager = TransactionManager(base_path=base_path, use_git=False)
 
             # Begin transaction
-            manifest = manager.begin_transaction('empty-session')
+            manifest = manager.begin_transaction("empty-session")
             assert len(manifest.entries) == 0
 
             # Commit immediately (no writes)
             manager.commit_transaction(manifest)
 
             # Should complete successfully
-            assert manifest.status == 'committed'
+            assert manifest.status == "committed"
 
 
 class TestMultipleSequentialSessions:
@@ -136,40 +131,46 @@ class TestMultipleSequentialSessions:
             sessions = []
 
             # Session 1: 2 changes
-            manifest1 = manager.begin_transaction('session-1')
+            manifest1 = manager.begin_transaction("session-1")
             for i in range(2):
-                filepath = base_path / f'session1_file{i}.py'
-                filepath.write_text('content')
-                backup = str(filepath) + '.bak'
-                Path(backup).write_text('')
-                manager.record_write(manifest1, str(filepath), backup, 'func', 'function', 'python')
+                filepath = base_path / f"session1_file{i}.py"
+                filepath.write_text("content")
+                backup = str(filepath) + ".bak"
+                Path(backup).write_text("")
+                manager.record_write(
+                    manifest1, str(filepath), backup, "func", "function", "python"
+                )
             manager.commit_transaction(manifest1)
             sessions.append(manifest1)
 
             # Session 2: 3 changes
-            manifest2 = manager.begin_transaction('session-2')
+            manifest2 = manager.begin_transaction("session-2")
             for i in range(3):
-                filepath = base_path / f'session2_file{i}.py'
-                filepath.write_text('content')
-                backup = str(filepath) + '.bak'
-                Path(backup).write_text('')
-                manager.record_write(manifest2, str(filepath), backup, 'func', 'function', 'python')
+                filepath = base_path / f"session2_file{i}.py"
+                filepath.write_text("content")
+                backup = str(filepath) + ".bak"
+                Path(backup).write_text("")
+                manager.record_write(
+                    manifest2, str(filepath), backup, "func", "function", "python"
+                )
             manager.commit_transaction(manifest2)
             sessions.append(manifest2)
 
             # Session 3: 1 change
-            manifest3 = manager.begin_transaction('session-3')
-            filepath = base_path / 'session3_file0.py'
-            filepath.write_text('content')
-            backup = str(filepath) + '.bak'
-            Path(backup).write_text('')
-            manager.record_write(manifest3, str(filepath), backup, 'func', 'function', 'python')
+            manifest3 = manager.begin_transaction("session-3")
+            filepath = base_path / "session3_file0.py"
+            filepath.write_text("content")
+            backup = str(filepath) + ".bak"
+            Path(backup).write_text("")
+            manager.record_write(
+                manifest3, str(filepath), backup, "func", "function", "python"
+            )
             manager.commit_transaction(manifest3)
             sessions.append(manifest3)
 
             # Verify all sessions completed
             for session in sessions:
-                assert session.status == 'committed'
+                assert session.status == "committed"
                 assert session.completed_at is not None
 
     def test_rollback_then_new_session(self):
@@ -179,29 +180,33 @@ class TestMultipleSequentialSessions:
             manager = TransactionManager(base_path=base_path, use_git=False)
 
             # Session 1: Create and rollback
-            file1 = base_path / 'file1.py'
-            file1.write_text('original')
+            file1 = base_path / "file1.py"
+            file1.write_text("original")
 
-            manifest1 = manager.begin_transaction('session-1')
-            backup1 = str(file1) + '.bak'
-            Path(backup1).write_text('original')
-            file1.write_text('modified')
-            manager.record_write(manifest1, str(file1), backup1, 'func1', 'function', 'python')
+            manifest1 = manager.begin_transaction("session-1")
+            backup1 = str(file1) + ".bak"
+            Path(backup1).write_text("original")
+            file1.write_text("modified")
+            manager.record_write(
+                manifest1, str(file1), backup1, "func1", "function", "python"
+            )
 
             # Rollback session 1
             manager.rollback_transaction(manifest1)
 
             # Session 2: New session should work fine
-            file2 = base_path / 'file2.py'
-            file2.write_text('new content')
-            manifest2 = manager.begin_transaction('session-2')
-            backup2 = str(file2) + '.bak'
-            Path(backup2).write_text('')
-            manager.record_write(manifest2, str(file2), backup2, 'func2', 'function', 'python')
+            file2 = base_path / "file2.py"
+            file2.write_text("new content")
+            manifest2 = manager.begin_transaction("session-2")
+            backup2 = str(file2) + ".bak"
+            Path(backup2).write_text("")
+            manager.record_write(
+                manifest2, str(file2), backup2, "func2", "function", "python"
+            )
             manager.commit_transaction(manifest2)
 
             # Verify session 2 committed successfully
-            assert manifest2.status == 'committed'
+            assert manifest2.status == "committed"
             assert len(manifest2.entries) == 1
 
 
@@ -214,21 +219,16 @@ class TestLargeSessions:
             base_path = Path(tmpdir)
             manager = TransactionManager(base_path=base_path, use_git=False)
 
-            manifest = manager.begin_transaction('large-session')
+            manifest = manager.begin_transaction("large-session")
 
             # Record 50 writes
             for i in range(50):
-                filepath = base_path / f'file{i}.py'
-                filepath.write_text(f'def func{i}(): pass')
-                backup = str(filepath) + '.bak'
-                Path(backup).write_text('')
+                filepath = base_path / f"file{i}.py"
+                filepath.write_text(f"def func{i}(): pass")
+                backup = str(filepath) + ".bak"
+                Path(backup).write_text("")
                 manager.record_write(
-                    manifest,
-                    str(filepath),
-                    backup,
-                    f'func{i}',
-                    'function',
-                    'python'
+                    manifest, str(filepath), backup, f"func{i}", "function", "python"
                 )
 
             # Verify all tracked
@@ -236,7 +236,7 @@ class TestLargeSessions:
 
             # Commit should handle large session
             manager.commit_transaction(manifest)
-            assert manifest.status == 'committed'
+            assert manifest.status == "committed"
 
 
 class TestNestedDirectories:
@@ -248,39 +248,43 @@ class TestNestedDirectories:
             base_path = Path(tmpdir)
             manager = TransactionManager(base_path=base_path, use_git=False)
 
-            manifest = manager.begin_transaction('nested-test')
+            manifest = manager.begin_transaction("nested-test")
 
             # Create dir structure a/b/c/d/e/f/
             nested_paths = [
-                base_path / 'file.py',
-                base_path / 'a' / 'file.py',
-                base_path / 'a' / 'b' / 'file.py',
-                base_path / 'a' / 'b' / 'c' / 'file.py',
-                base_path / 'a' / 'b' / 'c' / 'd' / 'file.py',
-                base_path / 'a' / 'b' / 'c' / 'd' / 'e' / 'file.py',
-                base_path / 'a' / 'b' / 'c' / 'd' / 'e' / 'f' / 'file.py',
+                base_path / "file.py",
+                base_path / "a" / "file.py",
+                base_path / "a" / "b" / "file.py",
+                base_path / "a" / "b" / "c" / "file.py",
+                base_path / "a" / "b" / "c" / "d" / "file.py",
+                base_path / "a" / "b" / "c" / "d" / "e" / "file.py",
+                base_path / "a" / "b" / "c" / "d" / "e" / "f" / "file.py",
             ]
 
             for filepath in nested_paths:
                 filepath.parent.mkdir(parents=True, exist_ok=True)
-                filepath.write_text('content')
-                backup = str(filepath) + '.bak'
-                Path(backup).write_text('')
-                manager.record_write(manifest, str(filepath), backup, 'func', 'function', 'python')
+                filepath.write_text("content")
+                backup = str(filepath) + ".bak"
+                Path(backup).write_text("")
+                manager.record_write(
+                    manifest, str(filepath), backup, "func", "function", "python"
+                )
 
             # Verify all paths handled
             assert len(manifest.entries) == len(nested_paths)
 
             # Commit (test that nested paths work with commit)
             manager.commit_transaction(manifest)
-            assert manifest.status == 'committed'
+            assert manifest.status == "committed"
 
             # Create another session to test rollback at nested levels
-            manifest2 = manager.begin_transaction('nested-rollback-test')
+            manifest2 = manager.begin_transaction("nested-rollback-test")
             for filepath in nested_paths:
-                backup = str(filepath) + '.bak'
-                Path(backup).write_text('rollback')
-                manager.record_write(manifest2, str(filepath), backup, 'func', 'function', 'python')
+                backup = str(filepath) + ".bak"
+                Path(backup).write_text("rollback")
+                manager.record_write(
+                    manifest2, str(filepath), backup, "func", "function", "python"
+                )
 
             # Test rollback at all nesting levels
             restored = manager.rollback_transaction(manifest2)
@@ -297,35 +301,37 @@ class TestSessionState:
             manager = TransactionManager(base_path=base_path, use_git=False)
 
             # Begin
-            manifest = manager.begin_transaction('state-test')
+            manifest = manager.begin_transaction("state-test")
 
-            assert manifest.session_id == 'state-test'
-            assert manifest.status == 'in_progress'
+            assert manifest.session_id == "state-test"
+            assert manifest.status == "in_progress"
             assert manifest.started_at is not None
             assert manifest.completed_at is None
             assert manifest.entries == []
             assert manifest.git_commit_sha is None
 
             # Record change
-            filepath = base_path / 'file.py'
-            filepath.write_text('content')
-            backup = str(filepath) + '.bak'
-            Path(backup).write_text('')
-            manager.record_write(manifest, str(filepath), backup, 'func', 'function', 'python')
+            filepath = base_path / "file.py"
+            filepath.write_text("content")
+            backup = str(filepath) + ".bak"
+            Path(backup).write_text("")
+            manager.record_write(
+                manifest, str(filepath), backup, "func", "function", "python"
+            )
 
             assert len(manifest.entries) == 1
             entry = manifest.entries[0]
             assert entry.filepath == str(filepath)
             assert entry.backup_path == backup
-            assert entry.item_name == 'func'
-            assert entry.item_type == 'function'
-            assert entry.language == 'python'
+            assert entry.item_name == "func"
+            assert entry.item_type == "function"
+            assert entry.language == "python"
             assert entry.success is True
 
             # Commit
             manager.commit_transaction(manifest)
 
-            assert manifest.status == 'committed'
+            assert manifest.status == "committed"
             assert manifest.completed_at is not None
 
     def test_entry_timestamps_consistent(self):
@@ -334,21 +340,23 @@ class TestSessionState:
             base_path = Path(tmpdir)
             manager = TransactionManager(base_path=base_path, use_git=False)
 
-            manifest = manager.begin_transaction('timestamp-test')
+            manifest = manager.begin_transaction("timestamp-test")
 
             # Record 3 changes
             for i in range(3):
-                filepath = base_path / f'file{i}.py'
-                filepath.write_text('content')
-                backup = str(filepath) + '.bak'
-                Path(backup).write_text('')
-                manager.record_write(manifest, str(filepath), backup, f'func{i}', 'function', 'python')
+                filepath = base_path / f"file{i}.py"
+                filepath.write_text("content")
+                backup = str(filepath) + ".bak"
+                Path(backup).write_text("")
+                manager.record_write(
+                    manifest, str(filepath), backup, f"func{i}", "function", "python"
+                )
 
             # All entries should have timestamps
             for entry in manifest.entries:
                 assert entry.timestamp is not None
                 # Timestamp should be ISO format
-                assert 'T' in entry.timestamp
+                assert "T" in entry.timestamp
 
 
 class TestErrorRecovery:
@@ -360,19 +368,21 @@ class TestErrorRecovery:
             base_path = Path(tmpdir)
             manager = TransactionManager(base_path=base_path, use_git=False)
 
-            manifest = manager.begin_transaction('partial-test')
+            manifest = manager.begin_transaction("partial-test")
 
             # Successful writes
             for i in range(3):
-                filepath = base_path / f'file{i}.py'
-                filepath.write_text('content')
-                backup = str(filepath) + '.bak'
-                Path(backup).write_text('')
-                manager.record_write(manifest, str(filepath), backup, f'func{i}', 'function', 'python')
+                filepath = base_path / f"file{i}.py"
+                filepath.write_text("content")
+                backup = str(filepath) + ".bak"
+                Path(backup).write_text("")
+                manager.record_write(
+                    manifest, str(filepath), backup, f"func{i}", "function", "python"
+                )
 
             # Should be able to commit partial session
             manager.commit_transaction(manifest)
-            assert manifest.status == 'committed'
+            assert manifest.status == "committed"
             assert len(manifest.entries) == 3
 
 
@@ -387,10 +397,10 @@ class TestBranchNaming:
 
             # Various session ID formats
             test_ids = [
-                'simple-id',
-                'session-123',
-                'feature-branch-20240101',
-                'user_session_abc',
+                "simple-id",
+                "session-123",
+                "feature-branch-20240101",
+                "user_session_abc",
             ]
 
             for session_id in test_ids:
@@ -399,7 +409,7 @@ class TestBranchNaming:
 
                 # Commit without errors
                 manager.commit_transaction(manifest)
-                assert manifest.status == 'committed'
+                assert manifest.status == "committed"
 
 
 class TestGitBasedLifecycle:
@@ -418,24 +428,19 @@ class TestGitBasedLifecycle:
             manager = TransactionManager(base_path=base_path, use_git=True)
 
             # Begin transaction
-            manifest = manager.begin_transaction('git-lifecycle-test')
-            assert manifest.session_id == 'git-lifecycle-test'
-            assert manifest.status == 'in_progress'
+            manifest = manager.begin_transaction("git-lifecycle-test")
+            assert manifest.session_id == "git-lifecycle-test"
+            assert manifest.status == "in_progress"
 
             # Record 3 writes
             for i in range(3):
-                filepath = base_path / f'file{i}.py'
-                filepath.write_text(f'def func{i}(): pass')
-                backup = str(filepath) + '.bak'
-                Path(backup).write_text('')
+                filepath = base_path / f"file{i}.py"
+                filepath.write_text(f"def func{i}(): pass")
+                backup = str(filepath) + ".bak"
+                Path(backup).write_text("")
 
                 manager.record_write(
-                    manifest,
-                    str(filepath),
-                    backup,
-                    f'func{i}',
-                    'function',
-                    'python'
+                    manifest, str(filepath), backup, f"func{i}", "function", "python"
                 )
 
             # Verify entries recorded
@@ -443,13 +448,13 @@ class TestGitBasedLifecycle:
 
             # Commit transaction
             manager.commit_transaction(manifest)
-            assert manifest.status == 'committed'
+            assert manifest.status == "committed"
             assert manifest.completed_at is not None
             assert manifest.git_commit_sha is not None  # Git-specific
 
             # Verify backups deleted
             for i in range(3):
-                backup = base_path / f'file{i}.py.bak'
+                backup = base_path / f"file{i}.py.bak"
                 assert not backup.exists()
 
     def test_git_full_lifecycle_rollback(self):
@@ -464,28 +469,28 @@ class TestGitBasedLifecycle:
             # Create original files
             originals = {}
             for i in range(3):
-                filepath = base_path / f'file{i}.py'
-                original_content = f'# Original content {i}\n'
+                filepath = base_path / f"file{i}.py"
+                original_content = f"# Original content {i}\n"
                 filepath.write_text(original_content)
                 originals[str(filepath)] = original_content
 
             # Begin transaction
-            manifest = manager.begin_transaction('git-rollback-test')
+            manifest = manager.begin_transaction("git-rollback-test")
 
             # Record changes
             for i in range(3):
-                filepath = base_path / f'file{i}.py'
-                backup = str(filepath) + '.bak'
+                filepath = base_path / f"file{i}.py"
+                backup = str(filepath) + ".bak"
                 Path(backup).write_text(originals[str(filepath)])
-                filepath.write_text(f'def new_func{i}(): pass')
+                filepath.write_text(f"def new_func{i}(): pass")
 
                 manager.record_write(
                     manifest,
                     str(filepath),
                     backup,
-                    f'new_func{i}',
-                    'function',
-                    'python'
+                    f"new_func{i}",
+                    "function",
+                    "python",
                 )
 
             # Rollback transaction (git-based)
@@ -494,7 +499,7 @@ class TestGitBasedLifecycle:
 
             # Verify files restored
             for i in range(3):
-                filepath = base_path / f'file{i}.py'
+                filepath = base_path / f"file{i}.py"
                 assert filepath.read_text() == originals[str(filepath)]
 
     def test_git_multiple_sequential_sessions(self):
@@ -507,25 +512,29 @@ class TestGitBasedLifecycle:
             manager = TransactionManager(base_path=base_path, use_git=True)
 
             # Session 1
-            manifest1 = manager.begin_transaction('git-session-1')
-            filepath1 = base_path / 'file1.py'
-            filepath1.write_text('content1')
-            backup1 = str(filepath1) + '.bak'
-            Path(backup1).write_text('')
-            manager.record_write(manifest1, str(filepath1), backup1, 'func1', 'function', 'python')
+            manifest1 = manager.begin_transaction("git-session-1")
+            filepath1 = base_path / "file1.py"
+            filepath1.write_text("content1")
+            backup1 = str(filepath1) + ".bak"
+            Path(backup1).write_text("")
+            manager.record_write(
+                manifest1, str(filepath1), backup1, "func1", "function", "python"
+            )
             manager.commit_transaction(manifest1)
-            assert manifest1.status == 'committed'
+            assert manifest1.status == "committed"
             assert manifest1.git_commit_sha is not None
 
             # Session 2
-            manifest2 = manager.begin_transaction('git-session-2')
-            filepath2 = base_path / 'file2.py'
-            filepath2.write_text('content2')
-            backup2 = str(filepath2) + '.bak'
-            Path(backup2).write_text('')
-            manager.record_write(manifest2, str(filepath2), backup2, 'func2', 'function', 'python')
+            manifest2 = manager.begin_transaction("git-session-2")
+            filepath2 = base_path / "file2.py"
+            filepath2.write_text("content2")
+            backup2 = str(filepath2) + ".bak"
+            Path(backup2).write_text("")
+            manager.record_write(
+                manifest2, str(filepath2), backup2, "func2", "function", "python"
+            )
             manager.commit_transaction(manifest2)
-            assert manifest2.status == 'committed'
+            assert manifest2.status == "committed"
             assert manifest2.git_commit_sha is not None
 
             # Both should have different commit SHAs
@@ -540,21 +549,16 @@ class TestGitBasedLifecycle:
             GitHelper.init_sidecar_repo(base_path)
             manager = TransactionManager(base_path=base_path, use_git=True)
 
-            manifest = manager.begin_transaction('git-large-session')
+            manifest = manager.begin_transaction("git-large-session")
 
             # Record 30 writes
             for i in range(30):
-                filepath = base_path / f'file{i}.py'
-                filepath.write_text(f'def func{i}(): pass')
-                backup = str(filepath) + '.bak'
-                Path(backup).write_text('')
+                filepath = base_path / f"file{i}.py"
+                filepath.write_text(f"def func{i}(): pass")
+                backup = str(filepath) + ".bak"
+                Path(backup).write_text("")
                 manager.record_write(
-                    manifest,
-                    str(filepath),
-                    backup,
-                    f'func{i}',
-                    'function',
-                    'python'
+                    manifest, str(filepath), backup, f"func{i}", "function", "python"
                 )
 
             # Verify all tracked
@@ -562,5 +566,5 @@ class TestGitBasedLifecycle:
 
             # Commit should handle large session
             manager.commit_transaction(manifest)
-            assert manifest.status == 'committed'
+            assert manifest.status == "committed"
             assert manifest.git_commit_sha is not None

--- a/analyzer/tests/test_transaction_manager.py
+++ b/analyzer/tests/test_transaction_manager.py
@@ -16,10 +16,10 @@ def test_begin_transaction_creates_manifest():
     """Test that begin_transaction creates a valid manifest."""
     with tempfile.TemporaryDirectory() as tmpdir:
         manager = TransactionManager(base_path=Path(tmpdir))
-        manifest = manager.begin_transaction('test-session-id')
+        manifest = manager.begin_transaction("test-session-id")
 
-        assert manifest.session_id == 'test-session-id'
-        assert manifest.status == 'in_progress'
+        assert manifest.session_id == "test-session-id"
+        assert manifest.status == "in_progress"
         assert manifest.entries == []
         assert manifest.started_at is not None
         assert manifest.completed_at is None
@@ -29,24 +29,24 @@ def test_begin_transaction_creates_manifest():
 def test_record_write_adds_entry():
     """Test that record_write adds entry to manifest."""
     manager = TransactionManager()  # No base_path = JSON mode
-    manifest = manager.begin_transaction('test-id')
+    manifest = manager.begin_transaction("test-id")
 
     manager.record_write(
         manifest=manifest,
-        filepath='/tmp/test.py',
-        backup_path='/tmp/test.py.bak',
-        item_name='foo',
-        item_type='function',
-        language='python'
+        filepath="/tmp/test.py",
+        backup_path="/tmp/test.py.bak",
+        item_name="foo",
+        item_type="function",
+        language="python",
     )
 
     assert len(manifest.entries) == 1
     entry = manifest.entries[0]
-    assert entry.filepath == '/tmp/test.py'
-    assert entry.backup_path == '/tmp/test.py.bak'
-    assert entry.item_name == 'foo'
-    assert entry.item_type == 'function'
-    assert entry.language == 'python'
+    assert entry.filepath == "/tmp/test.py"
+    assert entry.backup_path == "/tmp/test.py.bak"
+    assert entry.item_name == "foo"
+    assert entry.item_type == "function"
+    assert entry.language == "python"
     assert entry.success is True
     assert entry.timestamp is not None
     assert entry.entry_id is not None  # New field
@@ -55,32 +55,35 @@ def test_record_write_adds_entry():
 def test_record_multiple_writes():
     """Test recording multiple file modifications in one transaction."""
     manager = TransactionManager()
-    manifest = manager.begin_transaction('test-id')
+    manifest = manager.begin_transaction("test-id")
 
     # Record three writes
     for i in range(3):
         manager.record_write(
-            manifest, f'/tmp/file{i}.py', f'/tmp/file{i}.py.bak',
-            f'func{i}', 'function', 'python'
+            manifest,
+            f"/tmp/file{i}.py",
+            f"/tmp/file{i}.py.bak",
+            f"func{i}",
+            "function",
+            "python",
         )
 
     assert len(manifest.entries) == 3
-    assert manifest.entries[0].item_name == 'func0'
-    assert manifest.entries[1].item_name == 'func1'
-    assert manifest.entries[2].item_name == 'func2'
+    assert manifest.entries[0].item_name == "func0"
+    assert manifest.entries[1].item_name == "func1"
+    assert manifest.entries[2].item_name == "func2"
 
 
 def test_save_and_load_manifest_roundtrip():
     """Test manifest serialization and deserialization."""
     manager = TransactionManager()
-    manifest = manager.begin_transaction('test-id')
+    manifest = manager.begin_transaction("test-id")
     manager.record_write(
-        manifest, '/tmp/test.py', '/tmp/test.py.bak',
-        'foo', 'function', 'python'
+        manifest, "/tmp/test.py", "/tmp/test.py.bak", "foo", "function", "python"
     )
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        path = Path(tmpdir) / 'test-manifest.json'
+        path = Path(tmpdir) / "test-manifest.json"
         manager.save_manifest(manifest, path)
 
         # Verify file was created
@@ -88,21 +91,21 @@ def test_save_and_load_manifest_roundtrip():
 
         # Load and verify
         loaded = manager.load_manifest(path)
-        assert loaded.session_id == 'test-id'
-        assert loaded.status == 'in_progress'
+        assert loaded.session_id == "test-id"
+        assert loaded.status == "in_progress"
         assert len(loaded.entries) == 1
-        assert loaded.entries[0].item_name == 'foo'
-        assert loaded.entries[0].filepath == '/tmp/test.py'
+        assert loaded.entries[0].item_name == "foo"
+        assert loaded.entries[0].filepath == "/tmp/test.py"
 
 
 def test_save_creates_parent_directories():
     """Test that save_manifest creates parent directories if needed."""
     manager = TransactionManager()
-    manifest = manager.begin_transaction('test-id')
+    manifest = manager.begin_transaction("test-id")
 
     with tempfile.TemporaryDirectory() as tmpdir:
         # Path with non-existent subdirectories
-        path = Path(tmpdir) / 'subdir1' / 'subdir2' / 'manifest.json'
+        path = Path(tmpdir) / "subdir1" / "subdir2" / "manifest.json"
         manager.save_manifest(manifest, path)
 
         assert path.exists()
@@ -112,22 +115,20 @@ def test_save_creates_parent_directories():
 def test_commit_deletes_backups():
     """Test that commit marks manifest and deletes backup files."""
     manager = TransactionManager()
-    manifest = manager.begin_transaction('test-id')
+    manifest = manager.begin_transaction("test-id")
 
     with tempfile.TemporaryDirectory() as tmpdir:
         # Create backup files
-        backup1 = Path(tmpdir) / 'test1.py.bak'
-        backup2 = Path(tmpdir) / 'test2.py.bak'
-        backup1.write_text('backup content 1')
-        backup2.write_text('backup content 2')
+        backup1 = Path(tmpdir) / "test1.py.bak"
+        backup2 = Path(tmpdir) / "test2.py.bak"
+        backup1.write_text("backup content 1")
+        backup2.write_text("backup content 2")
 
         manager.record_write(
-            manifest, f'{tmpdir}/test1.py', str(backup1),
-            'foo', 'function', 'python'
+            manifest, f"{tmpdir}/test1.py", str(backup1), "foo", "function", "python"
         )
         manager.record_write(
-            manifest, f'{tmpdir}/test2.py', str(backup2),
-            'bar', 'class', 'python'
+            manifest, f"{tmpdir}/test2.py", str(backup2), "bar", "class", "python"
         )
 
         assert backup1.exists()
@@ -136,7 +137,7 @@ def test_commit_deletes_backups():
         manager.commit_transaction(manifest)
 
         # Verify manifest updated
-        assert manifest.status == 'committed'
+        assert manifest.status == "committed"
         assert manifest.completed_at is not None
 
         # Verify backups deleted
@@ -147,79 +148,81 @@ def test_commit_deletes_backups():
 def test_commit_handles_missing_backups():
     """Test that commit doesn't fail if backup files are already gone."""
     manager = TransactionManager()
-    manifest = manager.begin_transaction('test-id')
+    manifest = manager.begin_transaction("test-id")
 
     # Record write with non-existent backup
     manager.record_write(
-        manifest, '/tmp/test.py', '/tmp/nonexistent.bak',
-        'foo', 'function', 'python'
+        manifest, "/tmp/test.py", "/tmp/nonexistent.bak", "foo", "function", "python"
     )
 
     # Should not raise error
     manager.commit_transaction(manifest)
-    assert manifest.status == 'committed'
+    assert manifest.status == "committed"
 
 
 def test_rollback_restores_files():
     """Test that rollback restores files from backups."""
     manager = TransactionManager()
-    manifest = manager.begin_transaction('test-id')
+    manifest = manager.begin_transaction("test-id")
 
     with tempfile.TemporaryDirectory() as tmpdir:
         # Create original and backup
-        target_file = Path(tmpdir) / 'test.py'
-        backup_file = Path(tmpdir) / 'test.py.bak'
+        target_file = Path(tmpdir) / "test.py"
+        backup_file = Path(tmpdir) / "test.py.bak"
 
-        target_file.write_text('modified content')
-        backup_file.write_text('original content')
+        target_file.write_text("modified content")
+        backup_file.write_text("original content")
 
         manager.record_write(
-            manifest, str(target_file), str(backup_file),
-            'foo', 'function', 'python'
+            manifest, str(target_file), str(backup_file), "foo", "function", "python"
         )
 
         restored = manager.rollback_transaction(manifest)
 
         assert restored == 1
-        assert manifest.status == 'rolled_back'
+        assert manifest.status == "rolled_back"
         assert manifest.completed_at is not None
-        assert target_file.read_text() == 'original content'
+        assert target_file.read_text() == "original content"
         assert not backup_file.exists()
 
 
 def test_rollback_multiple_files():
     """Test rollback with multiple file modifications."""
     manager = TransactionManager()
-    manifest = manager.begin_transaction('test-id')
+    manifest = manager.begin_transaction("test-id")
 
     with tempfile.TemporaryDirectory() as tmpdir:
         # Create three files with backups
         files_data = [
-            ('file1.py', 'modified1', 'original1'),
-            ('file2.py', 'modified2', 'original2'),
-            ('file3.py', 'modified3', 'original3'),
+            ("file1.py", "modified1", "original1"),
+            ("file2.py", "modified2", "original2"),
+            ("file3.py", "modified3", "original3"),
         ]
 
         for filename, modified, original in files_data:
             target = Path(tmpdir) / filename
-            backup = Path(tmpdir) / f'{filename}.bak'
+            backup = Path(tmpdir) / f"{filename}.bak"
             target.write_text(modified)
             backup.write_text(original)
 
             manager.record_write(
-                manifest, str(target), str(backup),
-                f'func_{filename}', 'function', 'python'
+                manifest,
+                str(target),
+                str(backup),
+                f"func_{filename}",
+                "function",
+                "python",
             )
 
         restored = manager.rollback_transaction(manifest)
 
         assert restored == 3
-        assert manifest.status == 'rolled_back'
+        assert manifest.status == "rolled_back"
 
         # Verify all files restored
         for filename, _, original in files_data:
             target = Path(tmpdir) / filename
-            backup = Path(tmpdir) / f'{filename}.bak'
+            backup = Path(tmpdir) / f"{filename}.bak"
             assert target.read_text() == original
             assert not backup.exists()
 
@@ -227,8 +230,8 @@ def test_rollback_multiple_files():
 def test_rollback_on_committed_raises_error():
     """Test that rollback fails on already-committed transaction."""
     manager = TransactionManager()
-    manifest = manager.begin_transaction('test-id')
-    manifest.status = 'committed'
+    manifest = manager.begin_transaction("test-id")
+    manifest.status = "committed"
 
     try:
         manager.rollback_transaction(manifest)
@@ -241,8 +244,8 @@ def test_rollback_on_committed_raises_error():
 def test_rollback_already_rolled_back_raises_error():
     """Test that rollback fails on already-rolled-back transaction."""
     manager = TransactionManager()
-    manifest = manager.begin_transaction('test-id')
-    manifest.status = 'rolled_back'
+    manifest = manager.begin_transaction("test-id")
+    manifest.status = "rolled_back"
 
     try:
         manager.rollback_transaction(manifest)
@@ -255,35 +258,33 @@ def test_rollback_already_rolled_back_raises_error():
 def test_rollback_skips_missing_backups():
     """Test that rollback continues if some backups are missing."""
     manager = TransactionManager()
-    manifest = manager.begin_transaction('test-id')
+    manifest = manager.begin_transaction("test-id")
 
     with tempfile.TemporaryDirectory() as tmpdir:
         # First file: has backup
-        target1 = Path(tmpdir) / 'test1.py'
-        backup1 = Path(tmpdir) / 'test1.py.bak'
-        target1.write_text('modified1')
-        backup1.write_text('original1')
+        target1 = Path(tmpdir) / "test1.py"
+        backup1 = Path(tmpdir) / "test1.py.bak"
+        target1.write_text("modified1")
+        backup1.write_text("original1")
         manager.record_write(
-            manifest, str(target1), str(backup1),
-            'foo', 'function', 'python'
+            manifest, str(target1), str(backup1), "foo", "function", "python"
         )
 
         # Second file: missing backup
-        target2 = Path(tmpdir) / 'test2.py'
-        backup2 = Path(tmpdir) / 'test2.py.bak'
-        target2.write_text('modified2')
+        target2 = Path(tmpdir) / "test2.py"
+        backup2 = Path(tmpdir) / "test2.py.bak"
+        target2.write_text("modified2")
         # Don't create backup2
         manager.record_write(
-            manifest, str(target2), str(backup2),
-            'bar', 'function', 'python'
+            manifest, str(target2), str(backup2), "bar", "function", "python"
         )
 
         restored = manager.rollback_transaction(manifest)
 
         # Only one file should be restored
         assert restored == 1
-        assert target1.read_text() == 'original1'
-        assert target2.read_text() == 'modified2'  # Unchanged
+        assert target1.read_text() == "original1"
+        assert target2.read_text() == "modified2"  # Unchanged
 
 
 def test_list_uncommitted_filters_correctly():
@@ -291,31 +292,39 @@ def test_list_uncommitted_filters_correctly():
     manager = TransactionManager()
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        transactions_dir = Path(tmpdir) / 'transactions'
+        transactions_dir = Path(tmpdir) / "transactions"
         transactions_dir.mkdir()
 
         # Create manifests with different statuses
-        manifest1 = manager.begin_transaction('session-1')
-        manifest1.status = 'in_progress'
-        manager.save_manifest(manifest1, transactions_dir / 'transaction-session-1.json')
+        manifest1 = manager.begin_transaction("session-1")
+        manifest1.status = "in_progress"
+        manager.save_manifest(
+            manifest1, transactions_dir / "transaction-session-1.json"
+        )
 
-        manifest2 = manager.begin_transaction('session-2')
-        manifest2.status = 'committed'
-        manager.save_manifest(manifest2, transactions_dir / 'transaction-session-2.json')
+        manifest2 = manager.begin_transaction("session-2")
+        manifest2.status = "committed"
+        manager.save_manifest(
+            manifest2, transactions_dir / "transaction-session-2.json"
+        )
 
-        manifest3 = manager.begin_transaction('session-3')
-        manifest3.status = 'rolled_back'
-        manager.save_manifest(manifest3, transactions_dir / 'transaction-session-3.json')
+        manifest3 = manager.begin_transaction("session-3")
+        manifest3.status = "rolled_back"
+        manager.save_manifest(
+            manifest3, transactions_dir / "transaction-session-3.json"
+        )
 
-        manifest4 = manager.begin_transaction('session-4')
-        manifest4.status = 'in_progress'
-        manager.save_manifest(manifest4, transactions_dir / 'transaction-session-4.json')
+        manifest4 = manager.begin_transaction("session-4")
+        manifest4.status = "in_progress"
+        manager.save_manifest(
+            manifest4, transactions_dir / "transaction-session-4.json"
+        )
 
         uncommitted = manager.list_uncommitted_transactions(transactions_dir)
 
         assert len(uncommitted) == 2
         session_ids = {m.session_id for m in uncommitted}
-        assert session_ids == {'session-1', 'session-4'}
+        assert session_ids == {"session-1", "session-4"}
 
 
 def test_list_uncommitted_empty_directory():
@@ -323,7 +332,7 @@ def test_list_uncommitted_empty_directory():
     manager = TransactionManager()
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        nonexistent_dir = Path(tmpdir) / 'nonexistent'
+        nonexistent_dir = Path(tmpdir) / "nonexistent"
         uncommitted = manager.list_uncommitted_transactions(nonexistent_dir)
         assert uncommitted == []
 
@@ -333,15 +342,14 @@ def test_list_uncommitted_sorted_by_time():
     manager = TransactionManager()
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        transactions_dir = Path(tmpdir) / 'transactions'
+        transactions_dir = Path(tmpdir) / "transactions"
         transactions_dir.mkdir()
 
         # Create manifests with delays to ensure different timestamps
         for i in range(3):
-            manifest = manager.begin_transaction(f'session-{i}')
+            manifest = manager.begin_transaction(f"session-{i}")
             manager.save_manifest(
-                manifest,
-                transactions_dir / f'transaction-session-{i}.json'
+                manifest, transactions_dir / f"transaction-session-{i}.json"
             )
             time.sleep(0.01)
 
@@ -349,9 +357,9 @@ def test_list_uncommitted_sorted_by_time():
 
         # Should be newest first
         assert len(uncommitted) == 3
-        assert uncommitted[0].session_id == 'session-2'
-        assert uncommitted[1].session_id == 'session-1'
-        assert uncommitted[2].session_id == 'session-0'
+        assert uncommitted[0].session_id == "session-2"
+        assert uncommitted[1].session_id == "session-1"
+        assert uncommitted[2].session_id == "session-0"
 
 
 def test_cleanup_keeps_recent_and_uncommitted():
@@ -359,25 +367,23 @@ def test_cleanup_keeps_recent_and_uncommitted():
     manager = TransactionManager()
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        transactions_dir = Path(tmpdir) / 'transactions'
+        transactions_dir = Path(tmpdir) / "transactions"
         transactions_dir.mkdir()
 
         # Create 5 committed transactions
         for i in range(5):
-            manifest = manager.begin_transaction(f'committed-{i}')
-            manifest.status = 'committed'
+            manifest = manager.begin_transaction(f"committed-{i}")
+            manifest.status = "committed"
             manager.save_manifest(
-                manifest,
-                transactions_dir / f'transaction-committed-{i}.json'
+                manifest, transactions_dir / f"transaction-committed-{i}.json"
             )
             time.sleep(0.01)
 
         # Create 2 uncommitted transactions
         for i in range(2):
-            manifest = manager.begin_transaction(f'uncommitted-{i}')
+            manifest = manager.begin_transaction(f"uncommitted-{i}")
             manager.save_manifest(
-                manifest,
-                transactions_dir / f'transaction-uncommitted-{i}.json'
+                manifest, transactions_dir / f"transaction-uncommitted-{i}.json"
             )
             time.sleep(0.01)
 
@@ -387,7 +393,7 @@ def test_cleanup_keeps_recent_and_uncommitted():
         assert deleted == 2
 
         # Verify 5 files remain (3 committed + 2 uncommitted)
-        remaining = list(transactions_dir.glob('transaction-*.json'))
+        remaining = list(transactions_dir.glob("transaction-*.json"))
         assert len(remaining) == 5
 
         # Verify uncommitted preserved
@@ -400,15 +406,14 @@ def test_cleanup_preserves_all_uncommitted():
     manager = TransactionManager()
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        transactions_dir = Path(tmpdir) / 'transactions'
+        transactions_dir = Path(tmpdir) / "transactions"
         transactions_dir.mkdir()
 
         # Create 10 uncommitted, 0 committed
         for i in range(10):
-            manifest = manager.begin_transaction(f'uncommitted-{i}')
+            manifest = manager.begin_transaction(f"uncommitted-{i}")
             manager.save_manifest(
-                manifest,
-                transactions_dir / f'transaction-uncommitted-{i}.json'
+                manifest, transactions_dir / f"transaction-uncommitted-{i}.json"
             )
 
         # Try to keep only 2 (but all are uncommitted)
@@ -418,7 +423,7 @@ def test_cleanup_preserves_all_uncommitted():
         assert deleted == 0
 
         # All 10 should remain
-        remaining = list(transactions_dir.glob('transaction-*.json'))
+        remaining = list(transactions_dir.glob("transaction-*.json"))
         assert len(remaining) == 10
 
 
@@ -427,7 +432,7 @@ def test_cleanup_handles_empty_directory():
     manager = TransactionManager()
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        nonexistent_dir = Path(tmpdir) / 'nonexistent'
+        nonexistent_dir = Path(tmpdir) / "nonexistent"
         deleted = manager.cleanup_old_transactions(nonexistent_dir, keep_count=10)
         assert deleted == 0
 
@@ -437,22 +442,20 @@ def test_cleanup_with_zero_keep_count():
     manager = TransactionManager()
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        transactions_dir = Path(tmpdir) / 'transactions'
+        transactions_dir = Path(tmpdir) / "transactions"
         transactions_dir.mkdir()
 
         # Create 3 committed, 1 uncommitted
         for i in range(3):
-            manifest = manager.begin_transaction(f'committed-{i}')
-            manifest.status = 'committed'
+            manifest = manager.begin_transaction(f"committed-{i}")
+            manifest.status = "committed"
             manager.save_manifest(
-                manifest,
-                transactions_dir / f'transaction-committed-{i}.json'
+                manifest, transactions_dir / f"transaction-committed-{i}.json"
             )
 
-        manifest = manager.begin_transaction('uncommitted')
+        manifest = manager.begin_transaction("uncommitted")
         manager.save_manifest(
-            manifest,
-            transactions_dir / 'transaction-uncommitted.json'
+            manifest, transactions_dir / "transaction-uncommitted.json"
         )
 
         # Keep 0 committed
@@ -461,7 +464,7 @@ def test_cleanup_with_zero_keep_count():
         assert deleted == 3
 
         # Only uncommitted should remain
-        remaining = list(transactions_dir.glob('transaction-*.json'))
+        remaining = list(transactions_dir.glob("transaction-*.json"))
         assert len(remaining) == 1
 
 
@@ -474,10 +477,7 @@ def test_transaction_manager_accepts_timeout_config():
 
         # Custom timeout config
         timeout_config = GitTimeoutConfig(
-            base_timeout_ms=60000,
-            fast_scale=0.2,
-            slow_scale=5.0,
-            max_timeout_ms=400000
+            base_timeout_ms=60000, fast_scale=0.2, slow_scale=5.0, max_timeout_ms=400000
         )
 
         manager = TransactionManager(base_path=base_path, timeout_config=timeout_config)
@@ -519,18 +519,19 @@ def test_transaction_manager_passes_timeout_to_git():
         manager = TransactionManager(base_path=base_path, timeout_config=timeout_config)
 
         # Patch GitHelper.run_git_command to verify timeout_config is passed
-        with patch('src.utils.git_helper.GitHelper.run_git_command') as mock_run:
-            mock_run.return_value = MagicMock(returncode=0, stdout='')
+        with patch("src.utils.git_helper.GitHelper.run_git_command") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="")
 
             # Begin transaction (should call git checkout)
             try:
-                manager.begin_transaction('test-session')
+                manager.begin_transaction("test-session")
             except Exception:
-                pass  # We don't care about other errors, just checking timeout is passed
+                pass  # We don't care about other errors, just checking timeout is
+                # passed
 
             # Verify git command was called with timeout_config
             if mock_run.called:
                 call_kwargs = mock_run.call_args
                 if call_kwargs and len(call_kwargs) > 1:
-                    assert 'timeout_config' in call_kwargs[1]
-                    assert call_kwargs[1]['timeout_config'] == timeout_config
+                    assert "timeout_config" in call_kwargs[1]
+                    assert call_kwargs[1]["timeout_config"] == timeout_config

--- a/analyzer/tests/test_typescript_parser.py
+++ b/analyzer/tests/test_typescript_parser.py
@@ -12,12 +12,14 @@ from src.models.code_item import CodeItem
 
 # Test fixture paths
 PROJECT_ROOT = Path(__file__).parent.parent.parent
-MALFORMED_SAMPLES = PROJECT_ROOT / 'test-samples' / 'malformed'
-EXAMPLES_DIR = PROJECT_ROOT / 'examples'
+MALFORMED_SAMPLES = PROJECT_ROOT / "test-samples" / "malformed"
+EXAMPLES_DIR = PROJECT_ROOT / "examples"
 
 
 class TestTypeScriptParserInitialization:
-    """Test suite for TypeScriptParser initialization and dependency injection (Issue #63)."""
+    """Test suite for TypeScriptParser initialization and dependency
+
+    injection (Issue #63)."""
 
     def test_explicit_helper_path_injection(self, tmp_path):
         """Test explicit helper_path parameter (Priority 1: dependency injection)."""
@@ -38,7 +40,7 @@ class TestTypeScriptParserInitialization:
         mock_helper.write_text("// env helper")
 
         # Set environment variable
-        monkeypatch.setenv('DOCIMP_TS_HELPER_PATH', str(mock_helper))
+        monkeypatch.setenv("DOCIMP_TS_HELPER_PATH", str(mock_helper))
 
         # Create parser without explicit path
         parser = TypeScriptParser()
@@ -54,7 +56,7 @@ class TestTypeScriptParserInitialization:
         # Should auto-detect the real helper path
         assert parser.helper_path is not None
         assert parser.helper_path.exists()
-        assert parser.helper_path.name == 'ts-js-parser-cli.js'
+        assert parser.helper_path.name == "ts-js-parser-cli.js"
 
     def test_priority_explicit_over_environment(self, tmp_path, monkeypatch):
         """Test that explicit parameter takes priority over environment variable."""
@@ -65,7 +67,7 @@ class TestTypeScriptParserInitialization:
         env_helper.write_text("// env")
 
         # Set environment variable
-        monkeypatch.setenv('DOCIMP_TS_HELPER_PATH', str(env_helper))
+        monkeypatch.setenv("DOCIMP_TS_HELPER_PATH", str(env_helper))
 
         # Create parser with explicit path (should override env var)
         parser = TypeScriptParser(helper_path=explicit_helper)
@@ -80,14 +82,14 @@ class TestTypeScriptParserInitialization:
         mock_helper.write_text("// env helper")
 
         # Set environment variable
-        monkeypatch.setenv('DOCIMP_TS_HELPER_PATH', str(mock_helper))
+        monkeypatch.setenv("DOCIMP_TS_HELPER_PATH", str(mock_helper))
 
         # Create parser without explicit path
         parser = TypeScriptParser()
 
         # Should use env var, not auto-detection
         assert parser.helper_path == mock_helper
-        assert 'env-helper.js' in str(parser.helper_path)
+        assert "env-helper.js" in str(parser.helper_path)
 
     def test_error_when_explicit_path_not_found(self, tmp_path):
         """Test that FileNotFoundError is raised when explicit path doesn't exist."""
@@ -105,7 +107,7 @@ class TestTypeScriptParserInitialization:
     def test_error_when_environment_path_not_found(self, tmp_path, monkeypatch):
         """Test that FileNotFoundError is raised when env var path doesn't exist."""
         nonexistent_path = tmp_path / "nonexistent-helper.js"
-        monkeypatch.setenv('DOCIMP_TS_HELPER_PATH', str(nonexistent_path))
+        monkeypatch.setenv("DOCIMP_TS_HELPER_PATH", str(nonexistent_path))
 
         with pytest.raises(FileNotFoundError) as exc_info:
             TypeScriptParser()
@@ -136,10 +138,10 @@ class TestTypeScriptParserInitialization:
         helper_path = parser._find_helper()
 
         # Should find the cli/dist/parsers/ts-js-parser-cli.js path
-        assert 'cli' in str(helper_path)
-        assert 'dist' in str(helper_path)
-        assert 'parsers' in str(helper_path)
-        assert 'ts-js-parser-cli.js' in str(helper_path)
+        assert "cli" in str(helper_path)
+        assert "dist" in str(helper_path)
+        assert "parsers" in str(helper_path)
+        assert "ts-js-parser-cli.js" in str(helper_path)
 
 
 class TestTypeScriptParser:
@@ -153,17 +155,17 @@ class TestTypeScriptParser:
     @pytest.fixture
     def ts_file(self):
         """Return path to test TypeScript file."""
-        return str(EXAMPLES_DIR / 'test_simple.ts')
+        return str(EXAMPLES_DIR / "test_simple.ts")
 
     @pytest.fixture
     def js_esm_file(self):
         """Return path to test JavaScript ESM file."""
-        return str(EXAMPLES_DIR / 'test_javascript_patterns.js')
+        return str(EXAMPLES_DIR / "test_javascript_patterns.js")
 
     @pytest.fixture
     def js_cjs_file(self):
         """Return path to test CommonJS file."""
-        return str(EXAMPLES_DIR / 'test_commonjs.cjs')
+        return str(EXAMPLES_DIR / "test_commonjs.cjs")
 
     def test_parser_initialization(self, parser):
         """Test that parser initializes correctly."""
@@ -176,52 +178,52 @@ class TestTypeScriptParser:
 
         assert len(items) > 0
         assert all(isinstance(item, CodeItem) for item in items)
-        assert all(item.language == 'typescript' for item in items)
+        assert all(item.language == "typescript" for item in items)
 
     def test_typescript_extracts_classes(self, parser, ts_file):
         """Test that TypeScript parser extracts classes."""
         items = parser.parse_file(ts_file)
 
-        classes = [item for item in items if item.type == 'class']
+        classes = [item for item in items if item.type == "class"]
         assert len(classes) > 0
 
         # Check UserService class exists
-        user_service = next((c for c in classes if c.name == 'UserService'), None)
+        user_service = next((c for c in classes if c.name == "UserService"), None)
         assert user_service is not None
 
     def test_typescript_extracts_methods(self, parser, ts_file):
         """Test that TypeScript parser extracts methods."""
         items = parser.parse_file(ts_file)
 
-        methods = [item for item in items if item.type == 'method']
+        methods = [item for item in items if item.type == "method"]
         assert len(methods) > 0
 
         # Check getUser method
-        get_user = next((m for m in methods if 'getUser' in m.name), None)
+        get_user = next((m for m in methods if "getUser" in m.name), None)
         assert get_user is not None
         assert get_user.has_docs
-        assert 'id' in get_user.parameters
+        assert "id" in get_user.parameters
 
     def test_typescript_extracts_functions(self, parser, ts_file):
         """Test that TypeScript parser extracts functions."""
         items = parser.parse_file(ts_file)
 
-        functions = [item for item in items if item.type == 'function']
+        functions = [item for item in items if item.type == "function"]
         assert len(functions) > 0
 
         # Check validateEmail function exists
-        validate_email = next((f for f in functions if f.name == 'validateEmail'), None)
+        validate_email = next((f for f in functions if f.name == "validateEmail"), None)
         assert validate_email is not None
 
     def test_typescript_extracts_interfaces(self, parser, ts_file):
         """Test that TypeScript parser extracts interfaces."""
         items = parser.parse_file(ts_file)
 
-        interfaces = [item for item in items if item.type == 'interface']
+        interfaces = [item for item in items if item.type == "interface"]
         assert len(interfaces) > 0
 
         # Check User interface
-        user_interface = next((i for i in interfaces if i.name == 'User'), None)
+        user_interface = next((i for i in interfaces if i.name == "User"), None)
         assert user_interface is not None
 
     def test_typescript_detects_exports(self, parser, ts_file):
@@ -229,7 +231,7 @@ class TestTypeScriptParser:
         items = parser.parse_file(ts_file)
 
         # Should have named exports
-        exported_items = [item for item in items if item.export_type == 'named']
+        exported_items = [item for item in items if item.export_type == "named"]
         assert len(exported_items) > 0
 
     def test_typescript_complexity_calculation(self, parser, ts_file):
@@ -237,7 +239,7 @@ class TestTypeScriptParser:
         items = parser.parse_file(ts_file)
 
         # helperFunction has multiple if/else branches
-        helper = next((item for item in items if 'helperFunction' in item.name), None)
+        helper = next((item for item in items if "helperFunction" in item.name), None)
         assert helper is not None
         assert helper.complexity > 1  # Should have complexity > 1 due to branches
 
@@ -246,7 +248,7 @@ class TestTypeScriptParser:
         items = parser.parse_file(ts_file)
 
         # helperFunction has no documentation
-        helper = next((item for item in items if 'helperFunction' in item.name), None)
+        helper = next((item for item in items if "helperFunction" in item.name), None)
         assert helper is not None
         assert not helper.has_docs
 
@@ -256,21 +258,21 @@ class TestTypeScriptParser:
 
         assert len(items) > 0
         assert all(isinstance(item, CodeItem) for item in items)
-        assert all(item.language == 'javascript' for item in items)
+        assert all(item.language == "javascript" for item in items)
 
     def test_javascript_detects_esm_module_system(self, parser, js_esm_file):
         """Test that JavaScript parser detects ESM module system."""
         items = parser.parse_file(js_esm_file)
 
         # All items should be ESM
-        assert all(item.module_system == 'esm' for item in items)
+        assert all(item.module_system == "esm" for item in items)
 
     def test_javascript_esm_exports(self, parser, js_esm_file):
         """Test that JavaScript parser detects ESM exports."""
         items = parser.parse_file(js_esm_file)
 
         # Should have named exports
-        named_exports = [item for item in items if item.export_type == 'named']
+        named_exports = [item for item in items if item.export_type == "named"]
         assert len(named_exports) > 0
 
     def test_javascript_extracts_arrow_functions(self, parser, js_esm_file):
@@ -278,21 +280,23 @@ class TestTypeScriptParser:
         items = parser.parse_file(js_esm_file)
 
         # Check for 'first' arrow function
-        first_func = next((item for item in items if item.name == 'first'), None)
+        first_func = next((item for item in items if item.name == "first"), None)
         assert first_func is not None
-        assert first_func.type == 'function'
+        assert first_func.type == "function"
 
     def test_javascript_jsdoc_detection(self, parser, js_esm_file):
         """Test that JavaScript parser detects JSDoc documentation."""
         items = parser.parse_file(js_esm_file)
 
         # fetchUser should have JSDoc
-        fetch_user = next((item for item in items if item.name == 'fetchUser'), None)
+        fetch_user = next((item for item in items if item.name == "fetchUser"), None)
         assert fetch_user is not None
         assert fetch_user.has_docs
 
         # undocumentedHelper should not have docs
-        undoc = next((item for item in items if 'undocumented' in item.name.lower()), None)
+        undoc = next(
+            (item for item in items if "undocumented" in item.name.lower()), None
+        )
         assert undoc is not None
         assert not undoc.has_docs
 
@@ -302,14 +306,14 @@ class TestTypeScriptParser:
 
         assert len(items) > 0
         assert all(isinstance(item, CodeItem) for item in items)
-        assert all(item.language == 'javascript' for item in items)
+        assert all(item.language == "javascript" for item in items)
 
     def test_commonjs_detects_module_system(self, parser, js_cjs_file):
         """Test that parser detects CommonJS module system."""
         items = parser.parse_file(js_cjs_file)
 
         # Should detect CommonJS
-        commonjs_items = [item for item in items if item.module_system == 'commonjs']
+        commonjs_items = [item for item in items if item.module_system == "commonjs"]
         assert len(commonjs_items) > 0
 
     def test_commonjs_exports(self, parser, js_cjs_file):
@@ -317,13 +321,13 @@ class TestTypeScriptParser:
         items = parser.parse_file(js_cjs_file)
 
         # Should have commonjs export type
-        cjs_exports = [item for item in items if item.export_type == 'commonjs']
+        cjs_exports = [item for item in items if item.export_type == "commonjs"]
         assert len(cjs_exports) > 0
 
         # Check for specific exported functions
-        average = next((item for item in items if item.name == 'average'), None)
+        average = next((item for item in items if item.name == "average"), None)
         assert average is not None
-        assert average.export_type == 'commonjs'
+        assert average.export_type == "commonjs"
 
     def test_commonjs_module_exports_object(self, parser, js_cjs_file):
         """Test parsing module.exports = {...} pattern."""
@@ -331,16 +335,16 @@ class TestTypeScriptParser:
 
         # Should extract functions from module.exports object
         func_names = [item.name for item in items]
-        assert 'average' in func_names
-        assert 'max' in func_names
-        assert 'min' in func_names
+        assert "average" in func_names
+        assert "max" in func_names
+        assert "min" in func_names
 
     def test_commonjs_module_exports_property(self, parser, js_cjs_file):
         """Test parsing module.exports.foo = ... pattern."""
         items = parser.parse_file(js_cjs_file)
 
         # Should extract median function
-        median = next((item for item in items if item.name == 'median'), None)
+        median = next((item for item in items if item.name == "median"), None)
         assert median is not None
         assert median.has_docs
 
@@ -349,14 +353,16 @@ class TestTypeScriptParser:
         items = parser.parse_file(js_cjs_file)
 
         # Should extract undocumentedHelper
-        helper = next((item for item in items if 'undocumented' in item.name.lower()), None)
+        helper = next(
+            (item for item in items if "undocumented" in item.name.lower()), None
+        )
         assert helper is not None
         assert not helper.has_docs
 
     def test_file_not_found_error(self, parser):
         """Test that parser raises FileNotFoundError for missing files."""
         with pytest.raises(FileNotFoundError):
-            parser.parse_file('/nonexistent/file.ts')
+            parser.parse_file("/nonexistent/file.ts")
 
     def test_all_items_have_required_fields(self, parser, ts_file):
         """Test that all extracted items have required fields."""
@@ -364,15 +370,15 @@ class TestTypeScriptParser:
 
         for item in items:
             assert item.name
-            assert item.type in ['function', 'class', 'method', 'interface']
+            assert item.type in ["function", "class", "method", "interface"]
             assert item.filepath
             assert item.line_number > 0
-            assert item.language in ['typescript', 'javascript']
+            assert item.language in ["typescript", "javascript"]
             assert item.complexity >= 1
             assert isinstance(item.has_docs, bool)
             assert isinstance(item.parameters, list)
-            assert item.export_type in ['named', 'default', 'commonjs', 'internal']
-            assert item.module_system in ['esm', 'commonjs', 'unknown']
+            assert item.export_type in ["named", "default", "commonjs", "internal"]
+            assert item.module_system in ["esm", "commonjs", "unknown"]
 
 
 class TestTypeScriptParserMalformedSyntax:
@@ -398,7 +404,7 @@ class TestTypeScriptParserMalformedSyntax:
         # It uses error recovery to parse partial ASTs even with syntax errors
 
         # Parse a file with missing brace - should succeed with partial AST
-        result = parser.parse_file(str(malformed_dir / 'typescript_missing_brace.ts'))
+        result = parser.parse_file(str(malformed_dir / "typescript_missing_brace.ts"))
         assert isinstance(result, list), "Should return list even with syntax errors"
 
         # The key test is that it doesn't crash - error recovery allows partial parsing
@@ -415,13 +421,14 @@ class TestTypeScriptParserMalformedSyntax:
 
         # Parse files with syntax errors - should succeed with partial ASTs
         js_files = [
-            'javascript_esm_error.js',
-            'javascript_arrow_error.js',
-            'javascript_commonjs_error.cjs',
-            'javascript_unclosed_bracket.mjs'
+            "javascript_esm_error.js",
+            "javascript_arrow_error.js",
+            "javascript_commonjs_error.cjs",
+            "javascript_unclosed_bracket.mjs",
         ]
 
         for filename in js_files:
             result = parser.parse_file(str(malformed_dir / filename))
-            assert isinstance(result, list), \
-                f"{filename} should return list (error recovery allows partial parsing)"
+            assert isinstance(
+                result, list
+            ), f"{filename} should return list (error recovery allows partial parsing)"

--- a/analyzer/tests/test_writer.py
+++ b/analyzer/tests/test_writer.py
@@ -23,7 +23,7 @@ def writer():
     during tests. Security-specific tests create their own instances
     with restricted paths.
     """
-    return DocstringWriter(base_path='/')
+    return DocstringWriter(base_path="/")
 
 
 def write_and_check(writer, code, jsdoc, item_name, item_type):
@@ -48,7 +48,7 @@ def write_and_check(writer, code, jsdoc, item_name, item_type):
         Result after writing docstring
     """
     # Create temporary file
-    with tempfile.NamedTemporaryFile(mode='w', suffix='.js', delete=False) as f:
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".js", delete=False) as f:
         f.write(code)
         temp_path = f.name
 
@@ -59,13 +59,13 @@ def write_and_check(writer, code, jsdoc, item_name, item_type):
             item_name=item_name,
             item_type=item_type,
             docstring=jsdoc,
-            language='javascript'
+            language="javascript",
         )
 
         assert success, f"Writer returned False for {item_name}"
 
         # Read result
-        with open(temp_path, 'r') as f:
+        with open(temp_path, "r") as f:
             result = f.read()
 
         return result
@@ -73,7 +73,7 @@ def write_and_check(writer, code, jsdoc, item_name, item_type):
     finally:
         # Clean up temp file and backup
         Path(temp_path).unlink(missing_ok=True)
-        Path(temp_path + '.bak').unlink(missing_ok=True)
+        Path(temp_path + ".bak").unlink(missing_ok=True)
 
 
 def test_regular_function(writer):
@@ -83,8 +83,8 @@ def test_regular_function(writer):
 
     result = write_and_check(writer, code, jsdoc, "add", "function")
 
-    assert '/**' in result, "JSDoc not found in output"
-    assert 'add' in result, "Original code not found"
+    assert "/**" in result, "JSDoc not found in output"
+    assert "add" in result, "Original code not found"
 
 
 def test_export_function(writer):
@@ -94,8 +94,8 @@ def test_export_function(writer):
 
     result = write_and_check(writer, code, jsdoc, "multiply", "function")
 
-    assert '/**' in result, "JSDoc not found in output"
-    assert 'multiply' in result, "Original code not found"
+    assert "/**" in result, "JSDoc not found in output"
+    assert "multiply" in result, "Original code not found"
 
 
 def test_export_default_function(writer):
@@ -105,8 +105,8 @@ def test_export_default_function(writer):
 
     result = write_and_check(writer, code, jsdoc, "divide", "function")
 
-    assert '/**' in result, "JSDoc not found in output"
-    assert 'divide' in result, "Original code not found"
+    assert "/**" in result, "JSDoc not found in output"
+    assert "divide" in result, "Original code not found"
 
 
 def test_arrow_function(writer):
@@ -116,8 +116,8 @@ def test_arrow_function(writer):
 
     result = write_and_check(writer, code, jsdoc, "subtract", "function")
 
-    assert '/**' in result, "JSDoc not found in output"
-    assert 'subtract' in result, "Original code not found"
+    assert "/**" in result, "JSDoc not found in output"
+    assert "subtract" in result, "Original code not found"
 
 
 def test_export_arrow_function(writer):
@@ -127,8 +127,8 @@ def test_export_arrow_function(writer):
 
     result = write_and_check(writer, code, jsdoc, "power", "function")
 
-    assert '/**' in result, "JSDoc not found in output"
-    assert 'power' in result, "Original code not found"
+    assert "/**" in result, "JSDoc not found in output"
+    assert "power" in result, "Original code not found"
 
 
 def test_arrow_function_without_parens(writer):
@@ -138,8 +138,8 @@ def test_arrow_function_without_parens(writer):
 
     result = write_and_check(writer, code, jsdoc, "double", "function")
 
-    assert '/**' in result, "JSDoc not found in output"
-    assert 'double' in result, "Original code not found"
+    assert "/**" in result, "JSDoc not found in output"
+    assert "double" in result, "Original code not found"
 
 
 def test_arrow_function_without_parens_async(writer):
@@ -149,8 +149,8 @@ def test_arrow_function_without_parens_async(writer):
 
     result = write_and_check(writer, code, jsdoc, "fetchData", "function")
 
-    assert '/**' in result, "JSDoc not found in output"
-    assert 'fetchData' in result, "Original code not found"
+    assert "/**" in result, "JSDoc not found in output"
+    assert "fetchData" in result, "Original code not found"
 
 
 def test_export_arrow_function_without_parens(writer):
@@ -160,8 +160,8 @@ def test_export_arrow_function_without_parens(writer):
 
     result = write_and_check(writer, code, jsdoc, "triple", "function")
 
-    assert '/**' in result, "JSDoc not found in output"
-    assert 'triple' in result, "Original code not found"
+    assert "/**" in result, "JSDoc not found in output"
+    assert "triple" in result, "Original code not found"
 
 
 def test_class(writer):
@@ -171,19 +171,22 @@ def test_class(writer):
 
     result = write_and_check(writer, code, jsdoc, "Calculator", "class")
 
-    assert '/**' in result, "JSDoc not found in output"
-    assert 'Calculator' in result, "Original code not found"
+    assert "/**" in result, "JSDoc not found in output"
+    assert "Calculator" in result, "Original code not found"
 
 
 def test_class_method(writer):
     """Test writing JSDoc for class method."""
-    code = "class Math {\n  sum(numbers) {\n    return numbers.reduce((a, b) => a + b, 0);\n  }\n}"
+    code = (
+        "class Math {\n  sum(numbers) {\n    "
+        "return numbers.reduce((a, b) => a + b, 0);\n  }\n}"
+    )
     jsdoc = "Sum all numbers"
 
     result = write_and_check(writer, code, jsdoc, "sum", "method")
 
-    assert '/**' in result, "JSDoc not found in output"
-    assert 'sum' in result, "Original code not found"
+    assert "/**" in result, "JSDoc not found in output"
+    assert "sum" in result, "Original code not found"
 
 
 def test_private_method(writer):
@@ -193,19 +196,22 @@ def test_private_method(writer):
 
     result = write_and_check(writer, code, jsdoc, "#connect", "method")
 
-    assert '/**' in result, "JSDoc not found in output"
-    assert '#connect' in result, "Original code not found"
+    assert "/**" in result, "JSDoc not found in output"
+    assert "#connect" in result, "Original code not found"
 
 
 def test_private_method_async(writer):
     """Test writing JSDoc for async private class method."""
-    code = "class API {\n  async #fetchData() {\n    return await fetch('/api/data');\n  }\n}"
+    code = (
+        "class API {\n  async #fetchData() {\n    "
+        "return await fetch('/api/data');\n  }\n}"
+    )
     jsdoc = "Fetch data from API"
 
     result = write_and_check(writer, code, jsdoc, "#fetchData", "method")
 
-    assert '/**' in result, "JSDoc not found in output"
-    assert '#fetchData' in result, "Original code not found"
+    assert "/**" in result, "JSDoc not found in output"
+    assert "#fetchData" in result, "Original code not found"
 
 
 def test_private_method_static(writer):
@@ -215,8 +221,8 @@ def test_private_method_static(writer):
 
     result = write_and_check(writer, code, jsdoc, "#helper", "method")
 
-    assert '/**' in result, "JSDoc not found in output"
-    assert '#helper' in result, "Original code not found"
+    assert "/**" in result, "JSDoc not found in output"
+    assert "#helper" in result, "Original code not found"
 
 
 def test_typescript_public_method(writer):
@@ -226,8 +232,8 @@ def test_typescript_public_method(writer):
 
     result = write_and_check(writer, code, jsdoc, "getData", "method")
 
-    assert '/**' in result, "JSDoc not found in output"
-    assert 'getData' in result, "Original code not found"
+    assert "/**" in result, "JSDoc not found in output"
+    assert "getData" in result, "Original code not found"
 
 
 def test_typescript_private_method(writer):
@@ -237,30 +243,36 @@ def test_typescript_private_method(writer):
 
     result = write_and_check(writer, code, jsdoc, "helper", "method")
 
-    assert '/**' in result, "JSDoc not found in output"
-    assert 'helper' in result, "Original code not found"
+    assert "/**" in result, "JSDoc not found in output"
+    assert "helper" in result, "Original code not found"
 
 
 def test_typescript_protected_async_method(writer):
     """Test writing JSDoc for TypeScript protected async method."""
-    code = "class Base {\n  protected async validate() {\n    return await this.check();\n  }\n}"
+    code = (
+        "class Base {\n  protected async validate() {\n    "
+        "return await this.check();\n  }\n}"
+    )
     jsdoc = "Validate the input"
 
     result = write_and_check(writer, code, jsdoc, "validate", "method")
 
-    assert '/**' in result, "JSDoc not found in output"
-    assert 'validate' in result, "Original code not found"
+    assert "/**" in result, "JSDoc not found in output"
+    assert "validate" in result, "Original code not found"
 
 
 def test_typescript_private_static_method(writer):
     """Test writing JSDoc for TypeScript private static method."""
-    code = "class Factory {\n  private static create() {\n    return new Factory();\n  }\n}"
+    code = (
+        "class Factory {\n  private static create() {\n    "
+        "return new Factory();\n  }\n}"
+    )
     jsdoc = "Create instance"
 
     result = write_and_check(writer, code, jsdoc, "create", "method")
 
-    assert '/**' in result, "JSDoc not found in output"
-    assert 'create' in result, "Original code not found"
+    assert "/**" in result, "JSDoc not found in output"
+    assert "create" in result, "Original code not found"
 
 
 def test_method_name_starting_with_visibility_keyword(writer):
@@ -270,8 +282,8 @@ def test_method_name_starting_with_visibility_keyword(writer):
 
     result = write_and_check(writer, code, jsdoc, "publicity", "method")
 
-    assert '/**' in result, "JSDoc not found in output"
-    assert 'publicity' in result, "Original code not found"
+    assert "/**" in result, "JSDoc not found in output"
+    assert "publicity" in result, "Original code not found"
 
 
 def test_method_name_starting_with_private_keyword(writer):
@@ -281,8 +293,8 @@ def test_method_name_starting_with_private_keyword(writer):
 
     result = write_and_check(writer, code, jsdoc, "privatize", "method")
 
-    assert '/**' in result, "JSDoc not found in output"
-    assert 'privatize' in result, "Original code not found"
+    assert "/**" in result, "JSDoc not found in output"
+    assert "privatize" in result, "Original code not found"
 
 
 def test_method_name_starting_with_protected_keyword(writer):
@@ -292,8 +304,8 @@ def test_method_name_starting_with_protected_keyword(writer):
 
     result = write_and_check(writer, code, jsdoc, "protection", "method")
 
-    assert '/**' in result, "JSDoc not found in output"
-    assert 'protection' in result, "Original code not found"
+    assert "/**" in result, "JSDoc not found in output"
+    assert "protection" in result, "Original code not found"
 
 
 def test_arrow_function_with_underscore_param(writer):
@@ -303,8 +315,8 @@ def test_arrow_function_with_underscore_param(writer):
 
     result = write_and_check(writer, code, jsdoc, "increment", "function")
 
-    assert '/**' in result, "JSDoc not found in output"
-    assert 'increment' in result, "Original code not found"
+    assert "/**" in result, "JSDoc not found in output"
+    assert "increment" in result, "Original code not found"
 
 
 def test_arrow_function_with_dollar_param(writer):
@@ -314,17 +326,19 @@ def test_arrow_function_with_dollar_param(writer):
 
     result = write_and_check(writer, code, jsdoc, "transform", "function")
 
-    assert '/**' in result, "JSDoc not found in output"
-    assert 'transform' in result, "Original code not found"
+    assert "/**" in result, "JSDoc not found in output"
+    assert "transform" in result, "Original code not found"
 
 
 def test_backup_cleanup_on_successful_write(writer):
-    """Test that backup files are PRESERVED after successful writes (for transaction tracking)."""
+    """Test that backup files are PRESERVED after successful writes.
+
+    (for transaction tracking)."""
     code = "function test() {\n  return true;\n}"
     jsdoc = "Test function"
 
     # Create temporary file
-    with tempfile.NamedTemporaryFile(mode='w', suffix='.js', delete=False) as f:
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".js", delete=False) as f:
         f.write(code)
         temp_path = f.name
 
@@ -332,33 +346,39 @@ def test_backup_cleanup_on_successful_write(writer):
         # Write docstring (content changes, so write succeeds)
         success = writer.write_docstring(
             filepath=temp_path,
-            item_name='test',
-            item_type='function',
+            item_name="test",
+            item_type="function",
             docstring=jsdoc,
-            language='javascript'
+            language="javascript",
         )
 
         assert success, "Write should succeed"
 
         # Verify backup file DOES exist (preserved for transaction tracking)
-        backup_files = list(Path(temp_path).parent.glob(f'{Path(temp_path).name}.*.bak'))
-        assert len(backup_files) == 1, \
-            "Backup file should be preserved after successful write for transaction tracking"
+        backup_files = list(
+            Path(temp_path).parent.glob(f"{Path(temp_path).name}.*.bak")
+        )
+        assert len(backup_files) == 1, (
+            "Backup file should be preserved after successful write "
+            "for transaction tracking"
+        )
 
     finally:
         # Clean up temp file and backup
         Path(temp_path).unlink(missing_ok=True)
-        for backup in Path(temp_path).parent.glob(f'{Path(temp_path).name}.*.bak'):
+        for backup in Path(temp_path).parent.glob(f"{Path(temp_path).name}.*.bak"):
             backup.unlink(missing_ok=True)
 
 
 def test_backup_cleanup_on_idempotent_write(writer):
-    """Test that no backup is created when content is unchanged (idempotent operation)."""
+    """Test that no backup is created when content is unchanged (idempotent
+
+    operation)."""
     code = "/**\n * Test function\n */\nfunction test() {\n  return true;\n}"
     jsdoc = "Test function"
 
     # Create temporary file with docstring already present
-    with tempfile.NamedTemporaryFile(mode='w', suffix='.js', delete=False) as f:
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".js", delete=False) as f:
         f.write(code)
         temp_path = f.name
 
@@ -366,18 +386,21 @@ def test_backup_cleanup_on_idempotent_write(writer):
         # Write docstring (content unchanged, idempotent operation)
         success = writer.write_docstring(
             filepath=temp_path,
-            item_name='test',
-            item_type='function',
+            item_name="test",
+            item_type="function",
             docstring=jsdoc,
-            language='javascript'
+            language="javascript",
         )
 
         assert success, "Write should succeed"
 
         # Verify no backup file created (no change = no backup needed)
-        backup_files = list(Path(temp_path).parent.glob(f'{Path(temp_path).name}.*.bak'))
-        assert len(backup_files) == 0, \
-            "No backup should be created for idempotent operation (content unchanged)"
+        backup_files = list(
+            Path(temp_path).parent.glob(f"{Path(temp_path).name}.*.bak")
+        )
+        assert (
+            len(backup_files) == 0
+        ), "No backup should be created for idempotent operation (content unchanged)"
 
     finally:
         # Clean up temp file only (no backup to clean)
@@ -389,7 +412,7 @@ def test_backup_cleanup_on_write_failure(writer):
     code = "function test() {\n  return true;\n}"
 
     # Create temporary file
-    with tempfile.NamedTemporaryFile(mode='w', suffix='.js', delete=False) as f:
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".js", delete=False) as f:
         f.write(code)
         temp_path = f.name
 
@@ -398,26 +421,27 @@ def test_backup_cleanup_on_write_failure(writer):
         with pytest.raises(ValueError, match="Unsupported language"):
             writer.write_docstring(
                 filepath=temp_path,
-                item_name='test',
-                item_type='function',
-                docstring='Test function',
-                language='unsupported_language'
+                item_name="test",
+                item_type="function",
+                docstring="Test function",
+                language="unsupported_language",
             )
 
         # Verify backup file was cleaned up despite the failure
-        backup_path = Path(temp_path + '.bak')
-        assert not backup_path.exists(), \
-            "Backup file should be deleted even after write failure"
+        backup_path = Path(temp_path + ".bak")
+        assert (
+            not backup_path.exists()
+        ), "Backup file should be deleted even after write failure"
 
         # Verify original file is still intact (restored from backup)
-        with open(temp_path, 'r') as f:
+        with open(temp_path, "r") as f:
             content = f.read()
         assert content == code, "Original file should be restored after failure"
 
     finally:
         # Clean up temp file only (backup should already be gone)
         Path(temp_path).unlink(missing_ok=True)
-        Path(temp_path + '.bak').unlink(missing_ok=True)
+        Path(temp_path + ".bak").unlink(missing_ok=True)
 
 
 class TestPathTraversalValidation:
@@ -427,14 +451,14 @@ class TestPathTraversalValidation:
         """Test that paths outside base directory are rejected."""
         with tempfile.TemporaryDirectory() as temp_dir:
             # Create base directory and a file inside it
-            base_path = Path(temp_dir) / 'project'
+            base_path = Path(temp_dir) / "project"
             base_path.mkdir()
-            valid_file = base_path / 'code.py'
-            valid_file.write_text('def foo():\n    pass')
+            valid_file = base_path / "code.py"
+            valid_file.write_text("def foo():\n    pass")
 
             # Create file outside base directory
-            outside_file = Path(temp_dir) / 'outside.py'
-            outside_file.write_text('def bar():\n    pass')
+            outside_file = Path(temp_dir) / "outside.py"
+            outside_file.write_text("def bar():\n    pass")
 
             # Create writer with restricted base path
             writer = DocstringWriter(base_path=str(base_path))
@@ -443,49 +467,49 @@ class TestPathTraversalValidation:
             with pytest.raises(ValueError, match="outside allowed directory"):
                 writer.write_docstring(
                     filepath=str(outside_file),
-                    item_name='bar',
-                    item_type='function',
-                    docstring='Bar function',
-                    language='python'
+                    item_name="bar",
+                    item_type="function",
+                    docstring="Bar function",
+                    language="python",
                 )
 
     def test_reject_path_traversal_attack(self):
         """Test that path traversal attacks are blocked."""
         with tempfile.TemporaryDirectory() as temp_dir:
             # Create base directory structure
-            base_path = Path(temp_dir) / 'project'
+            base_path = Path(temp_dir) / "project"
             base_path.mkdir()
 
             # Create a file we want to protect outside the project
-            protected_file = Path(temp_dir) / 'secret.txt'
-            protected_file.write_text('sensitive data')
+            protected_file = Path(temp_dir) / "secret.txt"
+            protected_file.write_text("sensitive data")
 
             # Create writer with restricted base path
             writer = DocstringWriter(base_path=str(base_path))
 
             # Attempt path traversal using relative path
-            traversal_path = str(base_path / '..' / 'secret.txt')
+            traversal_path = str(base_path / ".." / "secret.txt")
 
             # Should reject because resolved path is outside base_path
             with pytest.raises(ValueError, match="outside allowed directory"):
                 writer.write_docstring(
                     filepath=traversal_path,
-                    item_name='foo',
-                    item_type='function',
-                    docstring='Doc',
-                    language='python'
+                    item_name="foo",
+                    item_type="function",
+                    docstring="Doc",
+                    language="python",
                 )
 
     def test_accept_path_inside_base_directory(self):
         """Test that paths inside base directory are accepted."""
         with tempfile.TemporaryDirectory() as temp_dir:
             # Create base directory and nested file
-            base_path = Path(temp_dir) / 'project'
+            base_path = Path(temp_dir) / "project"
             base_path.mkdir()
-            src_dir = base_path / 'src'
+            src_dir = base_path / "src"
             src_dir.mkdir()
-            valid_file = src_dir / 'module.py'
-            valid_file.write_text('def foo():\n    pass')
+            valid_file = src_dir / "module.py"
+            valid_file.write_text("def foo():\n    pass")
 
             # Create writer with base path
             writer = DocstringWriter(base_path=str(base_path))
@@ -493,10 +517,10 @@ class TestPathTraversalValidation:
             # Should accept file inside base directory
             success = writer.write_docstring(
                 filepath=str(valid_file),
-                item_name='foo',
-                item_type='function',
-                docstring='Foo function',
-                language='python'
+                item_name="foo",
+                item_type="function",
+                docstring="Foo function",
+                language="python",
             )
 
             assert success, "Should accept file inside base directory"
@@ -505,17 +529,17 @@ class TestPathTraversalValidation:
         """Test that symlinks are resolved before path validation."""
         with tempfile.TemporaryDirectory() as temp_dir:
             # Create base directory
-            base_path = Path(temp_dir) / 'project'
+            base_path = Path(temp_dir) / "project"
             base_path.mkdir()
 
             # Create file outside base
-            outside_dir = Path(temp_dir) / 'outside'
+            outside_dir = Path(temp_dir) / "outside"
             outside_dir.mkdir()
-            target_file = outside_dir / 'target.py'
-            target_file.write_text('def foo():\n    pass')
+            target_file = outside_dir / "target.py"
+            target_file.write_text("def foo():\n    pass")
 
             # Create symlink inside base pointing to file outside
-            symlink_file = base_path / 'link.py'
+            symlink_file = base_path / "link.py"
             symlink_file.symlink_to(target_file)
 
             # Create writer with restricted base path
@@ -525,10 +549,10 @@ class TestPathTraversalValidation:
             with pytest.raises(ValueError, match="outside allowed directory"):
                 writer.write_docstring(
                     filepath=str(symlink_file),
-                    item_name='foo',
-                    item_type='function',
-                    docstring='Doc',
-                    language='python'
+                    item_name="foo",
+                    item_type="function",
+                    docstring="Doc",
+                    language="python",
                 )
 
     def test_default_base_path_is_cwd(self):
@@ -539,7 +563,7 @@ class TestPathTraversalValidation:
     def test_custom_base_path_is_resolved(self):
         """Test that custom base_path is resolved to absolute path."""
         with tempfile.TemporaryDirectory() as temp_dir:
-            base_path = Path(temp_dir) / 'project'
+            base_path = Path(temp_dir) / "project"
             base_path.mkdir()
 
             # Pass relative path representation
@@ -551,18 +575,19 @@ class TestPathTraversalValidation:
             assert writer.base_path == base_path.resolve()
 
     def test_nonexistent_file_raises_error(self):
-        """Test that attempting to write to nonexistent file raises FileNotFoundError."""
+        """Test that attempting to write to nonexistent file raises
+        FileNotFoundError."""
         with tempfile.TemporaryDirectory() as temp_dir:
             writer = DocstringWriter(base_path=temp_dir)
-            nonexistent = Path(temp_dir) / 'nonexistent.py'
+            nonexistent = Path(temp_dir) / "nonexistent.py"
 
             with pytest.raises(FileNotFoundError, match="File not found"):
                 writer.write_docstring(
                     filepath=str(nonexistent),
-                    item_name='foo',
-                    item_type='function',
-                    docstring='Doc',
-                    language='python'
+                    item_name="foo",
+                    item_type="function",
+                    docstring="Doc",
+                    language="python",
                 )
 
     def test_improve_workflow_integration(self):
@@ -576,14 +601,14 @@ class TestPathTraversalValidation:
         """
         with tempfile.TemporaryDirectory() as temp_dir:
             # Create mock user project directory
-            project_dir = Path(temp_dir) / 'user_project'
+            project_dir = Path(temp_dir) / "user_project"
             project_dir.mkdir()
 
             # Create nested source directory with a Python file
-            src_dir = project_dir / 'src'
+            src_dir = project_dir / "src"
             src_dir.mkdir()
-            test_file = src_dir / 'module.py'
-            test_file.write_text('def foo():\n    pass')
+            test_file = src_dir / "module.py"
+            test_file.write_text("def foo():\n    pass")
 
             # Simulate production: base_path is the project root
             # (NOT the Python subprocess CWD which would be analyzer/)
@@ -592,10 +617,10 @@ class TestPathTraversalValidation:
             # This should succeed because file is within base_path
             success = writer.write_docstring(
                 filepath=str(test_file),
-                item_name='foo',
-                item_type='function',
-                docstring='Test function documentation.',
-                language='python'
+                item_name="foo",
+                item_type="function",
+                docstring="Test function documentation.",
+                language="python",
             )
 
             assert success, "Should successfully write to file within project"
@@ -603,24 +628,28 @@ class TestPathTraversalValidation:
             # Verify docstring was actually written
             content = test_file.read_text()
             assert '"""' in content, "Docstring markers should be present"
-            assert 'Test function documentation.' in content, \
-                "Docstring content should be present in file"
+            assert (
+                "Test function documentation." in content
+            ), "Docstring content should be present in file"
 
             # Verify original code is preserved
-            assert 'def foo():' in content, "Original function definition should be preserved"
+            assert (
+                "def foo():" in content
+            ), "Original function definition should be preserved"
 
 
 class TestAtomicWrites:
     """Test suite for atomic write operations with validation."""
 
     def test_successful_atomic_write(self):
-        """Test that atomic write creates temp file, validates, and renames atomically."""
+        """Test that atomic write creates temp file, validates, and renames
+        atomically."""
         from unittest.mock import patch
 
         with tempfile.TemporaryDirectory() as temp_dir:
             # Create test file
-            test_file = Path(temp_dir) / 'test.js'
-            test_file.write_text('function foo() {}')
+            test_file = Path(temp_dir) / "test.js"
+            test_file.write_text("function foo() {}")
 
             writer = DocstringWriter(base_path=temp_dir)
 
@@ -633,29 +662,31 @@ class TestAtomicWrites:
                 temp_files_created.append(path)
                 return fd, path
 
-            with patch('tempfile.mkstemp', side_effect=track_mkstemp):
+            with patch("tempfile.mkstemp", side_effect=track_mkstemp):
                 success = writer.write_docstring(
                     filepath=str(test_file),
-                    item_name='foo',
-                    item_type='function',
-                    docstring='Test function',
-                    language='javascript'
+                    item_name="foo",
+                    item_type="function",
+                    docstring="Test function",
+                    language="javascript",
                 )
 
             assert success, "Write should succeed"
 
             # Verify temp file was created and cleaned up
-            assert len(temp_files_created) == 1, "Exactly one temp file should be created"
+            assert (
+                len(temp_files_created) == 1
+            ), "Exactly one temp file should be created"
             temp_file_path = Path(temp_files_created[0])
             assert not temp_file_path.exists(), "Temp file should be cleaned up"
 
             # Verify final content is correct
             content = test_file.read_text()
-            assert '/**' in content, "JSDoc should be present"
-            assert 'foo' in content, "Original code should be preserved"
+            assert "/**" in content, "JSDoc should be present"
+            assert "foo" in content, "Original code should be preserved"
 
             # Verify no backup remains
-            backup_path = test_file.with_suffix(test_file.suffix + '.bak')
+            backup_path = test_file.with_suffix(test_file.suffix + ".bak")
             assert not backup_path.exists(), "Backup should be cleaned up"
 
     def test_disk_full_scenario(self):
@@ -664,8 +695,8 @@ class TestAtomicWrites:
 
         with tempfile.TemporaryDirectory() as temp_dir:
             # Create test file
-            test_file = Path(temp_dir) / 'test.py'
-            original_content = 'def foo():\n    pass'
+            test_file = Path(temp_dir) / "test.py"
+            original_content = "def foo():\n    pass"
             test_file.write_text(original_content)
 
             writer = DocstringWriter(base_path=temp_dir)
@@ -675,14 +706,16 @@ class TestAtomicWrites:
             mock_usage.free = 10  # Only 10 bytes free (not enough for any write)
 
             # Patch at the module where it's used, not where it's imported from
-            with patch('src.writer.docstring_writer.shutil.disk_usage', return_value=mock_usage):
+            with patch(
+                "src.writer.docstring_writer.shutil.disk_usage", return_value=mock_usage
+            ):
                 with pytest.raises(OSError, match="Insufficient disk space"):
                     writer.write_docstring(
                         filepath=str(test_file),
-                        item_name='foo',
-                        item_type='function',
-                        docstring='New documentation',
-                        language='python'
+                        item_name="foo",
+                        item_type="function",
+                        docstring="New documentation",
+                        language="python",
                     )
 
             # Verify original file is untouched
@@ -690,7 +723,7 @@ class TestAtomicWrites:
             assert content == original_content, "Original file should be unchanged"
 
             # Verify no backup or temp files remain
-            backup_path = test_file.with_suffix(test_file.suffix + '.bak')
+            backup_path = test_file.with_suffix(test_file.suffix + ".bak")
             assert not backup_path.exists(), "No backup should exist"
 
     def test_write_validation_failure(self):
@@ -699,8 +732,8 @@ class TestAtomicWrites:
 
         with tempfile.TemporaryDirectory() as temp_dir:
             # Create test file
-            test_file = Path(temp_dir) / 'test.js'
-            original_content = 'function bar() {}'
+            test_file = Path(temp_dir) / "test.js"
+            original_content = "function bar() {}"
             test_file.write_text(original_content)
 
             writer = DocstringWriter(base_path=temp_dir)
@@ -708,16 +741,19 @@ class TestAtomicWrites:
             # Mock _validate_write to raise validation error
             def mock_validate(file_path, expected_content):
                 # Always fail validation
-                raise IOError(f"Write validation failed for '{file_path}'. Content mismatch detected.")
+                raise IOError(
+                    f"Write validation failed for '{file_path}'. Content "
+                    f"mismatch detected."
+                )
 
-            with patch.object(writer, '_validate_write', side_effect=mock_validate):
+            with patch.object(writer, "_validate_write", side_effect=mock_validate):
                 with pytest.raises(IOError, match="Write validation failed"):
                     writer.write_docstring(
                         filepath=str(test_file),
-                        item_name='bar',
-                        item_type='function',
-                        docstring='Test docs',
-                        language='javascript'
+                        item_name="bar",
+                        item_type="function",
+                        docstring="Test docs",
+                        language="javascript",
                     )
 
             # Verify original file is restored
@@ -731,8 +767,8 @@ class TestAtomicWrites:
 
         with tempfile.TemporaryDirectory() as temp_dir:
             # Create test file
-            test_file = Path(temp_dir) / 'test.py'
-            test_file.write_text('def foo():\n    pass')
+            test_file = Path(temp_dir) / "test.py"
+            test_file.write_text("def foo():\n    pass")
 
             writer = DocstringWriter(base_path=temp_dir)
 
@@ -749,15 +785,20 @@ class TestAtomicWrites:
                 raise PermissionError("Mock restore failure")
 
             # Also mock os.replace to fail, triggering restore attempt
-            with patch('src.writer.docstring_writer.shutil.copy2', side_effect=mock_copy2):
-                with patch('src.writer.docstring_writer.os.replace', side_effect=PermissionError("Mock replace failure")):
+            with patch(
+                "src.writer.docstring_writer.shutil.copy2", side_effect=mock_copy2
+            ):
+                with patch(
+                    "src.writer.docstring_writer.os.replace",
+                    side_effect=PermissionError("Mock replace failure"),
+                ):
                     with pytest.raises(IOError, match="CRITICAL: Failed to restore"):
                         writer.write_docstring(
                             filepath=str(test_file),
-                            item_name='foo',
-                            item_type='function',
-                            docstring='New docs',
-                            language='python'
+                            item_name="foo",
+                            item_type="function",
+                            docstring="New docs",
+                            language="python",
                         )
 
     def test_atomic_rename_behavior(self):
@@ -767,8 +808,8 @@ class TestAtomicWrites:
 
         with tempfile.TemporaryDirectory() as temp_dir:
             # Create test file
-            test_file = Path(temp_dir) / 'test.js'
-            test_file.write_text('function test() {}')
+            test_file = Path(temp_dir) / "test.js"
+            test_file.write_text("function test() {}")
 
             writer = DocstringWriter(base_path=temp_dir)
 
@@ -780,13 +821,15 @@ class TestAtomicWrites:
                 replace_calls.append((src, dst))
                 return original_replace(src, dst)
 
-            with patch('src.writer.docstring_writer.os.replace', side_effect=track_replace):
+            with patch(
+                "src.writer.docstring_writer.os.replace", side_effect=track_replace
+            ):
                 writer.write_docstring(
                     filepath=str(test_file),
-                    item_name='test',
-                    item_type='function',
-                    docstring='Test function',
-                    language='javascript'
+                    item_name="test",
+                    item_type="function",
+                    docstring="Test function",
+                    language="javascript",
                 )
 
             # Verify os.replace was called exactly once
@@ -794,32 +837,41 @@ class TestAtomicWrites:
 
             src, dst = replace_calls[0]
             # Verify temp file was in same directory as target
-            assert Path(src).parent == Path(dst).parent, \
-                "Temp file must be in same directory as target for atomic rename"
+            assert (
+                Path(src).parent == Path(dst).parent
+            ), "Temp file must be in same directory as target for atomic rename"
 
-            # Verify destination is the target file (resolve both to handle symlinks like /var -> /private/var on macOS)
-            assert Path(dst).resolve() == test_file.resolve(), "Destination should be the target file"
+            # Verify destination is the target file (resolve both to handle
+            # symlinks like /var -> /private/var on macOS)
+            assert (
+                Path(dst).resolve() == test_file.resolve()
+            ), "Destination should be the target file"
 
     def test_temp_file_creation_failure(self):
         """Test that mkstemp failure is handled without NameError."""
         from unittest.mock import patch
 
         with tempfile.TemporaryDirectory() as temp_dir:
-            test_file = Path(temp_dir) / 'test.py'
-            original_content = 'def foo():\n    pass'
+            test_file = Path(temp_dir) / "test.py"
+            original_content = "def foo():\n    pass"
             test_file.write_text(original_content)
 
             writer = DocstringWriter(base_path=temp_dir)
 
             # Mock mkstemp to fail
-            with patch('tempfile.mkstemp', side_effect=OSError("Disk full during temp file creation")):
-                with pytest.raises(OSError, match="Disk full during temp file creation"):
+            with patch(
+                "tempfile.mkstemp",
+                side_effect=OSError("Disk full during temp file creation"),
+            ):
+                with pytest.raises(
+                    OSError, match="Disk full during temp file creation"
+                ):
                     writer.write_docstring(
                         filepath=str(test_file),
-                        item_name='foo',
-                        item_type='function',
-                        docstring='New docs',
-                        language='python'
+                        item_name="foo",
+                        item_type="function",
+                        docstring="New docs",
+                        language="python",
                     )
 
             # Verify original file is untouched
@@ -827,23 +879,23 @@ class TestAtomicWrites:
             assert content == original_content, "Original file should be unchanged"
 
             # Verify no backup files created
-            backup_path = test_file.with_suffix(test_file.suffix + '.bak')
+            backup_path = test_file.with_suffix(test_file.suffix + ".bak")
             assert not backup_path.exists(), "No backup should exist"
 
             # Verify no temp files remain (they'd have pattern .test.py.*.tmp)
-            temp_files = list(Path(temp_dir).glob('.test.py.*.tmp'))
+            temp_files = list(Path(temp_dir).glob(".test.py.*.tmp"))
             assert len(temp_files) == 0, "No temp files should remain"
 
     def test_backup_collision_handling(self):
         """Test that pre-existing .bak files don't cause data loss."""
         with tempfile.TemporaryDirectory() as temp_dir:
             # Create test file
-            test_file = Path(temp_dir) / 'test.py'
-            test_file.write_text('def foo():\n    pass')
+            test_file = Path(temp_dir) / "test.py"
+            test_file.write_text("def foo():\n    pass")
 
             # Create pre-existing .bak file that user cares about
-            user_backup = test_file.with_suffix(test_file.suffix + '.bak')
-            important_content = 'IMPORTANT USER BACKUP - DO NOT LOSE'
+            user_backup = test_file.with_suffix(test_file.suffix + ".bak")
+            important_content = "IMPORTANT USER BACKUP - DO NOT LOSE"
             user_backup.write_text(important_content)
 
             writer = DocstringWriter(base_path=temp_dir)
@@ -851,28 +903,33 @@ class TestAtomicWrites:
             # Write docstring
             success = writer.write_docstring(
                 filepath=str(test_file),
-                item_name='foo',
-                item_type='function',
-                docstring='New documentation',
-                language='python'
+                item_name="foo",
+                item_type="function",
+                docstring="New documentation",
+                language="python",
             )
 
             assert success, "Write should succeed"
 
-            # Verify user's original .bak file is NOT overwritten (timestamp approach creates new file)
+            # Verify user's original .bak file is NOT overwritten (timestamp
+            # approach creates new file)
             if user_backup.exists():
                 content = user_backup.read_text()
-                assert content == important_content, \
-                    "User's original .bak file should not be overwritten"
+                assert (
+                    content == important_content
+                ), "User's original .bak file should not be overwritten"
 
             # Verify docstring was written to actual file
             test_content = test_file.read_text()
             assert '"""' in test_content, "Docstring should be present"
-            assert 'New documentation' in test_content, "Docstring content should be in file"
+            assert (
+                "New documentation" in test_content
+            ), "Docstring content should be in file"
 
             # Verify timestamp backup IS preserved (for transaction tracking)
-            timestamp_backups = list(Path(temp_dir).glob('test.py.*.bak'))
+            timestamp_backups = list(Path(temp_dir).glob("test.py.*.bak"))
             # Filter out the user's manual .bak file
             timestamp_backups = [b for b in timestamp_backups if b != user_backup]
-            assert len(timestamp_backups) == 1, \
-                "Timestamp-based backup should be preserved for transaction tracking"
+            assert (
+                len(timestamp_backups) == 1
+            ), "Timestamp-based backup should be preserved for transaction tracking"


### PR DESCRIPTION
## Summary

Replaces deprecated `datetime.utcnow()` with modern `datetime.now(UTC)` pattern throughout the codebase and adds comprehensive Black formatting + Ruff linting to prevent future regressions.

## Changes

### Datetime Modernization
- **docstring_writer.py (line 278)**: Changed `datetime.datetime.now()` → `datetime.now(UTC)` for backup file timestamps
- **transaction_manager.py (line 1210)**: Changed `datetime.now()` → `datetime.now(UTC)` for backup age filtering

### Code Quality Infrastructure
- **Added pyproject.toml**: Ruff configuration with E, F, and DTZ rules
  - Line length: 88 characters (Black/Ruff default)
  - DTZ rules prevent timezone-naive datetime usage
  - Enforces E501 (line too long), F (pyflakes), DTZ (datetime timezone)
- **Installed Black**: Added via conda to docimp environment
- **Applied Black formatting**: Reformatted entire codebase (88-char lines)
- **Fixed manual E501 errors**: 72 line-length errors in comments/docstrings that Black doesn't auto-format

## Testing

- ✅ All 530 Python tests pass
- ✅ Ruff checks pass with zero errors
- ✅ DTZ rules enforce timezone-aware datetime usage going forward
- ✅ No backward compatibility issues (Python 3.13 only)

## Rationale

**Why datetime.now(UTC)?**
- `datetime.utcnow()` is deprecated as of Python 3.12
- `datetime.now(UTC)` is the recommended modern pattern
- Explicitly timezone-aware (prevents subtle bugs)

**Why 88 characters?**
- Black's default line length
- Modern Python standard (10% more than PEP 8's 79)
- Widely adopted (pytest, Django, requests, many Google projects)
- Good balance between readability and fewer line breaks

**Why add Black now?**
- Preparing for Black adoption in near future (per user)
- Consistent formatting across contributors
- Eliminates style debates

## Migration Notes

No migration needed - this is purely internal tooling improvement. The codebase now uses:
- Modern datetime patterns (Python 3.11+)
- Black-compatible formatting
- Strict Ruff linting (E, F, DTZ rules)

Generated with [Claude Code](https://claude.com/claude-code)