### PR TITLE
Make architectural pattern documentation public

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,6 @@ WARP.md
 # Project-specific
 CLAUDE.md
 CLAUDE_CONTEXT.md
-docs/patterns
 
 # Temporary planning and scratch files
 .scratch

--- a/docs/patterns/dependency-injection.md
+++ b/docs/patterns/dependency-injection.md
@@ -1,0 +1,222 @@
+# Dependency Injection Pattern
+
+DocImp uses pure dependency injection throughout the codebase for testability and modularity.
+
+## Core Principle: Required Parameters with Entry-Point Instantiation
+
+**Rule**: All dependencies are passed as **required parameters** to functions/constructors. The only place that uses `new` is the entry point (main.py for Python, index.ts for TypeScript).
+
+## Python Layer
+
+**Components accept dependencies via required parameters:**
+
+```python
+# create_analyzer() accepts parsers and scorer as parameters
+def create_analyzer(
+    parsers: dict,
+    scorer: ImpactScorer
+) -> DocumentationAnalyzer:
+    return DocumentationAnalyzer(
+        parsers=parsers,
+        scorer=scorer
+    )
+
+# Command functions accept dependencies
+def cmd_analyze(
+    args: argparse.Namespace,
+    parsers: dict,
+    scorer: ImpactScorer
+) -> int:
+    analyzer = create_analyzer(parsers, scorer)
+    # ... command logic
+```
+
+**Entry point (main.py) is the only place with instantiations:**
+
+```python
+def main(argv: Optional[list] = None) -> int:
+    # Instantiate dependencies ONCE at entry point
+    parsers = {
+        'python': PythonParser(),
+        'typescript': TypeScriptParser(),
+        'javascript': TypeScriptParser()
+    }
+    scorer = ImpactScorer()
+
+    # Dispatch commands with injected dependencies
+    if args.command == 'analyze':
+        return cmd_analyze(args, parsers, scorer)
+    elif args.command == 'audit':
+        return cmd_audit(args, parsers, scorer)
+```
+
+**For optional dependencies, use `Optional` with explicit None check:**
+
+```python
+def generate_plan(
+    result: AnalysisResult,
+    audit_file: Optional[Path] = None,
+    quality_threshold: int = 2,
+    scorer: Optional[ImpactScorer] = None  # Optional for backwards compatibility
+) -> PlanResult:
+    if scorer is None:
+        scorer = ImpactScorer()  # Create default only if not provided
+    # ... use scorer
+```
+
+## TypeScript Layer
+
+**Command core functions accept dependencies as required parameters:**
+
+```typescript
+export async function analyzeCore(
+  path: string,
+  options: AnalyzeOptions,
+  bridge: IPythonBridge,      // Required parameter
+  display: IDisplay,           // Required parameter
+  configLoader: IConfigLoader  // Required parameter
+): Promise<void> {
+  const config = await configLoader.load(options.config);
+  const result = await bridge.analyze({ path, config });
+  display.showAnalysisResult(result);
+}
+```
+
+**Entry point (index.ts) is the only place with instantiations:**
+
+```typescript
+// In index.ts command action handlers
+program
+  .command('analyze')
+  .action(async (path, options) => {
+    // Instantiate dependencies at entry point
+    const display = new TerminalDisplay();
+    const configLoader = new ConfigLoader();
+    const config = await configLoader.load(options.config);
+    const bridge = new PythonBridge(undefined, undefined, config);
+
+    // Call command with injected dependencies
+    await analyzeCommand(path, options, bridge, display, configLoader);
+  });
+```
+
+**Interactive sessions accept all dependencies via constructor:**
+
+```typescript
+export interface SessionOptions {
+  config: IConfig;
+  pythonBridge: IPythonBridge;
+  pluginManager: IPluginManager;
+  editorLauncher: IEditorLauncher;
+  styleGuides: Partial<Record<SupportedLanguage, string>>;
+  tone: string;
+  basePath: string;
+}
+
+export class InteractiveSession {
+  constructor(options: SessionOptions) {
+    this.pythonBridge = options.pythonBridge;
+    this.editorLauncher = options.editorLauncher;
+    // ... all dependencies injected, none created
+  }
+}
+```
+
+## Benefits of Pure DI
+
+- **Testability**: Tests inject mocks, production injects real implementations
+- **No hidden dependencies**: All dependencies are explicit in function signatures
+- **Single instantiation point**: Easy to trace where objects are created
+- **Compile-time safety**: TypeScript/mypy catch missing dependencies
+
+## Acceptable Exceptions to Strict DI
+
+While DocImp follows pure dependency injection, there are documented exceptions for specific performance and backward-compatibility reasons:
+
+### 1. Module-Level Performance Caches (Plugin Layer)
+
+The validate-types.js plugin maintains module-level caches for TypeScript language services:
+- `languageServiceCache` - Caches TypeScript programs to prevent memory leaks
+- `cacheAccessOrder` - LRU tracking for cache eviction
+- `documentRegistry` - Shared TypeScript SourceFile registry
+
+**Rationale**: These caches must persist across multiple validation calls to be effective. Recreating them per-factory would defeat their purpose. The factory pattern captures dependencies (ts, parseJSDoc) in closure scope for all helper functions, while caches remain at module level.
+
+**See**: plugins/README.md for detailed cache architecture and thread-safety considerations.
+
+### 2. Optional Dependencies with Defaults (Backward Compatibility)
+
+Functions like `generate_plan()` do NOT use dependency injection for simple internal utilities:
+
+```python
+def generate_plan(
+    result: AnalysisResult,
+    audit_file: Optional[Path] = None,
+    quality_threshold: int = 2
+) -> PlanResult:
+    """Generate a prioritized documentation improvement plan."""
+    # Creates ImpactScorer internally when needed
+    if audit_results:
+        scorer = ImpactScorer()  # Simple utility, no DI needed
+        # ... use scorer for calculations
+```
+
+**Rationale**: Not every dependency needs injection. Simple utility classes like `ImpactScorer` that have no external dependencies or state can be instantiated internally. DI is reserved for dependencies that need mocking in tests (parsers, API clients, file system) or configuration (timeouts, paths). Over-applying DI adds unnecessary complexity.
+
+### 3. Environment Variable Fallback Pattern (Hybrid DI)
+
+The `TypeScriptParser` demonstrates a hybrid approach that combines dependency injection with environment variable and auto-detection fallbacks:
+
+```python
+class TypeScriptParser(BaseParser):
+    def __init__(self, helper_path: Optional[Path] = None):
+        """Initialize with three-tier resolution strategy:
+        1. Explicit helper_path parameter (highest priority, for DI)
+        2. DOCIMP_TS_HELPER_PATH environment variable (for CI/CD)
+        3. Auto-detection fallback (for development environment)
+        """
+        if helper_path:
+            # Priority 1: Explicit parameter (dependency injection)
+            self.helper_path = helper_path
+        else:
+            # Priority 2: Environment variable
+            env_path = os.environ.get('DOCIMP_TS_HELPER_PATH')
+            if env_path:
+                self.helper_path = Path(env_path)
+            else:
+                # Priority 3: Auto-detection fallback
+                self.helper_path = self._find_helper()
+
+        if not self.helper_path.exists():
+            raise FileNotFoundError(f"Helper not found at {self.helper_path}")
+
+    def _find_helper(self) -> Path:
+        """Auto-detect helper path with fallback strategies."""
+        # Development environment detection
+        dev_path = Path(__file__).parent.parent.parent.parent / 'cli' / 'dist' / '...'
+        if dev_path.exists():
+            return dev_path
+        # Future: pip-installed package location
+        return dev_path
+```
+
+**Usage in tests:**
+```python
+# Dependency injection for testing
+mock_helper = Path("/path/to/mock-helper.js")
+parser = TypeScriptParser(helper_path=mock_helper)
+```
+
+**Usage in production:**
+```python
+# Auto-detection (development)
+parser = TypeScriptParser()
+
+# Environment variable (CI/CD)
+# export DOCIMP_TS_HELPER_PATH=/custom/path/helper.js
+parser = TypeScriptParser()
+```
+
+**Rationale**: This pattern balances flexibility (works in development, CI/CD, and future pip installations), testability (tests inject mock paths), and backward compatibility (existing code continues to work). The fragile path traversal is isolated in `_find_helper()`, making it easy to extend with additional strategies (e.g., pip package detection).
+
+**See**: Issue #63 for the motivation behind this pattern.

