### PR TITLE
Add --dry-run flag for incremental analysis (Issue #376)

### DIFF
--- a/cli/src/__tests__/commands/analyze-incremental-dry-run.test.ts
+++ b/cli/src/__tests__/commands/analyze-incremental-dry-run.test.ts
@@ -1,0 +1,482 @@
+/**
+ * Tests for analyze command --incremental --dry-run functionality.
+ *
+ * Tests the dry-run preview mode for incremental analysis, which shows
+ * what files would be re-analyzed without actually running the analysis.
+ */
+
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import type { Mock } from 'jest-mock';
+import { analyzeCommand } from '../../commands/analyze.js';
+import type { IPythonBridge } from '../../python-bridge/i-python-bridge.js';
+import type { IDisplay } from '../../display/i-display.js';
+import type { IConfigLoader } from '../../config/i-config-loader.js';
+import type { IConfig } from '../../config/i-config.js';
+import type { AnalysisResult } from '../../types/analysis.js';
+import { StateManager } from '../../utils/state-manager.js';
+import { WorkflowStateManager } from '../../utils/workflow-state-manager.js';
+import { FileTracker } from '../../utils/file-tracker.js';
+import { PathValidator } from '../../utils/path-validator.js';
+import { EXIT_CODE } from '../../constants/exit-codes.js';
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+// Mock filesystem operations
+jest.mock('node:fs');
+jest.mock('node:fs/promises', () => ({
+  readFile: jest.fn(),
+}));
+jest.mock('../../utils/state-manager.js');
+jest.mock('../../utils/workflow-state-manager.js');
+jest.mock('../../utils/file-tracker.js');
+jest.mock('../../utils/path-validator.js');
+jest.mock('prompts', () => ({
+  default: jest.fn().mockResolvedValue({ confirm: false }),
+}));
+
+describe('analyze --incremental --dry-run', () => {
+  let mockBridge: jest.Mocked<IPythonBridge>;
+  let mockDisplay: jest.Mocked<IDisplay>;
+  let mockConfigLoader: jest.Mocked<IConfigLoader>;
+  let mockConfig: IConfig;
+  let mockPreviousResult: AnalysisResult;
+
+  beforeEach(() => {
+    // Reset mocks
+    jest.clearAllMocks();
+
+    // Mock Python bridge
+    mockBridge = {
+      analyze: jest.fn(),
+      audit: jest.fn(),
+      plan: jest.fn(),
+      improve: jest.fn(),
+      generateDocstring: jest.fn(),
+      writeDocstring: jest.fn(),
+      beginTransaction: jest.fn(),
+      recordWrite: jest.fn(),
+      commitTransaction: jest.fn(),
+      rollbackSession: jest.fn(),
+      rollbackChange: jest.fn(),
+      listSessions: jest.fn(),
+      listChanges: jest.fn(),
+      cleanup: jest.fn(),
+    };
+
+    // Mock display with all required methods
+    mockDisplay = {
+      showAnalysisResult: jest.fn(),
+      showConfig: jest.fn(),
+      showMessage: jest.fn(),
+      showError: jest.fn(),
+      showWarning: jest.fn(),
+      showSuccess: jest.fn(),
+      showCodeItems: jest.fn(),
+      startSpinner: jest.fn(() => jest.fn()),
+      showProgress: jest.fn(),
+      showAuditSummary: jest.fn(),
+      showBoxedDocstring: jest.fn(),
+      showCodeBlock: jest.fn(),
+      showSignature: jest.fn(),
+      showSessionList: jest.fn(),
+      showChangeList: jest.fn(),
+      showRollbackResult: jest.fn(),
+      showWorkflowStatus: jest.fn(),
+      showIncrementalDryRun: jest.fn(),
+    };
+
+    // Mock config loader
+    mockConfig = {
+      styleGuides: {},
+      tone: 'concise',
+      claude: {
+        apiKey: 'test-key',
+        model: 'claude-3-5-sonnet-20241022',
+        maxTokens: 4096,
+        temperature: 0,
+        timeout: 30000,
+        maxRetries: 3,
+        retryDelay: 1000,
+      },
+      pythonBridge: {
+        timeout: 120000,
+        analyzeTimeout: 300000,
+        auditTimeout: 300000,
+        planTimeout: 60000,
+        improveTimeout: 300000,
+        killEscalationDelay: 5000,
+      },
+      audit: {
+        showCode: 'auto',
+        maxLines: 20,
+      },
+      impactWeights: {
+        complexity: 0.6,
+        quality: 0.4,
+      },
+      plugins: [],
+      exclude: [],
+      jsdocStyle: {
+        tagAliases: {},
+        requireDescription: true,
+        requireParamDescription: true,
+        requireReturnDescription: true,
+        requireExample: false,
+      },
+    };
+
+    mockConfigLoader = {
+      load: jest.fn().mockResolvedValue(mockConfig),
+    };
+
+    // Mock previous analysis result
+    mockPreviousResult = {
+      items: [
+        {
+          name: 'function1',
+          type: 'function',
+          filepath: '/test/file1.ts',
+          line_number: 1,
+          end_line: 10,
+          language: 'typescript',
+          complexity: 5,
+          impact_score: 25,
+          has_docs: false,
+          parameters: [],
+          return_type: 'void',
+          docstring: null,
+          export_type: 'named',
+          module_system: 'esm',
+          audit_rating: null,
+        },
+        {
+          name: 'function2',
+          type: 'function',
+          filepath: '/test/file2.ts',
+          line_number: 1,
+          end_line: 15,
+          language: 'typescript',
+          complexity: 8,
+          impact_score: 40,
+          has_docs: true,
+          parameters: [],
+          return_type: 'string',
+          docstring: 'Test function',
+          export_type: 'named',
+          module_system: 'esm',
+          audit_rating: null,
+        },
+        {
+          name: 'function3',
+          type: 'function',
+          filepath: '/test/file3.ts',
+          line_number: 1,
+          end_line: 20,
+          language: 'typescript',
+          complexity: 3,
+          impact_score: 15,
+          has_docs: false,
+          parameters: [],
+          return_type: 'number',
+          docstring: null,
+          export_type: 'named',
+          module_system: 'esm',
+          audit_rating: null,
+        },
+      ],
+      coverage_percent: 33.33,
+      total_items: 3,
+      documented_items: 1,
+      by_language: {},
+      parse_failures: [],
+    };
+
+    // Mock StateManager
+    (StateManager.getAnalyzeFile as jest.Mock).mockReturnValue(
+      '/test/.docimp/session-reports/analyze-latest.json'
+    );
+    (StateManager.getAuditFile as jest.Mock).mockReturnValue(
+      '/test/.docimp/audit.json'
+    );
+    (StateManager.ensureStateDir as jest.Mock).mockReturnValue(undefined);
+    (StateManager.clearSessionReports as jest.Mock).mockReturnValue(0);
+
+    // Mock WorkflowStateManager
+    (WorkflowStateManager.loadWorkflowState as jest.Mock).mockResolvedValue({
+      schema_version: '1.0',
+      migration_log: [],
+      last_analyze: {
+        timestamp: new Date().toISOString(),
+        item_count: 3,
+        file_checksums: {
+          '/test/file1.ts': 'checksum1',
+          '/test/file2.ts': 'checksum2',
+          '/test/file3.ts': 'checksum3',
+        },
+      },
+      last_audit: null,
+      last_plan: null,
+      last_improve: null,
+    });
+
+    // Mock existsSync - analyze-latest.json exists, audit.json doesn't
+    (existsSync as unknown as Mock).mockImplementation((path: string) => {
+      if (path === '/test/.docimp/session-reports/analyze-latest.json') {
+        return true;
+      }
+      if (path === '/test/.docimp/audit.json') {
+        return false;
+      }
+      return false;
+    });
+
+    // Mock readFile (fs/promises) to return previous result
+    (readFile as unknown as Mock).mockResolvedValue(
+      JSON.stringify(mockPreviousResult)
+    );
+
+    // Mock PathValidator
+    (PathValidator.validatePathExists as jest.Mock).mockReturnValue('/test');
+    (PathValidator.validatePathReadable as jest.Mock).mockReturnValue(
+      undefined
+    );
+    (PathValidator.warnIfEmpty as jest.Mock).mockReturnValue(undefined);
+  });
+
+  it('should show preview without running analysis when --dry-run is used', async () => {
+    // Mock FileTracker to detect 2 changed files
+    (FileTracker.detectChanges as jest.Mock).mockResolvedValue([
+      '/test/file1.ts',
+      '/test/file2.ts',
+    ]);
+
+    const exitCode = await analyzeCommand(
+      '/test',
+      {
+        incremental: true,
+        dryRun: true,
+        format: 'summary',
+      },
+      mockBridge,
+      mockDisplay,
+      mockConfigLoader
+    );
+
+    // Should NOT call bridge.analyze (no actual analysis)
+    expect(mockBridge.analyze).not.toHaveBeenCalled();
+
+    // Should call showIncrementalDryRun with correct data
+    expect(mockDisplay.showIncrementalDryRun).toHaveBeenCalledWith({
+      changedFiles: ['/test/file1.ts', '/test/file2.ts'],
+      unchangedFiles: expect.arrayContaining([
+        '/test/file1.ts',
+        '/test/file2.ts',
+        '/test/file3.ts',
+      ]),
+      previousResult: expect.objectContaining({
+        total_items: 3,
+        documented_items: 1,
+      }),
+    });
+
+    // Should return success
+    expect(exitCode).toBe(EXIT_CODE.SUCCESS);
+  });
+
+  it('should show "no changes" when no files modified in dry-run', async () => {
+    // Mock FileTracker to detect 0 changed files
+    (FileTracker.detectChanges as jest.Mock).mockResolvedValue([]);
+
+    const exitCode = await analyzeCommand(
+      '/test',
+      {
+        incremental: true,
+        dryRun: true,
+        format: 'summary',
+      },
+      mockBridge,
+      mockDisplay,
+      mockConfigLoader
+    );
+
+    // Should NOT call bridge.analyze
+    expect(mockBridge.analyze).not.toHaveBeenCalled();
+
+    // Should call showIncrementalDryRun with empty changedFiles
+    expect(mockDisplay.showIncrementalDryRun).toHaveBeenCalledWith({
+      changedFiles: [],
+      unchangedFiles: expect.any(Array),
+      previousResult: expect.any(Object),
+    });
+
+    expect(exitCode).toBe(EXIT_CODE.SUCCESS);
+  });
+
+  it('should not update workflow state in dry-run mode', async () => {
+    // Mock FileTracker to detect 1 changed file
+    (FileTracker.detectChanges as jest.Mock).mockResolvedValue([
+      '/test/file1.ts',
+    ]);
+
+    const updateSpy = jest.spyOn(WorkflowStateManager, 'updateCommandState');
+
+    await analyzeCommand(
+      '/test',
+      {
+        incremental: true,
+        dryRun: true,
+        format: 'summary',
+      },
+      mockBridge,
+      mockDisplay,
+      mockConfigLoader
+    );
+
+    // Should NOT update workflow state
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it('should not write analyze-latest.json in dry-run mode', async () => {
+    // Mock FileTracker to detect 1 changed file
+    (FileTracker.detectChanges as jest.Mock).mockResolvedValue([
+      '/test/file1.ts',
+    ]);
+
+    await analyzeCommand(
+      '/test',
+      {
+        incremental: true,
+        dryRun: true,
+        format: 'summary',
+      },
+      mockBridge,
+      mockDisplay,
+      mockConfigLoader
+    );
+
+    // writeFileSync should not be called (no file writes)
+    expect(writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it('should warn when --dry-run used without --incremental', async () => {
+    // Mock successful analysis
+    mockBridge.analyze.mockResolvedValue(mockPreviousResult);
+
+    await analyzeCommand(
+      '/test',
+      {
+        incremental: false,
+        dryRun: true, // dry-run without incremental
+        format: 'summary',
+      },
+      mockBridge,
+      mockDisplay,
+      mockConfigLoader
+    );
+
+    // Should show warning
+    expect(mockDisplay.showWarning).toHaveBeenCalledWith(
+      expect.stringContaining('--dry-run requires --incremental')
+    );
+
+    // Should run normal analysis (ignoring dry-run)
+    expect(mockBridge.analyze).toHaveBeenCalled();
+  });
+
+  it('should fall back to full analysis message if no previous analysis exists', async () => {
+    // Mock existsSync to return false (no previous analysis)
+    (existsSync as unknown as Mock).mockReturnValue(false);
+
+    // Mock successful analysis
+    mockBridge.analyze.mockResolvedValue(mockPreviousResult);
+
+    await analyzeCommand(
+      '/test',
+      {
+        incremental: true,
+        dryRun: true,
+        format: 'summary',
+      },
+      mockBridge,
+      mockDisplay,
+      mockConfigLoader
+    );
+
+    // Should show message about no previous analysis
+    expect(mockDisplay.showMessage).toHaveBeenCalledWith(
+      expect.stringContaining('No previous analysis found')
+    );
+
+    // Should run full analysis (can't do incremental without previous)
+    expect(mockBridge.analyze).toHaveBeenCalled();
+
+    // Should NOT call showIncrementalDryRun (no incremental analysis possible)
+    expect(mockDisplay.showIncrementalDryRun).not.toHaveBeenCalled();
+  });
+
+  it('should return previous result unchanged in dry-run mode', async () => {
+    // Mock FileTracker to detect 1 changed file
+    (FileTracker.detectChanges as jest.Mock).mockResolvedValue([
+      '/test/file1.ts',
+    ]);
+
+    await analyzeCommand(
+      '/test',
+      {
+        incremental: true,
+        dryRun: true,
+        format: 'summary',
+      },
+      mockBridge,
+      mockDisplay,
+      mockConfigLoader
+    );
+
+    // Should display analysis result with previous data
+    expect(mockDisplay.showAnalysisResult).toHaveBeenCalledWith(
+      expect.objectContaining({
+        total_items: 3,
+        documented_items: 1,
+        coverage_percent: 33.33,
+      }),
+      'summary'
+    );
+  });
+
+  it('should handle workflow state missing gracefully in dry-run', async () => {
+    // Mock WorkflowStateManager to return null last_analyze
+    (WorkflowStateManager.loadWorkflowState as jest.Mock).mockResolvedValue({
+      schema_version: '1.0',
+      migration_log: [],
+      last_analyze: null,
+      last_audit: null,
+      last_plan: null,
+      last_improve: null,
+    });
+
+    // Mock successful analysis
+    mockBridge.analyze.mockResolvedValue(mockPreviousResult);
+
+    await analyzeCommand(
+      '/test',
+      {
+        incremental: true,
+        dryRun: true,
+        format: 'summary',
+      },
+      mockBridge,
+      mockDisplay,
+      mockConfigLoader
+    );
+
+    // Should show message about workflow state missing
+    expect(mockDisplay.showMessage).toHaveBeenCalledWith(
+      expect.stringContaining('Workflow state missing')
+    );
+
+    // Should run full analysis
+    expect(mockBridge.analyze).toHaveBeenCalled();
+  });
+});

--- a/cli/src/display/i-display.ts
+++ b/cli/src/display/i-display.ts
@@ -187,4 +187,21 @@ export interface IDisplay {
    * @param status - Workflow status result from Python backend
    */
   showWorkflowStatus(status: WorkflowStatusResult): void;
+
+  /**
+   * Display incremental analysis dry-run preview.
+   *
+   * Shows which files would be re-analyzed, which would be reused,
+   * and estimated time savings without actually running the analysis.
+   *
+   * @param preview - Dry-run preview data
+   * @param preview.changedFiles - List of files that would be re-analyzed
+   * @param preview.unchangedFiles - List of files that would be reused
+   * @param preview.previousResult - Previous analysis result for reference
+   */
+  showIncrementalDryRun(preview: {
+    changedFiles: string[];
+    unchangedFiles: string[];
+    previousResult: AnalysisResult;
+  }): void;
 }

--- a/cli/src/display/terminal-display.ts
+++ b/cli/src/display/terminal-display.ts
@@ -864,4 +864,71 @@ export class TerminalDisplay implements IDisplay {
 
     console.log('');
   }
+
+  /**
+   * Display incremental analysis dry-run preview.
+   *
+   * Shows which files would be re-analyzed, which would be reused,
+   * and estimated time savings.
+   *
+   * @param preview - Dry-run preview data
+   */
+  public showIncrementalDryRun(preview: {
+    changedFiles: string[];
+    unchangedFiles: string[];
+    previousResult: import('../types/analysis.js').AnalysisResult;
+  }): void {
+    console.log('');
+    console.log(
+      chalk.bold('Incremental Analysis') + chalk.dim(' (dry run mode)')
+    );
+    console.log('');
+
+    // Calculate unique files
+    const unchangedCount = preview.unchangedFiles.length;
+    const totalFiles = unchangedCount + preview.changedFiles.length;
+
+    if (preview.changedFiles.length === 0) {
+      console.log(chalk.green('✓ No files changed since last analysis'));
+      console.log(chalk.dim(`  All ${unchangedCount} file(s) would be reused`));
+    } else {
+      console.log(
+        chalk.yellow(`Would re-analyze ${preview.changedFiles.length} file(s):`)
+      );
+
+      // Show changed files (limit to 10 for readability)
+      const displayFiles = preview.changedFiles.slice(0, 10);
+      for (const file of displayFiles) {
+        console.log(chalk.dim(`  • ${file}`));
+      }
+
+      if (preview.changedFiles.length > 10) {
+        console.log(
+          chalk.dim(`  ... and ${preview.changedFiles.length - 10} more`)
+        );
+      }
+
+      console.log('');
+      console.log(
+        chalk.green(
+          `Would reuse results from ${unchangedCount} unchanged file(s)`
+        )
+      );
+
+      // Show time savings estimate
+      const percentChanged = (preview.changedFiles.length / totalFiles) * 100;
+      const percentReused = 100 - percentChanged;
+      console.log('');
+      console.log(
+        chalk.cyan('Estimated time savings:') +
+          chalk.dim(` ~${percentReused.toFixed(0)}%`)
+      );
+    }
+
+    console.log('');
+    console.log(
+      chalk.dim('Run without --dry-run to perform incremental analysis')
+    );
+    console.log('');
+  }
 }

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -53,6 +53,10 @@ program
   .option('--preserve-audit', 'Preserve audit.json file only')
   .option('--force-clean', 'Force clean session reports without prompting')
   .option('--incremental', 'Only re-analyze changed files')
+  .option(
+    '--dry-run',
+    'Preview incremental analysis without running (shows what would be analyzed)'
+  )
   .option('--apply-audit', 'Apply existing audit ratings to analyzed items')
   .option(
     '--strict',


### PR DESCRIPTION
## Summary

Implements Phase 3.8 from workflow-state-management.md: adds `--dry-run` flag to `docimp analyze --incremental` for previewing what files would be re-analyzed without actually running the analysis.

## Changes

**Core Implementation:**
- Added `--dry-run` flag to analyze command in CLI
- Implemented early return logic in `handleIncrementalAnalysis()` for dry-run mode
- Added validation to warn if `--dry-run` used without `--incremental`
- Modified analyze core to skip file writes and workflow state updates in dry-run mode

**Display:**
- Added `showIncrementalDryRun()` method to IDisplay interface
- Implemented colorful terminal output in TerminalDisplay showing:
  - List of files that would be re-analyzed (limited to 10, with "...and N more")
  - Count of unchanged files that would be reused
  - Estimated time savings percentage

**Testing:**
- Created `analyze-incremental-dry-run.test.ts` with 8 comprehensive tests
- All tests passing
- Tests cover: preview display, no file writes, no workflow updates, validation warnings, edge cases

**Documentation:**
- Updated CLAUDE.md with --dry-run usage examples
- Updated workflow-state-management.md with implementation details and status

## Output Example

```
Incremental Analysis (dry run mode)

Would re-analyze 3 file(s):
  • src/analyzer.ts
  • src/parser.py
  • cli/commands/analyze.ts

Would reuse results from 97 unchanged file(s)

Estimated time savings: ~97%

Run without --dry-run to perform incremental analysis
```

## Test Plan

- [x] All 8 new tests pass
- [x] Full test suite passes (829/846 tests, pre-existing failures unrelated)
- [x] Manual testing: dry-run shows correct preview without running analysis
- [x] Manual testing: warning shown when --dry-run used without --incremental
- [x] Pre-commit hooks pass (prettier, eslint)

## Related

- Closes #376
- Related to #381 (auto-incremental default behavior)
- Part of Phase 3.8 in workflow-state-management.md

Generated with [Claude Code](https://claude.com/claude-code)