--- a/docs/patterns/error-handling.md
+++ b/docs/patterns/error-handling.md
@@ -1,0 +1,69 @@
+# Error Handling Architecture
+
+DocImp uses a three-layer error handling pattern for CLI commands that separates business logic from process lifecycle management.
+
+## Layer 1: Core Functions (Business Logic)
+
+Core functions (`analyzeCore`, `auditCore`, `planCore`, `improveCore`) throw errors for exceptional conditions:
+- File not found
+- Invalid configuration
+- Python subprocess failures
+- Missing required environment variables
+
+Core functions don't know about exit codes or process lifecycle - they're pure business logic that can be tested in isolation.
+
+**Testing**: Core functions are tested by expecting thrown errors.
+
+## Layer 2: Command Wrappers (CLI Interface)
+
+Command functions (`analyzeCommand`, `auditCommand`, etc.) wrap Core functions and convert errors to exit codes:
+- Return `EXIT_CODE.SUCCESS` (0) for successful completion
+- Return `EXIT_CODE.ERROR` (1) for errors
+- Display errors using `display.showError()` before returning
+
+Command wrappers bridge business logic and CLI concerns, making commands usable as library functions.
+
+**Testing**: Command wrappers are tested by checking returned exit codes (no process.exit mocking needed).
+
+## Layer 3: Entry Point (Process Lifecycle)
+
+The CLI entry point (`index.ts`) checks exit codes from Command wrappers:
+- Calls `process.exit(exitCode)` only when `exitCode !== EXIT_CODE.SUCCESS`
+- Catches unexpected errors defensively (commands should not throw)
+- Manages process lifecycle
+
+This is the only place in the codebase where `process.exit()` is called.
+
+## Special Case: UserCancellationError
+
+The `improve` command has interactive prompts where users can cancel (ESC, Ctrl+C). User cancellations are not errors, so they exit with code 0:
+
+1. `improveCore()` throws `UserCancellationError` when user cancels a prompt
+2. `improveCommand()` catches it and returns `EXIT_CODE.USER_CANCELLED` (0)
+3. `index.ts` sees exit code 0 and doesn't call `process.exit()`
+
+This follows Unix conventions where user-initiated cancellations are not failures.
+
+## Exit Code Constants
+
+Exit codes are defined in `cli/src/constants/exitCodes.ts`:
+
+```typescript
+export const EXIT_CODE = {
+  SUCCESS: 0,          // Command completed successfully
+  ERROR: 1,            // Command encountered an error
+  USER_CANCELLED: 0,   // User cancelled (not an error)
+} as const;
+
+export type ExitCode = typeof EXIT_CODE[keyof typeof EXIT_CODE];
+```
+
+All command functions return `Promise<ExitCode>` for type safety.
+
+## Testing Benefits
+
+This architecture eliminates the need to mock `process.exit()` in tests:
+- Unit tests call Core functions and expect thrown errors
+- Integration tests call Command wrappers and check exit codes
+- No brittle process.exit mocking required
+- Tests are more maintainable and easier to understand

--- a/docs/patterns/session-resume.md
+++ b/docs/patterns/session-resume.md
@@ -1,0 +1,742 @@
+# Session Resume Pattern
+
+DocImp's session resume capability allows users to interrupt and continue audit and improve workflows across multiple CLI executions. This document details the architecture, design decisions, and implementation patterns.
+
+## Architecture Overview
+
+### Component Stack
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                    CLI Commands (TypeScript)                  │
+│  audit --resume, improve --resume, list-sessions, etc.       │
+└────────────────────────┬─────────────────────────────────────┘
+                         │
+                         v
+┌──────────────────────────────────────────────────────────────┐
+│               SessionStateManager (TS + Python)               │
+│  - save_session_state() - Atomic writes (temp + rename)      │
+│  - load_session_state() - JSON parse + Zod validation        │
+│  - list_sessions()      - Sorted by started_at               │
+│  - get_latest_session() - Most recent session helper         │
+└────────────────────────┬─────────────────────────────────────┘
+                         │
+                         v
+┌──────────────────────────────────────────────────────────────┐
+│                  FileTracker (TS + Python)                    │
+│  - create_snapshot()    - SHA256 checksum + mtime           │
+│  - detect_changes()     - Compare checksums and timestamps   │
+│  - get_changed_items()  - Filter CodeItem list               │
+└────────────────────────┬─────────────────────────────────────┘
+                         │
+                         v
+┌──────────────────────────────────────────────────────────────┐
+│           Session State Files (.docimp/session-reports/)      │
+│  audit-session-{uuid}.json     - In-progress audit sessions  │
+│  improve-session-{uuid}.json   - In-progress improve sessions│
+└──────────────────────────────────────────────────────────────┘
+```
+
+### Hybrid Persistence Strategy
+
+DocImp uses a hybrid approach combining JSON state files and git transaction branches:
+
+**JSON State Files** (all sessions):
+- Audit sessions: Preserve ratings, file snapshots, config
+- Improve sessions: Preserve plan items, preferences, progress, file snapshots
+
+**Git Transaction Branches** (improve only):
+- Links improve sessions to git branches via `transaction_id`
+- Enables rollback of documentation changes
+- Preserves full change history
+
+### Key Design Principles
+
+1. **Full State Capture**: Save everything needed to resume seamlessly
+2. **Atomic Operations**: Prevent corruption via temp file + rename pattern
+3. **Smart Invalidation**: Re-analyze only files that changed
+4. **Auto-Detection UX**: Prompt users when sessions exist (hybrid resume approach)
+5. **Multiple Sessions**: Support concurrent audit and improve workflows
+
+## Design Decisions
+
+### Decision 1: Multiple Sessions vs Single Session
+
+**Chosen**: Multiple sessions with UUID identifiers
+
+**Rationale**:
+- Supports concurrent workflows (audit and improve simultaneously)
+- Enables session management commands (list, delete by ID)
+- Flexible for future enhancements (named sessions, shared sessions)
+- User can experiment with different approaches in parallel
+
+**Trade-offs**:
+- More complex implementation (session IDs, management commands)
+- Better UX for advanced use cases
+
+**Alternative**: Single session per command (`audit-session-latest.json`)
+- Simpler but limits concurrent workflows
+
+### Decision 2: Hybrid Resume UX
+
+**Chosen**: Auto-detection with explicit override flags
+
+**User Experience**:
+```bash
+# No flags: Auto-detect and prompt
+$ docimp audit ./src
+→ Found session abc12345 (5/23 rated, started 2h ago). Resume? [Y/n]
+
+# Explicit resume
+$ docimp audit ./src --resume
+→ Resuming session abc12345...
+
+# Explicit fresh start
+$ docimp audit ./src --new
+→ Starting new session...
+```
+
+**Rationale**:
+- Protects against forgetting `--resume` flag (auto-detection)
+- Maintains intentional control (explicit flags)
+- Discoverable feature (users see prompt even if unaware)
+
+**Alternative Considered**: Explicit `--resume` required (no auto-detection)
+- More explicit but users lose progress if they forget flag
+
+### Decision 3: File Invalidation Strategy
+
+**Chosen**: Dual validation (checksum + timestamp)
+
+**Algorithm**:
+1. Create snapshot: SHA256 checksum + mtime for each file
+2. On resume: Compare both checksum and timestamp
+3. Changed file detection: Checksum differs OR (timestamp differs AND checksum differs)
+4. Re-analysis: Only changed files
+
+**Rationale**:
+- Checksum: Catches actual content changes
+- Timestamp: Quick first check, handles git checkout
+- Both: Prevents false positives from timestamp-only changes
+
+**Trade-offs**:
+- Checksum calculation takes time (mitigated: only analyzed files, not entire codebase)
+- Parallelizable if needed (future optimization)
+
+**Alternative**: Timestamp only
+- Faster but false positives common (build tools, version control)
+
+### Decision 4: Transaction Integration (Improve Only)
+
+**Chosen**: Link improve sessions to git transaction branches
+
+**Implementation**:
+- Session state includes `transaction_id` field
+- On resume: Verify git branch `docimp/session-{transaction-id}` exists
+- In-progress transactions: Resume on existing branch
+- Committed transactions: Create new transaction (continuation)
+- Rolled-back sessions: Error, cannot resume
+
+**Rationale**:
+- Preserves rollback capability across resume
+- Maintains transaction history integrity
+- Prevents resuming invalid states
+
+**Alternative**: Decouple sessions from transactions
+- Simpler but loses rollback capability on resume
+
+### Decision 5: Session State Schema Versioning
+
+**Chosen**: Defer versioning to future (MVP uses implicit v1)
+
+**Current Approach**:
+- No `schema_version` field in MVP
+- Breaking changes require `delete-audit-session --all`
+- Document limitation in README
+
+**Future Enhancement**:
+- Add `schema_version: string` field
+- Implement migration logic in `load_session_state()`
+- Graceful upgrade path for users
+
+**Rationale**: YAGNI for MVP, add when schema evolution actually happens
+
+## Data Models
+
+### AuditSessionState
+
+**Fields**:
+- `session_id`: UUID for session identification
+- `started_at`: ISO 8601 timestamp of session creation
+- `current_index`: Position in items array (0-based)
+- `total_items`: Total count of items to audit
+- `partial_ratings`: Nested map `filepath -> item_name -> rating (1-4 or None)`
+- `file_snapshot`: Map `filepath -> FileSnapshot`
+- `config`: Audit display config (`showCodeMode`, `maxLines`)
+- `completed_at`: ISO 8601 timestamp or null if in-progress
+
+**Serialization**:
+- Python: `@dataclass` with `to_dict()` / `from_dict()` methods
+- TypeScript: Zod schema for runtime validation
+
+**File Location**: `.docimp/session-reports/audit-session-{uuid}.json`
+
+### ImproveSessionState
+
+**Fields**:
+- `session_id`: UUID for session identification
+- `transaction_id`: Links to git branch `docimp/session-{transaction-id}`
+- `started_at`: ISO 8601 timestamp
+- `current_index`: Position in plan_items array
+- `plan_items`: Serialized PlanItem objects (from plan.json)
+- `user_preferences`: Style guides and tone (`{ styleGuides, tone }`)
+- `progress`: Counters (`{ accepted, skipped, errors }`)
+- `file_snapshot`: Map `filepath -> FileSnapshot`
+- `config`: Full IConfig object used in session
+- `completed_at`: ISO 8601 timestamp or null if in-progress
+
+**Transaction Linking**:
+- `transaction_id` must match existing git branch
+- Verified on resume via `git branch --list docimp/session-{transaction-id}`
+- Status checked: in-progress (resume), committed (new transaction), rolled-back (error)
+
+**File Location**: `.docimp/session-reports/improve-session-{uuid}.json`
+
+### FileSnapshot
+
+**Fields**:
+- `filepath`: Absolute or relative path to source file
+- `timestamp`: Unix timestamp from `os.path.getmtime()` (Python) or `fs.stat().mtimeMs` (TypeScript)
+- `checksum`: SHA256 hash of file contents (hex string)
+- `size`: File size in bytes
+
+**Usage**: Embedded in session state for modification detection
+
+## File Invalidation Implementation
+
+### Snapshot Creation
+
+**Timing**: Immediately after loading CodeItems in audit/improve commands
+
+**Process**:
+```typescript
+// TypeScript
+const filepaths = items.map(item => item.filepath);
+const snapshot = await FileTracker.createSnapshot(filepaths);
+
+// Store in session state
+sessionState.file_snapshot = snapshot;
+```
+
+**Python equivalent**: Uses `hashlib.sha256()` for checksums
+
+### Change Detection
+
+**Timing**: On session resume, before starting interactive loop
+
+**Algorithm**:
+```typescript
+// Load session state
+const state = await SessionStateManager.loadSessionState(sessionId, 'audit');
+
+// Detect changes
+const changedFiles = await FileTracker.detectChanges(state.file_snapshot);
+
+// Handle changes
+if (changedFiles.length > 0) {
+  console.warn(`${changedFiles.length} files modified, re-analyzing...`);
+
+  // Re-run analysis on changed files only
+  const newItems = await pythonBridge.analyze({
+    path: basePath,
+    files: changedFiles
+  });
+
+  // Merge with existing session state
+  // (logic varies by command: audit merges ratings, improve updates plan_items)
+}
+```
+
+### Edge Cases
+
+**Case 1: File Deleted Since Session**
+- Detection: `fs.stat()` throws ENOENT
+- Handling: Show error, remove from session state, continue with remaining items
+
+**Case 2: File Timestamp Changed But Content Same**
+- Detection: Timestamp differs but checksum matches
+- Handling: No re-analysis, update snapshot with new timestamp
+
+**Case 3: All Files Changed**
+- Detection: All checksums differ
+- Handling: Warn user, re-analyze entire codebase, merge results
+
+**Case 4: Checksum Collision** (astronomically rare with SHA256)
+- Detection: Timestamps differ, checksums match
+- Handling: Trust checksum, no re-analysis
+
+## Transaction Integration (Improve Only)
+
+### Session-to-Transaction Mapping
+
+**One-to-one relationship**: Each improve session has exactly one `transaction_id`
+
+**Transaction States**:
+1. **in-progress**: Session branch exists, not squash-merged to main
+2. **committed**: Session branch exists, squash-merged to main
+3. **rolled-back**: Session has been rolled back (cannot resume)
+
+### Resume Logic by Transaction State
+
+**In-Progress**:
+```typescript
+// Resume on existing transaction branch
+// No begin_transaction() call
+// Continue committing to same branch
+await pythonBridge.recordWrite(transactionId, filepath, ...);
+```
+
+**Committed**:
+```typescript
+// Create new transaction (continuation)
+const newTransactionId = uuidv4();
+await pythonBridge.beginTransaction(newTransactionId);
+
+// Update session state
+sessionState.transaction_id = newTransactionId;
+sessionState.metadata.continued_from = originalTransactionId;
+```
+
+**Rolled-Back**:
+```typescript
+// Error and abort
+throw new Error(
+  `Cannot resume session ${sessionId}: transaction ${transactionId} has been rolled back. ` +
+  `Use 'docimp improve --new' to start fresh.`
+);
+```
+
+### Transaction Verification
+
+**Git Branch Check**:
+```bash
+git --git-dir=.docimp/state/.git --work-tree=. branch --list "docimp/session-${transaction-id}"
+```
+
+**Status Determination**:
+```bash
+# Check if squash-merged (committed)
+git --git-dir=.docimp/state/.git --work-tree=. log main --grep="docimp session ${transaction-id}"
+
+# Check manifest for rolled_back status
+# Parse TransactionManifest JSON
+```
+
+## Testing Strategy
+
+### Unit Tests
+
+**SessionStateManager** (23 tests total: 13 Python + 10 TypeScript):
+- Atomic write (temp file + rename)
+- Load with validation (Zod schema)
+- Load non-existent file (error)
+- Load corrupted JSON (error)
+- List sessions sorted by started_at
+- Delete session file
+- Get latest session
+
+**FileTracker** (18 tests total: 10 Python + 8 TypeScript):
+- Create snapshot (checksums calculated)
+- Detect changed file (checksum differs)
+- Detect unchanged file (checksum matches)
+- Detect deleted file (file not found)
+- Detect new file (not in snapshot)
+- Get changed items (filter CodeItem list)
+
+### Integration Tests
+
+**Audit Resume** (25 tests in `audit-resume.test.ts`):
+- Auto-detection: prompt user when session exists
+- User accepts/rejects auto-resume prompt
+- Resume with no file changes
+- Resume with modified files (re-analysis)
+- Resume with deleted files (error)
+- --new flag bypasses auto-detection
+- --clear-session deletes and exits
+- Session file created with correct structure
+- Partial ratings preserved
+
+**Improve Resume** (22 tests in `improve-resume.test.ts`):
+- Auto-detection and prompt
+- Resume in-progress transaction
+- Resume committed transaction (create new)
+- Error on rolled-back transaction
+- File invalidation and re-analysis
+- User preferences restored
+- Progress metrics restored
+- Undo after resume
+
+**Cross-Workflow** (8 tests in `cross-workflow-resume.test.ts`):
+- Audit → resume → complete → use in plan
+- Improve → resume → undo → resume again
+- File invalidation across commands
+- Multiple concurrent sessions
+- Session cleanup
+- Corrupted file recovery
+- Performance (1000+ items)
+
+**Session Management** (18 tests total: 8 audit + 10 improve):
+- List empty sessions
+- List multiple sessions (sorted)
+- Delete specific session
+- Delete all sessions
+- Confirmation prompts
+- Table formatting
+- Transaction status display (improve only)
+
+### Manual Testing
+
+**Scripts**:
+- `test-samples/test-audit-resume.sh`: Full audit resume workflow
+- `test-samples/test-resume-improve.sh`: Improve resume with file modification
+
+**Validation Points**:
+- Auto-detection prompt appears
+- File change warnings shown correctly
+- Final outputs correct (audit.json, transaction history)
+- Colorful output renders properly
+
+### Regression Tests
+
+**Ensure Unaffected**:
+- Non-resume workflows (no `--resume` flag)
+- Transaction system (rollback, undo, list)
+- Existing commands (analyze, plan)
+
+**Coverage**: 70+ tests across entire codebase
+
+## Edge Cases and Error Handling
+
+### Corrupted Session File
+
+**Scenario**: JSON parse error or schema validation failure
+
+**Handling**:
+```typescript
+try {
+  const state = await SessionStateManager.loadSessionState(sessionId, 'audit');
+} catch (error) {
+  console.error(`Failed to load session ${sessionId}: ${error.message}`);
+  console.error('Session file may be corrupted. Starting fresh session.');
+  // Continue with new session
+}
+```
+
+**Result**: Graceful degradation, user not blocked
+
+### Missing Transaction Branch
+
+**Scenario**: Improve session references transaction branch that doesn't exist
+
+**Handling**:
+```typescript
+const branchExists = await GitHelper.branchExists(transactionId);
+if (!branchExists) {
+  throw new Error(
+    `Transaction branch not found: ${transactionId}\n` +
+    `Session ${sessionId} cannot be resumed. The transaction may have been manually deleted.\n` +
+    `Use 'docimp list-sessions' to see available sessions or start a new session with --new.`
+  );
+}
+```
+
+**Result**: Clear error with recovery suggestions
+
+### Concurrent Session Modifications
+
+**Scenario**: Two CLI instances modify same session file simultaneously
+
+**Handling**: Last write wins (atomic writes prevent corruption)
+
+**Limitation**: Not designed for multi-user concurrent access
+
+**Documentation**: README.md warns about this limitation
+
+### Schema Evolution
+
+**Scenario**: Future version changes session state schema
+
+**Current Handling** (MVP): No migration, breaking changes documented
+
+**Future Enhancement**:
+```typescript
+// Add schema_version field
+const state = JSON.parse(fileContents);
+if (state.schema_version === '1.0') {
+  // Migrate to 2.0
+  state = migrateV1ToV2(state);
+}
+```
+
+### Performance: Large Codebases
+
+**Scenario**: 1000+ files to snapshot
+
+**Optimizations**:
+- Only snapshot analyzed files (not entire codebase)
+- Stream processing for checksums (not load entire file into memory)
+- Parallel checksum calculation (future if needed)
+
+**Target**: < 500ms for typical codebases (100-500 files)
+
+## Future Enhancements
+
+### Session Encryption
+
+**Motivation**: Session files may contain sensitive info (file paths, config)
+
+**Approach**:
+- Optional encryption with user-provided key
+- Store encrypted in `.docimp/session-reports/`
+- Decrypt on load
+
+**Complexity**: Key management, backward compatibility
+
+### Multi-User Sessions
+
+**Motivation**: Collaborative audits across team
+
+**Approach**:
+- Session sharing via git remote
+- Conflict resolution for concurrent edits
+- Session ownership and permissions
+
+**Complexity**: Distributed state, merge conflicts
+
+### Session Versioning and Migration
+
+**Motivation**: Schema changes shouldn't break old sessions
+
+**Approach**:
+- Add `schema_version` field to session state
+- Implement migration functions per version
+- Graceful upgrade path
+
+**Implementation**:
+```python
+def load_session_state(session_id: str, session_type: str) -> SessionState:
+    data = json.loads(file.read())
+    version = data.get('schema_version', '1.0')
+
+    if version == '1.0':
+        data = migrate_v1_to_v2(data)
+
+    return SessionState.from_dict(data)
+```
+
+### Auto-Save Timer
+
+**Motivation**: Checkpoint every N seconds, not just on user action
+
+**Approach**:
+- Background timer in InteractiveSession
+- Debounced save (only if state changed)
+- Non-blocking writes
+
+**Complexity**: Concurrency, race conditions
+
+**Status**: Deferred (incremental save after each action sufficient for MVP)
+
+### Session Export/Import
+
+**Motivation**: Backup sessions, share across machines
+
+**Approach**:
+- `docimp export-session <id> --output session.json.gz`
+- `docimp import-session session.json.gz`
+- Validate on import, generate new UUIDs
+
+**Use Cases**: Disaster recovery, collaborative workflows
+
+## API Reference
+
+### SessionStateManager
+
+**TypeScript** (`cli/src/utils/session-state-manager.ts`):
+```typescript
+class SessionStateManager {
+  static async saveSessionState(
+    state: AuditSessionState | ImproveSessionState,
+    sessionType: 'audit' | 'improve'
+  ): Promise<string>;
+
+  static async loadSessionState(
+    sessionId: string,
+    sessionType: 'audit' | 'improve'
+  ): Promise<AuditSessionState | ImproveSessionState>;
+
+  static async listSessions(
+    sessionType: 'audit' | 'improve'
+  ): Promise<Array<AuditSessionState | ImproveSessionState>>;
+
+  static async deleteSessionState(
+    sessionId: string,
+    sessionType: 'audit' | 'improve'
+  ): Promise<void>;
+
+  static async getLatestSession(
+    sessionType: 'audit' | 'improve'
+  ): Promise<AuditSessionState | ImproveSessionState | null>;
+}
+```
+
+**Python** (`analyzer/src/utils/session_state_manager.py`):
+```python
+class SessionStateManager:
+    @staticmethod
+    def save_session_state(
+        state: Union[AuditSessionState, ImproveSessionState],
+        session_type: str
+    ) -> str: ...
+
+    @staticmethod
+    def load_session_state(
+        session_id: str,
+        session_type: str
+    ) -> Union[AuditSessionState, ImproveSessionState]: ...
+
+    @staticmethod
+    def list_sessions(
+        session_type: str
+    ) -> List[Union[AuditSessionState, ImproveSessionState]]: ...
+
+    @staticmethod
+    def delete_session_state(
+        session_id: str,
+        session_type: str
+    ) -> None: ...
+
+    @staticmethod
+    def get_latest_session(
+        session_type: str
+    ) -> Optional[Union[AuditSessionState, ImproveSessionState]]: ...
+```
+
+### FileTracker
+
+**TypeScript** (`cli/src/utils/file-tracker.ts`):
+```typescript
+class FileTracker {
+  static async createSnapshot(
+    filepaths: string[]
+  ): Promise<Record<string, FileSnapshot>>;
+
+  static async detectChanges(
+    snapshot: Record<string, FileSnapshot>
+  ): Promise<string[]>;
+
+  static getChangedItems(
+    changedFiles: string[],
+    items: CodeItem[]
+  ): CodeItem[];
+}
+```
+
+**Python** (`analyzer/src/utils/file_tracker.py`):
+```python
+class FileTracker:
+    @staticmethod
+    def create_snapshot(filepaths: List[str]) -> Dict[str, FileSnapshot]: ...
+
+    @staticmethod
+    def detect_changes(snapshot: Dict[str, FileSnapshot]) -> List[str]: ...
+
+    @staticmethod
+    def get_changed_items(
+        changed_files: List[str],
+        items: List[CodeItem]
+    ) -> List[CodeItem]: ...
+```
+
+## Security Considerations
+
+### Session File Storage
+
+**Location**: `.docimp/session-reports/` (gitignored)
+
+**Contents**: May include:
+- File paths (potentially sensitive project structure)
+- API configuration (timeouts, retry settings)
+- User preferences (style guides, tone)
+
+**Mitigation**:
+- Never commit `.docimp/` to version control
+- Document security implications in README
+- Consider encryption for future (optional user key)
+
+### Transaction Side-Car Repository
+
+**Isolation**: `.docimp/state/.git` never touches user's `.git/`
+
+**Security Guarantees**:
+- No interference with user's repository
+- No commit history leakage
+- No remote push (local only)
+
+### File System Operations
+
+**Atomic Writes**: Temp file + rename prevents corruption
+
+**Race Conditions**: Last write wins (acceptable for single-user MVP)
+
+**Permissions**: Session files inherit user's umask
+
+## Performance Benchmarks
+
+### Session Save/Load
+
+**Target**: < 100ms for typical session (< 100 items)
+
+**Measured** (on development machine):
+- Save: 5-15ms
+- Load: 10-25ms
+- Well under target
+
+### File Invalidation
+
+**Target**: < 500ms for typical codebase (< 1000 files)
+
+**Measured**:
+- 100 files: 50-100ms
+- 500 files: 200-350ms
+- 1000 files: 400-600ms (near target)
+
+**Optimization Opportunities**:
+- Parallel checksum calculation
+- Stream processing for large files
+- Cache checksums in snapshot
+
+### Integration Test Performance
+
+**Cross-workflow suite**: 8 tests in ~2-3 seconds
+
+**Session management**: 18 tests in ~1-2 seconds
+
+**Total regression suite**: 70+ tests in ~30 seconds
+
+## Related Documentation
+
+- **Transaction Integration**: `docs/patterns/transaction-integration.md`
+- **Dependency Injection**: `docs/patterns/dependency-injection.md`
+- **Testing Strategy**: `docs/patterns/testing-strategy.md`
+- **Error Handling**: `docs/patterns/error-handling.md`
+- **CLAUDE.md**: Session state architecture section
+- **README.md**: Resume workflow user documentation
+
+## Implementation Tracking
+
+**Issue**: #216 (Phase 1+2)
+**Related**: #28 (audit resume workflow documentation)
+**Sessions**: 1-8 (32 hours total)
+**Status**: Complete
+**PR**: #365 (draft)

--- a/docs/patterns/testing-strategy.md
+++ b/docs/patterns/testing-strategy.md
@@ -1,0 +1,79 @@
+# Testing Strategy
+
+**Commands**: `cd analyzer && pytest -v` (Python), `cd cli && npm test` (TypeScript/Jest)
+
+**CI/CD**: GitHub Actions with Python 3.13, Node 22, CommonJS/ESM matrix, ruff/eslint linting, mypy/tsc type-checking
+
+## Test Organization (CRITICAL)
+
+**Always create permanent test files, never ad-hoc validation scripts.** Tests must run in CI/CD, catch regressions, and document expected behavior.
+
+### Python Tests (`analyzer/tests/test_*.py`)
+
+```python
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).parent.parent))  # Enable src.* imports
+from src.parsers.python_parser import PythonParser
+```
+
+**Guidelines:**
+- Import from `src.*` not `analyzer.src.*`
+- Use `Path(__file__).parent.parent.parent` for project root in fixtures
+- Focus: Parsers, scorer monotonicity, coverage calc, JSDoc writer patterns
+
+### TypeScript Tests (`cli/src/__tests__/*.test.ts`)
+
+```typescript
+import { PythonBridge } from '../python-bridge/PythonBridge';
+```
+
+**Guidelines:**
+- Mock external dependencies (Python bridge, file system)
+- Focus: Config loader (CommonJS/ESM), plugin manager, JSDoc validation (checkJs), Python bridge
+
+### JavaScript/Plugin Tests (`plugins/__tests__/*.test.js`)
+
+```javascript
+import validateTypesPlugin from '../validate-types.js';
+```
+
+**Guidelines:**
+- Plugin-specific tests co-located with plugin code
+- Jest configured to handle .js test files (jest.config.js includes .test.js patterns)
+- Focus: Plugin hook implementations, JSDoc parsing, validation logic
+
+### Bash Scripts (`test-samples/*.sh`)
+
+For manual testing with API keys/interactive input:
+- Use `set -e`, validate prerequisites, color-coded output
+- Progressive workflow: cleanup → execute → validate → restore
+- See `test-samples/test-workflows-improve.sh` for examples
+- Document conversion path to automated tests (mock API, programmatic input)
+
+## Malformed Syntax Testing
+
+DocImp gracefully handles syntax errors in user codebases being analyzed. Test samples with intentional syntax errors are located in `test-samples/malformed/` and `test-samples/mixed-valid-invalid/`.
+
+### Error Handling Guarantees
+
+- Parsers raise `SyntaxError` for malformed code
+- Analyzer catches syntax errors and tracks them in `parse_failures` array
+- Analysis continues with remaining valid files (non-strict mode)
+- Parse failures are displayed to users with clear error messages
+- Analysis completes without crashing
+
+### Test Samples
+
+- `test-samples/malformed/` - 12 intentionally broken files (4 Python, 4 TypeScript, 4 JavaScript)
+- `test-samples/mixed-valid-invalid/` - 6 files (3 valid, 3 broken) to test "continue on error" behavior
+- See `test-samples/malformed/README.md` for detailed description of each syntax error
+- Separated from `examples/` to avoid interfering with tests expecting valid code
+
+### Testing Layers
+
+1. **Parser level** (`analyzer/tests/test_parsers.py`, `test_typescript_parser.py`): Verify parsers raise `SyntaxError`
+2. **Analyzer level** (`analyzer/tests/test_analyzer.py`): Verify failures tracked in `parse_failures`, analysis continues
+3. **Display level** (`cli/src/__tests__/display.test.ts`): Verify failures displayed correctly
+
+**Strict Mode**: Use `--strict` flag to fail immediately on first syntax error (useful for CI/CD).

--- a/docs/patterns/transaction-integration.md
+++ b/docs/patterns/transaction-integration.md
@@ -1,0 +1,408 @@
+# Transaction System Integration
+
+This document provides detailed workflow examples and architectural decisions for DocImp's transaction system integration.
+
+## Integration Status
+
+### Infrastructure (PR #312)
+
+**Status**: Complete
+
+- GitHelper utility for isolated side-car repository operations
+- TransactionManager for session lifecycle management
+- CLI commands: `rollback-session`, `rollback-change`, `list-sessions`, `list-changes`
+- Comprehensive test coverage: 467 tests passing
+- Side-car repository pattern (`.docimp/state/.git`)
+
+### Integration (Issue #315)
+
+**Status**: Complete (as of 2025-10-31)
+
+Transaction lifecycle is now fully integrated into the `docimp improve` workflow:
+
+- `begin_transaction()` called at session start (generates UUID, creates git branch)
+- `record_write()` creates git commit for each accepted documentation change
+- `commit_transaction()` performs squash merge on session exit
+- Session branches preserved after squash for individual change rollback
+- Re-squash strategy enables rolling back changes from committed sessions
+
+**Implementation Details**:
+- Python CLI commands: `analyzer/src/main.py:695-900` (begin-transaction, record-write, commit-transaction)
+- TypeScript bridge: `cli/src/python-bridge/IPythonBridge.ts:222-261` (interface), `cli/src/python-bridge/PythonBridge.ts:284-422` (implementation)
+- Session integration: `cli/src/session/InteractiveSession.ts:87-203` (transaction lifecycle)
+- Test coverage: 476 Python tests + 447 TypeScript tests = 923 total tests passing
+- Post-squash rollback: `analyzer/src/writer/transaction_manager.py:234-355` (re-squash strategy)
+
+### Undo Feature (Issue #314)
+
+**Status**: Complete (as of 2025-10-31)
+
+Interactive [U]ndo option added to improve workflow:
+
+- [U] appears in prompt after first accepted change
+- Calls `pythonBridge.rollbackChange('last')` to revert HEAD commit on session branch
+- Displays item metadata (name, type, filepath) from git commit
+- Current item re-presented after undo for new suggestion
+- Unlimited undo depth via git commit history
+
+**Implementation Details**:
+- TypeScript UI: `cli/src/session/InteractiveSession.ts:507-548` (handleUndo method)
+- Change tracking: `changeCount` field, incremented on accept, decremented on undo
+- Conditional display: [U] only shown when `changeCount > 0 && transactionActive`
+- Python backend: RollbackResult enhanced with `item_name`, `item_type`, `filepath` fields
+- Test coverage: 451 TypeScript tests (4 undo tests passing, 4 skipped - see `.scratch/undo-tests-todo.md`)
+
+### Future Work
+
+- **--last rollback semantics** (Issue #319): Define behavior for repeated --last usage
+- **Timeout configuration** (Issue #316): Configurable timeouts for git operations
+- **Undo test completion**: Fix 4 skipped transaction lifecycle mock tests
+
+## Architectural Decisions
+
+### Squash Merge Strategy
+
+**Decision**: Use squash merge for session finalization, but preserve session branches.
+
+**Rationale**:
+- Clean main branch history: One commit per improve session
+- Detailed history preserved: Session branch contains all individual changes
+- Post-commit rollback: Preserved branches enable rolling back individual changes after squash
+- Audit trail: Full change history available for debugging and review
+
+**Implementation**: On session completion, `commit_transaction()` performs squash merge to main, then keeps the session branch instead of deleting it.
+
+### Git Revert for All Rollbacks
+
+**Decision**: Use `git revert` for all rollback operations, never rewrite history.
+
+**Rationale**:
+- Safety: Revert is non-destructive, preserves original commits
+- Revertability: Rollbacks themselves can be rolled back if needed
+- Collaboration-safe: No force pushes or history rewrites required
+- Conflict detection: Git's 3-way merge detects conflicts automatically
+
+**Trade-offs**: Creates additional commits rather than removing commits, but safety outweighs cleanliness.
+
+### --last Behavior
+
+**Decision**: Running `rollback-session --last` twice on the same session fails with a clear error.
+
+**Error message**: "Session {id} already rolled back. Use explicit session ID or select different session."
+
+**Rationale**:
+- Prevents accidental double-rollback
+- Forces user to be explicit when rolling back multiple sessions
+- Manifests include status tracking (in_progress, committed, rolled_back)
+
+### Undo Suggestion Caching
+
+**Decision**: Extract previous docstrings via `git show <commit-sha>`, not by re-requesting from Claude API.
+
+**Rationale**:
+- Efficiency: No API calls or token usage for undo
+- Accuracy: Git commit contains exact previous state
+- Speed: Instant extraction vs API round-trip
+- Enhancement: Can show before/after diff when presenting undone change
+
+**Implementation**: Use `git show <commit-sha>:<filepath>` to extract file contents at specific commit.
+
+### Graceful Degradation
+
+**Decision**: If git unavailable or transaction fails, log warning and continue session without transactions.
+
+**Behavior**:
+- Session initialization: Warning logged, `transactionActive = false`
+- Documentation writes: Proceed normally without git commits
+- Session completion: No squash merge, but docstrings still written
+- User experience: Improve workflow remains functional
+
+**Rationale**: Transaction tracking is valuable but not essential - documentation changes are the primary goal.
+
+## Workflow Examples
+
+### Normal Improve Session with Transaction Tracking
+
+```bash
+$ docimp improve ./src
+```
+
+**Behind the scenes**:
+
+```typescript
+// 1. Session starts - generate UUID
+const sessionId = 'abc-123-def-456';
+
+// 2. Initialize transaction
+await pythonBridge.beginTransaction(sessionId);
+// Git: checkout -b docimp/session-abc-123-def-456
+// Creates: .docimp/state/.git branch
+// Status: transactionActive = true
+
+// 3. User accepts first suggestion for calculate_impact_score()
+await writeDocstring(item, docstring);
+// File written: analyzer/src/scoring/impact_scorer.py
+// Backup created: impact_scorer.py.20251030-195622.bak
+
+await pythonBridge.recordWrite(
+  sessionId,
+  'analyzer/src/scoring/impact_scorer.py',
+  'analyzer/src/scoring/impact_scorer.py.20251030-195622.bak',
+  'calculate_impact_score',
+  'function',
+  'python'
+);
+// Git: add impact_scorer.py
+// Git: commit -m "docimp: Add docs to calculate_impact_score
+//
+// Metadata:
+//   item_name: calculate_impact_score
+//   item_type: function
+//   language: python
+//   filepath: analyzer/src/scoring/impact_scorer.py"
+
+// 4. User accepts second and third suggestions...
+// (Same process: write file, create backup, git commit)
+
+// 5. User quits session (Q)
+await pythonBridge.commitTransaction(sessionId);
+// Git: checkout main
+// Git: merge --squash docimp/session-abc-123-def-456
+// Git: commit -m "docimp session abc-123-def-456 (squash)"
+// Delete: All .bak backup files
+// Preserve: Session branch docimp/session-abc-123-def-456
+// Status: committed
+```
+
+**Result**: Three individual changes committed to session branch, one squash commit on main, session branch preserved.
+
+### Interactive Undo During Improve Session (Issue #314)
+
+```bash
+$ docimp improve ./src
+```
+
+**User interaction**:
+
+```
+[1/5] function calculateScore
+  Suggested documentation:
+  ---
+  /** Calculates priority score based on complexity and quality */
+  ---
+
+What would you like to do?
+> [A] Accept  [E] Edit  [R] Regenerate  [S] Skip  [Q] Quit
+
+# User presses A - accept first change
+✓ Documentation written to src/scorer.js
+
+[2/5] function formatOutput
+  Suggested documentation:
+  ---
+  /** Formats analysis results for display */
+  ---
+
+What would you like to do?
+> [A] Accept  [E] Edit  [R] Regenerate  [S] Skip  [U] Undo  [Q] Quit
+#                                                     ^^^^
+#                                                  [U] appears!
+
+# User presses A - accept second change
+✓ Documentation written to src/formatter.js
+
+[3/5] class DataValidator
+  Suggested documentation:
+  ---
+  /** Validates input data against schema */
+  ---
+
+What would you like to do?
+> [A] Accept  [E] Edit  [R] Regenerate  [S] Skip  [U] Undo  [Q] Quit
+
+# User presses U - undo last change (formatOutput)
+Rolling back last change...
+✓ Reverted documentation for formatOutput (function)
+  File: src/formatter.js
+
+# User is returned to formatOutput (current item re-presented)
+[2/5] function formatOutput
+  Suggested documentation:
+  ---
+  /** Formats analysis results for display */
+  ---
+
+What would you like to do?
+> [A] Accept  [E] Edit  [R] Regenerate  [S] Skip  [U] Undo  [Q] Quit
+#                                                     ^^^^
+#                                      [U] still available (can undo calculateScore)
+```
+
+**Behind the scenes**:
+
+```typescript
+// After first accept: changeCount = 1
+this.changeCount++; // Now 1
+// [U] becomes visible in next prompt
+
+// User presses [U]:
+await this.handleUndo();
+  -> await pythonBridge.rollbackChange('last');
+     // Git: revert HEAD commit on session branch
+     // Returns: { success: true, item_name: 'formatOutput', item_type: 'function', ... }
+  -> console.log('Reverted documentation for formatOutput (function)')
+  -> this.changeCount--;  // Back to 1
+
+// processItem() loop uses `continue` - stays on same item
+// Current docstring is reused (no new API call)
+```
+
+**Key behaviors**:
+- [U] hidden when `changeCount === 0`
+- [U] appears after first accept (`changeCount > 0`)
+- Undo calls `rollbackChange('last')` - reverts HEAD commit
+- File restored from git history (no backup needed)
+- Current item re-presented with same suggestion
+- Can undo repeatedly (git history provides unlimited depth)
+- `changeCount` decrements on successful undo
+
+### Rollback Individual Change After Session
+
+```bash
+# List changes from a session
+$ docimp list-changes abc-123-def
+
+Session: abc-123-def
+Status: committed
+Changes: 3
+
+Entry a1b2c3d: calculate_impact_score (function, Python)
+  File: analyzer/src/scoring/impact_scorer.py
+  Time: 2025-10-30 19:56:22
+
+Entry e4f5g6h: DocumentationAnalyzer.__init__ (method, Python)
+  File: analyzer/src/analysis/documentation_analyzer.py
+  Time: 2025-10-30 19:58:15
+
+Entry i7j8k9l: parseTypeScript (function, TypeScript)
+  File: cli/src/parsers/ts-js-parser-helper.ts
+  Time: 2025-10-30 20:01:43
+
+# Rollback specific change
+$ docimp rollback-change a1b2c3d
+```
+
+**Behind the scenes (re-squash strategy)**:
+
+```bash
+# 1. Detect session is committed (squashed)
+session_branch='docimp/session-abc-123-def'
+main_commit=$(git rev-parse HEAD)  # Current squash commit
+
+# 2. Verify session branch exists
+git branch --list "$session_branch"  # Must exist for rollback
+
+# 3. Checkout session branch
+git checkout "$session_branch"
+
+# 4. Revert the specific commit on session branch
+git revert --no-commit a1b2c3d
+# Conflict check: If conflicts, abort and return error
+
+# 5. Commit the revert
+git commit -m "Revert change a1b2c3d"
+
+# 6. Checkout main
+git checkout main
+
+# 7. Reset main to before previous squash
+parent=$(git rev-parse HEAD^)  # Parent of current squash commit
+git reset --hard "$parent"
+
+# 8. Re-squash-merge session branch (now with reverted commit)
+git merge --squash "$session_branch"
+
+# 9. Create new squash commit
+git commit -m "docimp session abc-123-def (squash, change a1b2c3d reverted)"
+
+# 10. Update manifest
+# Mark entry a1b2c3d as reverted: true
+# Update reverted_at timestamp
+```
+
+**Result**: Session branch has revert commit, main has new squash commit, net effect shows only changes e4f5g6h and i7j8k9l.
+
+### Cancellation Handling (Uncommitted Session)
+
+```bash
+$ docimp improve ./src
+
+# User accepts 2 changes
+# User presses Q to quit early (before completing all items)
+```
+
+**Behind the scenes**:
+
+```typescript
+// Session branch exists with 2 commits
+// Squash merge NOT performed
+// Backup files still exist
+
+console.log('\nSession cancelled. Changes left uncommitted.');
+console.log(`Use 'docimp rollback-session abc-123-def' to undo.`);
+```
+
+**User options**:
+1. Resume session later (future enhancement)
+2. Rollback uncommitted session: `docimp rollback-session abc-123-def`
+3. Leave changes in place (session branch and backup files remain)
+
+### Error Scenario: Git Unavailable
+
+```bash
+$ docimp improve ./src
+# Git not installed or not in PATH
+```
+
+**Behind the scenes**:
+
+```typescript
+try {
+  await pythonBridge.beginTransaction(sessionId);
+  this.transactionActive = true;
+} catch (error) {
+  console.warn('Failed to initialize transaction:', error.message);
+  console.warn('Continuing without transaction tracking - rollback unavailable');
+  this.transactionActive = false;
+}
+
+// Session continues normally
+// Documentation written to files
+// No git commits, no rollback capability
+```
+
+**Result**: Improve workflow completes successfully, but no transaction history or rollback features.
+
+### Error Scenario: Transaction Init Fails
+
+```bash
+$ docimp improve ./src
+# Git available but side-car repo initialization fails
+```
+
+**Behind the scenes**:
+
+```typescript
+try {
+  await pythonBridge.beginTransaction(sessionId);
+} catch (error) {
+  // Log error details
+  console.warn('Transaction initialization failed:', error.message);
+  this.transactionActive = false;
+}
+
+// Continue with improve workflow
+// recordWrite calls are no-ops when transactionActive = false
+```
+
+**Result**: Documentation written normally, no transaction tracking, session completes without rollback capability.

--- a/docs/patterns/workflow-state-management.md
+++ b/docs/patterns/workflow-state-management.md
@@ -1,0 +1,631 @@
+# Workflow State Management
+
+DocImp's workflow state tracking enables bidirectional workflows, dependency validation, stale detection, and incremental re-analysis. This document details the architecture, design decisions, and implementation patterns for the workflow state system introduced in Issue #216 Phase 3.
+
+## Architecture Overview
+
+### Component Stack
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                    CLI Commands (TypeScript)                  │
+│  analyze, audit, plan, improve with validation               │
+└────────────────────────┬─────────────────────────────────────┘
+                         │
+                         v
+┌──────────────────────────────────────────────────────────────┐
+│               WorkflowValidator (TypeScript)                  │
+│  - validateAuditPrerequisites()   - Prerequisites checking   │
+│  - validatePlanPrerequisites()    - Stale detection          │
+│  - checkStaleAnalysis()           - Helpful error messages   │
+└────────────────────────┬─────────────────────────────────────┘
+                         │
+                         v
+┌──────────────────────────────────────────────────────────────┐
+│           WorkflowStateManager (TS + Python)                  │
+│  - loadWorkflowState()    - Atomic reads with Zod validation │
+│  - saveWorkflowState()    - Atomic writes (temp + rename)    │
+│  - updateCommandState()   - Update single command state      │
+└────────────────────────┬─────────────────────────────────────┘
+                         │
+                         v
+┌──────────────────────────────────────────────────────────────┐
+│           WorkflowState File (.docimp/workflow-state.json)    │
+│  - schema_version: "1.0"                                     │
+│  - last_analyze, last_audit, last_plan, last_improve         │
+│  - Each: { timestamp, item_count, file_checksums }           │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### Data Model
+
+**WorkflowState** (TypeScript + Python):
+```typescript
+interface WorkflowState {
+  schema_version: string;           // "1.0" for current version
+  migration_log: MigrationLogEntry[];  // History of applied migrations
+  last_analyze: CommandState | null;
+  last_audit: CommandState | null;
+  last_plan: CommandState | null;
+  last_improve: CommandState | null;
+}
+
+interface MigrationLogEntry {
+  from: string;                      // Source version (e.g., "legacy", "1.0")
+  to: string;                        // Target version (e.g., "1.0", "1.1")
+  timestamp: string;                 // ISO 8601 timestamp of migration
+}
+
+interface CommandState {
+  timestamp: string;                 // ISO 8601 timestamp
+  item_count: number;                // Number of items processed
+  file_checksums: Record<string, string>;  // filepath → SHA256 checksum
+}
+```
+
+### Integration with Session Resume
+
+Workflow state and session resume are **complementary features** that work together:
+
+**Workflow State** (workflow-state.json):
+- Tracks command execution history across sessions
+- Validates command dependencies (audit requires analyze, etc.)
+- Detects stale data (analyze re-run since audit)
+- Enables incremental re-analysis
+
+**Session Resume** (audit-session-{uuid}.json, improve-session-{uuid}.json):
+- Preserves in-progress work within a single command execution
+- Allows pausing and resuming interactive workflows
+- Handles file invalidation when files change during pause
+
+**How They Complement Each Other**:
+1. **Session resume** uses file_checksums from **workflow state** to detect changes during pause
+2. **Workflow state** is updated when session completes (not during in-progress)
+3. **Stale detection** warns users before starting new session if prior command data changed
+4. **Incremental analysis** uses workflow state checksums; session resume uses session-specific checksums
+
+**Example Workflow**:
+```
+1. docimp analyze ./src
+   → Saves workflow-state.json: last_analyze = { timestamp, item_count, checksums }
+
+2. docimp audit ./src
+   → Validates: last_analyze exists ✓
+   → User rates 5/23 items, presses Q to quit
+   → Saves audit-session-abc123.json with progress
+
+3. User modifies 2 files
+
+4. docimp audit ./src --resume
+   → Loads audit-session-abc123.json
+   → Detects 2 changed files (checksums differ from session snapshot)
+   → Re-analyzes those 2 files
+   → Continues audit from item #6
+   → On completion, saves workflow-state.json: last_audit = { ... }
+
+5. docimp analyze ./src (re-run)
+   → Saves new workflow-state.json: last_analyze timestamp updated
+
+6. docimp plan ./src
+   → Validates: last_analyze exists ✓
+   → Detects: last_audit timestamp < last_analyze timestamp (stale!)
+   → Warns: "Audit data may be stale. Consider re-running 'docimp audit'."
+   → User can proceed or re-audit
+```
+
+## Design Decisions
+
+### Decision 1: SHA256 Checksums for File Tracking
+
+**Chosen**: SHA256 checksums with timestamp fallback
+
+**Rationale**:
+- **SHA256 strength**: Cryptographically strong, virtually no collision risk
+- **Content-based**: Detects actual changes, not just metadata changes
+- **Timestamp optimization**: Quick first check (mtime) before expensive checksum calculation
+- **Git compatibility**: Aligns with git's content-addressable storage model
+
+**Algorithm**:
+```typescript
+// Change detection logic
+if (timestamp !== storedTimestamp) {
+  // Timestamp changed, now check checksum
+  const currentChecksum = await calculateSHA256(filepath);
+  if (currentChecksum !== storedChecksum) {
+    return true; // File actually changed
+  }
+  // False alarm: timestamp changed but content unchanged (e.g., git checkout)
+}
+return false; // File unchanged
+```
+
+**Trade-offs**:
+- ✅ Accurate change detection (no false positives)
+- ✅ Works across git operations (checkout, merge, stash)
+- ❌ Checksum calculation takes time (~10-50ms per file on SSD)
+- Mitigation: Only checksum files already analyzed (not entire codebase)
+
+**Alternative Considered**: Timestamp-only
+- Faster but frequent false positives (build tools, version control)
+
+### Decision 2: Schema Versioning Strategy
+
+**Chosen**: Include `schema_version` field in WorkflowState from v1.0
+
+**Rationale**:
+- **Forward compatibility**: Enables safe schema evolution without breaking old files
+- **Graceful migration**: Can implement migration logic when schema changes
+- **User transparency**: Clear error messages when schema incompatible
+
+**Current Implementation (v1.0)**:
+```typescript
+const WorkflowStateSchema = z.object({
+  schema_version: z.literal('1.0'),  // Only accept v1.0
+  last_analyze: CommandStateSchema.nullable(),
+  // ...
+});
+```
+
+**Future Migration Path** (when v1.1 introduced):
+```typescript
+function loadWorkflowState(): WorkflowState {
+  const content = readFileSync(workflowFile, 'utf8');
+  const parsed = JSON.parse(content);
+
+  // Migrate old schemas
+  if (parsed.schema_version === '1.0') {
+    parsed = migrateV1ToV2(parsed);
+  }
+
+  return WorkflowStateSchema.parse(parsed);
+}
+```
+
+**Trade-offs**:
+- ✅ Future-proof design
+- ✅ No breaking changes on schema evolution
+- ❌ Slightly more complex initial implementation
+- ❌ Migration code adds maintenance burden
+
+**Alternative Considered**: No schema versioning (YAGNI)
+- Simpler initially but requires manual file deletion on breaking changes
+- User friction and data loss
+
+### Decision 3: Stale Detection Thresholds
+
+**Chosen**: Timestamp-based stale detection without time threshold
+
+**Logic**:
+```
+audit is stale IF:
+  last_analyze exists AND
+  last_audit exists AND
+  last_analyze.timestamp > last_audit.timestamp
+
+plan is stale IF:
+  last_analyze exists AND
+  last_plan exists AND
+  last_analyze.timestamp > last_plan.timestamp
+```
+
+**Rationale**:
+- **Simple and predictable**: No magic time thresholds to configure
+- **Command-based**: If you re-run analyze, downstream commands become stale
+- **User control**: Warnings suggest re-running commands but don't block
+
+**Example**:
+```bash
+$ docimp analyze ./src  # 10:00 AM
+$ docimp audit ./src    # 10:15 AM - audit ratings saved
+$ docimp analyze ./src  # 10:30 AM - re-run analysis
+$ docimp plan ./src     # 10:35 AM
+
+Warning: Audit data may be stale (analysis re-run since audit).
+Consider re-running 'docimp audit' to refresh ratings.
+
+[Plan continues anyway - user decision]
+```
+
+**Trade-offs**:
+- ✅ No false positives (only warns when commands actually re-run)
+- ✅ User remains in control
+- ❌ Doesn't detect file changes without re-running analyze
+
+**Alternative Considered**: File checksum-based staleness
+- Warn if checksums differ between analyze and audit
+- More accurate but slower (requires scanning all files)
+- Deferred to incremental analysis feature
+
+### Decision 4: Atomic Write Pattern
+
+**Chosen**: Temp file + rename for atomic writes
+
+**Implementation**:
+```typescript
+async function saveWorkflowState(state: WorkflowState): Promise<void> {
+  const workflowFile = StateManager.getWorkflowFile();
+  const tempFile = `${workflowFile}.tmp`;
+
+  // Write to temp file
+  await fs.writeFile(tempFile, JSON.stringify(state, null, 2), 'utf8');
+
+  // Atomic rename (POSIX guarantee)
+  await fs.rename(tempFile, workflowFile);
+}
+```
+
+**Rationale**:
+- **Atomic operations**: Prevents corruption on process kill or crash
+- **POSIX guarantee**: `rename()` is atomic on all POSIX filesystems
+- **No partial writes**: Either old file exists or new file exists, never partial
+
+**Trade-offs**:
+- ✅ Corruption-proof
+- ✅ Works on all platforms (Linux, macOS, Windows)
+- ❌ Slightly more disk I/O (temp file creation)
+- Mitigation: Negligible for small JSON files (<1KB)
+
+**Alternative Considered**: Direct overwrite
+- Faster but risks corruption on crash
+
+### Decision 5: Separate Workflow State from Session State
+
+**Chosen**: Two separate JSON files (workflow-state.json vs session-{uuid}.json)
+
+**Rationale**:
+- **Different lifecycles**: Workflow state persists across sessions, session state is ephemeral
+- **Different update patterns**: Workflow state updated on command completion, session state updated continuously
+- **Independent features**: Can implement session resume without workflow state, vice versa
+- **Clear separation of concerns**: Easier to understand and maintain
+
+**Trade-offs**:
+- ✅ Clear boundaries between features
+- ✅ Independent evolution
+- ❌ Two file management systems instead of one
+- Mitigation: Shared utilities (StateManager, FileTracker)
+
+**Alternative Considered**: Single unified state file
+- Simpler file management but tightly couples features
+
+## Integration Points
+
+### Analyze Command Integration
+
+**Location**: `cli/src/commands/analyze.ts`
+
+**Changes**:
+1. After analysis completes, create command state with checksums
+2. Update workflow state with `last_analyze`
+3. Support `--incremental` flag for incremental re-analysis
+4. Support `--apply-audit` flag to load audit ratings
+
+**Code**:
+```typescript
+// In analyzeCore() after analysis completes
+const filepaths = result.items.map(item => item.filepath);
+const snapshot = await FileTracker.createSnapshot(filepaths);
+
+const fileChecksums: Record<string, string> = {};
+for (const [filepath, fileSnapshot] of Object.entries(snapshot)) {
+  fileChecksums[filepath] = fileSnapshot.checksum;
+}
+
+const commandState = createCommandState(result.total_items, fileChecksums);
+await WorkflowStateManager.updateCommandState('analyze', commandState);
+```
+
+### Audit Command Integration
+
+**Location**: `cli/src/commands/audit.ts`
+
+**Changes**:
+1. Validate analyze prerequisite before starting
+2. Warn if analyze is stale (re-run since last audit)
+3. After audit completes, update workflow state with `last_audit`
+
+**Code**:
+```typescript
+// In auditCore() before starting interactive audit
+const validation = await WorkflowValidator.validateAuditPrerequisites();
+if (!validation.valid) {
+  display.showError(validation.error);
+  display.showMessage(validation.suggestion);
+  return EXIT_CODE.ERROR;
+}
+
+const staleCheck = await WorkflowValidator.checkStaleAnalysis();
+if (!staleCheck.valid) {
+  display.showWarning(staleCheck.error);
+}
+
+// After audit completes...
+const commandState = createCommandState(totalItems, fileChecksums);
+await WorkflowStateManager.updateCommandState('audit', commandState);
+```
+
+### Plan Command Integration
+
+Similar to audit, validates analyze prerequisite and checks for stale analyze/audit data.
+
+### Improve Command Integration
+
+Validates plan prerequisite and checks for stale plan data.
+
+## Testing Strategy
+
+### Unit Tests
+
+**WorkflowStateManager** (22 TypeScript + 30+ Python = 52+ tests):
+- Atomic write (temp file + rename)
+- Load with Zod validation
+- Load non-existent file (creates default state)
+- Load corrupted JSON (throws error with helpful message)
+- Update single command state
+- Schema validation (rejects invalid timestamps, negative counts, malformed checksums)
+
+**WorkflowValidator** (24 tests):
+- validateAuditPrerequisites (6 tests)
+  - No analyze file → error
+  - Analyze file exists → valid
+  - Corrupted analyze file → error
+- validatePlanPrerequisites (6 tests)
+  - No analyze file → error
+  - No plan file when required → error
+  - Both exist → valid
+- checkStaleAnalysis (6 tests)
+  - analyze newer than audit → stale warning
+  - audit newer than analyze → not stale
+  - No audit → not stale
+- checkStalePlan (6 tests)
+  - analyze newer than plan → stale warning
+  - plan newer than analyze → not stale
+  - No plan → not stale
+
+### Integration Tests
+
+**Analyze Command** (13 tests in `analyze-workflow-state.test.ts`):
+- Workflow state created after first analysis
+- Workflow state updated on re-run
+- Incremental analysis uses checksums
+- Apply audit loads ratings from audit.json
+
+**Audit Command** (8 tests):
+- Validates analyze prerequisite
+- Warns on stale analyze
+- Updates workflow state on completion
+- Workflow state includes checksums from analyzed files
+
+**Plan Command** (8 tests):
+- Validates analyze prerequisite
+- Warns on stale analyze
+- Warns on stale audit (if audit exists)
+- Updates workflow state on completion
+
+**Stale Detection** (24 tests in `workflow-validator.test.ts`):
+- Cross-command staleness detection
+- Edge cases (missing files, corrupted state, concurrent updates)
+
+### End-to-End Tests
+
+**Bidirectional Workflow** (`test-samples/test-workflows.sh`):
+```bash
+# Workflow: analyze → audit → analyze → audit (bidirectional)
+docimp analyze ./src           # Creates workflow-state.json
+docimp audit ./src             # Validates analyze exists
+docimp analyze ./src           # Re-run analyze
+docimp audit ./src             # Warns: analyze re-run since audit (stale)
+```
+
+## Future Enhancements
+
+### Phase 3.6: Workflow State Visualization
+
+**Command**: `docimp status`
+
+**Output**:
+```
+Workflow State (.docimp/workflow-state.json)
+
+analyze:  ✓ Run 2 hours ago (23 items, 5 files)
+audit:    ✓ Run 1 hour ago (18 items rated)
+plan:     ✓ Run 30 minutes ago (12 high-priority items)
+improve:  ✗ Not run yet
+
+Staleness Warnings:
+  • analyze is stale (2 files modified since last run)
+  • plan is stale (analyze re-run since plan generated)
+
+Suggestions:
+  → Run 'docimp analyze --incremental' to update analysis
+  → Run 'docimp plan' to regenerate plan with latest analysis
+```
+
+**Benefits**:
+- Users understand workflow state at a glance
+- Debugging workflow issues becomes trivial
+- Guides users to next logical command
+
+**Related**: Issue #374
+
+### Phase 3.7: Schema Migration Utilities (Implemented)
+
+**Status**: Complete (Issue #375)
+
+**Command**: `docimp migrate-workflow-state`
+
+**Implementation**:
+- Migration registry pattern mapping version transitions to migration functions
+- Auto-migration on load in WorkflowStateManager (transparent upgrades)
+- Migration log tracking in WorkflowState (`migration_log` field)
+- CLI command with `--dry-run`, `--check`, `--version`, `--force` options
+- Comprehensive test coverage (15 TS + 15 Python + 12 command tests)
+
+**Usage**:
+```bash
+# Check if migration needed (CI/CD mode)
+docimp migrate-workflow-state --check
+
+# Preview migration without changes
+docimp migrate-workflow-state --dry-run
+
+# Migrate to specific version
+docimp migrate-workflow-state --version 1.1
+
+# Skip confirmation prompt
+docimp migrate-workflow-state --force
+```
+
+**Architecture**:
+- `WORKFLOW_STATE_MIGRATIONS` registry maps "1.0->1.1" to migration functions
+- `buildMigrationPath()` constructs sequential migration chains
+- `applyMigrations()` executes chain and updates `migration_log`
+- Legacy files (no `schema_version`) automatically upgraded to v1.0
+
+**Files**:
+- TypeScript: `cli/src/types/workflow-state-migrations.ts`
+- Python: `analyzer/src/models/workflow_state_migrations.py`
+- Command: `cli/src/commands/migrate-workflow-state.ts`, `analyzer/src/main.py`
+- Tests: `cli/src/__tests__/workflow-state-migrations.test.ts`, `analyzer/tests/test_workflow_state_migrations.py`
+
+**Related**: Issue #375, PR #[pending]
+
+### Phase 3.8: --dry-run Flag for Incremental Analysis (Implemented)
+
+**Status**: Complete (Issue #376)
+
+**Flag**: `docimp analyze --incremental --dry-run`
+
+**Purpose**: Preview what files would be re-analyzed in incremental mode without actually running the analysis.
+
+**Output Example**:
+```
+Incremental Analysis (dry run mode)
+
+Would re-analyze 3 file(s):
+  • src/analyzer.ts
+  • src/parser.py
+  • cli/commands/analyze.ts
+
+Would reuse results from 97 unchanged file(s)
+
+Estimated time savings: ~97%
+
+Run without --dry-run to perform incremental analysis
+```
+
+**Implementation Details**:
+- Early return in `handleIncrementalAnalysis()` after detecting changed files
+- Calls `display.showIncrementalDryRun()` to show preview
+- No analysis performed, no file writes, no workflow state updates
+- Returns previous analysis result unchanged
+- Warning shown if `--dry-run` used without `--incremental`
+
+**Files Modified**:
+- `cli/src/index.ts` - Added `--dry-run` flag
+- `cli/src/commands/analyze.ts` - Dry-run logic and skip save/update in dry-run mode
+- `cli/src/display/i-display.ts` - Added `showIncrementalDryRun()` interface method
+- `cli/src/display/terminal-display.ts` - Implemented colorful dry-run output
+- `cli/src/__tests__/commands/analyze-incremental-dry-run.test.ts` - 8 comprehensive tests
+
+**Test Coverage**: 8 new tests (all passing)
+
+**Related**: Issue #376, PR #[pending]
+
+### Phase 3.9: File-Level Checksum Staleness
+
+**Enhancement**: Detect stale data based on file checksums, not just command timestamps
+
+**Logic**:
+```
+audit is stale IF:
+  ANY file in audit.file_checksums has different checksum in last_analyze.file_checksums
+```
+
+**Benefit**: More precise staleness detection (file-granular, not command-granular)
+
+### Phase 3.10: Workflow State History
+
+**Feature**: Keep history of workflow state changes
+
+**File**: `.docimp/history/workflow-state-{timestamp}.json`
+
+**Benefits**:
+- Audit trail for debugging
+- Rollback to previous state
+- Understand how workflow evolved over time
+
+## Performance Benchmarks
+
+### Workflow State Operations
+
+**Save workflow state**: 5-15ms (typical)
+**Load workflow state**: 10-25ms (typical)
+**Validate prerequisites**: 5-10ms (file existence checks)
+**Checksum calculation**: 10-50ms per file (1KB-100KB files on SSD)
+
+**Total overhead per command**: ~50-100ms (negligible)
+
+### Incremental Analysis Savings
+
+**Scenario**: 100-file codebase, 5 files changed
+
+**Full analysis**: 30 seconds
+**Incremental analysis**: 3 seconds (90% time savings)
+
+**Scenario**: 1000-file codebase, 10 files changed
+
+**Full analysis**: 5 minutes
+**Incremental analysis**: 15 seconds (95% time savings)
+
+## Security Considerations
+
+### Workflow State File
+
+**Location**: `.docimp/workflow-state.json` (gitignored)
+
+**Contents**:
+- File paths (potentially sensitive project structure)
+- Checksums (SHA256, not reversible to original content)
+- Timestamps (innocuous)
+
+**Mitigation**:
+- Never commit `.docimp/` to version control
+- Document in README and CONTRIBUTING
+- Consider encryption for future (optional user key)
+
+### Checksum Security
+
+**SHA256**: Cryptographically secure hash function
+- No known collision attacks (as of 2025)
+- Cannot reverse checksum to original content
+- Safe for integrity checking
+
+**Not Used For**: Authentication, authorization, or security boundaries
+
+## Related Documentation
+
+- **Session Resume**: `docs/patterns/session-resume.md` - Complementary feature
+- **Transaction Integration**: `docs/patterns/transaction-integration.md` - Uses workflow state
+- **Testing Strategy**: `docs/patterns/testing-strategy.md` - Test organization
+- **Error Handling**: `docs/patterns/error-handling.md` - Validation error patterns
+- **CLAUDE.md**: Workflow state architecture section
+- **README.md**: User-facing workflow documentation
+
+## Implementation Tracking
+
+**Issue**: #216 (Phase 3.1-3.5)
+**Related**: #374 (status command), #375 (migration utilities), #376 (--dry-run flag)
+**Status**: Complete (Phase 3.1-3.5, Phase 3.7-3.8)
+**PRs**: #372 (Phase 3.1-3.5), #379 (Phase 3.7), #[pending] (Phase 3.8)
+
+**Files Implemented**:
+- `cli/src/types/workflow-state.ts` - Data models and Zod schemas
+- `cli/src/utils/workflow-state-manager.ts` - Persistence layer (TypeScript)
+- `cli/src/utils/workflow-validator.ts` - Validation and staleness checking
+- `analyzer/src/models/workflow_state.py` - Data models (Python)
+- `analyzer/src/utils/workflow_state_manager.py` - Persistence layer (Python)
+- `cli/src/__tests__/workflow-state-manager.test.ts` - Unit tests
+- `cli/src/__tests__/workflow-validator.test.ts` - Validator tests
+- `analyzer/tests/test_workflow_state_manager.py` - Python unit tests
+
+**Test Coverage**: 117+ new tests (52+ unit tests for managers, 24 for validator, 41+ integration tests)


### PR DESCRIPTION
## Summary

Make architectural pattern documentation available to contributors by moving 6 pattern files from gitignored `.docimp-shared/docs/patterns/` to public `docs/patterns/` directory.

## Changes

**Added Files** (docs/patterns/):
- `dependency-injection.md` (222 lines) - Pure DI pattern with entry-point instantiation
- `error-handling.md` (69 lines) - Three-layer error handling architecture
- `session-resume.md` (742 lines) - Session persistence and file invalidation
- `testing-strategy.md` (79 lines) - Test organization across Python/TypeScript/JavaScript
- `transaction-integration.md` (408 lines) - Git side-car transaction system
- `workflow-state-management.md` (631 lines) - Workflow state tracking and validation

**Modified**:
- `.gitignore` - Removed `docs/patterns` to allow pattern files to be committed

**Note**: `development-workflow.md` was moved to `.docimp-shared/.planning/` as it documents personal workflow with Claude Code (references gitignored PLAN.md), not a reusable architectural pattern.

## Impact

- **Contributors** gain access to comprehensive architectural documentation
- **Onboarding** becomes easier with documented design patterns
- **Transparency** increases - community can understand design decisions
- **No breaking changes** - existing functionality unaffected

## Test Plan

- Verified all 6 pattern files copied correctly
- Verified CLAUDE.md imports still resolve (updated development-workflow.md reference to `.planning/`)
- Verified .gitignore no longer blocks docs/patterns/

Generated with [Claude Code](https://claude.com/claude-code)