### PR TITLE
Add Python tool interceptors with subdirectory warnings

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -7,7 +7,17 @@ mkdir -p .direnv/bin
 cat > .direnv/bin/python <<'PYTHON_EOF'
 #!/bin/bash
 # Intercept bare python calls and redirect to uv
+ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo ".")
+CURRENT=$(pwd)
+
+if [ -f "pyproject.toml" ] && [ "$CURRENT" != "$ROOT" ]; then
+  echo "Warning: Running python from subdirectory with pyproject.toml ($CURRENT)" >&2
+  echo "   May cause errors or create local .venv/. To avoid: cd $ROOT && uv run python" >&2
+fi
+
 echo "→ Redirecting to: uv run python" >&2
+# Remove .direnv/bin from PATH to prevent recursion
+PATH=$(echo "$PATH" | tr ':' '\n' | grep -v '.direnv/bin' | tr '\n' ':' | sed 's/:$//')
 exec uv run python "$@"
 PYTHON_EOF
 
@@ -15,7 +25,17 @@ PYTHON_EOF
 cat > .direnv/bin/python3 <<'PYTHON3_EOF'
 #!/bin/bash
 # Intercept bare python3 calls and redirect to uv
+ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo ".")
+CURRENT=$(pwd)
+
+if [ -f "pyproject.toml" ] && [ "$CURRENT" != "$ROOT" ]; then
+  echo "Warning: Running python3 from subdirectory with pyproject.toml ($CURRENT)" >&2
+  echo "   May cause errors or create local .venv/. To avoid: cd $ROOT && uv run python" >&2
+fi
+
 echo "→ Redirecting to: uv run python" >&2
+# Remove .direnv/bin from PATH to prevent recursion
+PATH=$(echo "$PATH" | tr ':' '\n' | grep -v '.direnv/bin' | tr '\n' ':' | sed 's/:$//')
 exec uv run python "$@"
 PYTHON3_EOF
 
@@ -23,7 +43,16 @@ PYTHON3_EOF
 cat > .direnv/bin/pip <<'PIP_EOF'
 #!/bin/bash
 # Block bare pip, show helpful error
-echo "❌ Bare 'pip' detected!" >&2
+ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo ".")
+CURRENT=$(pwd)
+
+if [ -f "pyproject.toml" ] && [ "$CURRENT" != "$ROOT" ]; then
+  echo "Warning: Running pip from subdirectory with pyproject.toml ($CURRENT)" >&2
+  echo "   May cause errors or create local .venv/. To avoid: cd $ROOT && uv pip ..." >&2
+  echo "" >&2
+fi
+
+echo "Bare 'pip' detected!" >&2
 echo "" >&2
 echo "Instead of 'pip install <package>', use:" >&2
 echo "  uv add <package>" >&2
@@ -33,10 +62,64 @@ echo "  uv pip sync requirements-dev.lock" >&2
 exit 1
 PIP_EOF
 
+# pytest interceptor
+cat > .direnv/bin/pytest <<'PYTEST_EOF'
+#!/bin/bash
+# Intercept bare pytest calls and redirect to uv
+ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo ".")
+CURRENT=$(pwd)
+
+if [ -f "pyproject.toml" ] && [ "$CURRENT" != "$ROOT" ]; then
+  echo "Warning: Running pytest from subdirectory with pyproject.toml ($CURRENT)" >&2
+  echo "   May cause errors or create local .venv/. To avoid: cd $ROOT && uv run pytest" >&2
+fi
+
+# Remove .direnv/bin from PATH to prevent recursion
+PATH=$(echo "$PATH" | tr ':' '\n' | grep -v '.direnv/bin' | tr '\n' ':' | sed 's/:$//')
+exec uv run pytest "$@"
+PYTEST_EOF
+
+# ruff interceptor
+cat > .direnv/bin/ruff <<'RUFF_EOF'
+#!/bin/bash
+# Intercept bare ruff calls and redirect to uv
+ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo ".")
+CURRENT=$(pwd)
+
+if [ -f "pyproject.toml" ] && [ "$CURRENT" != "$ROOT" ]; then
+  echo "Warning: Running ruff from subdirectory with pyproject.toml ($CURRENT)" >&2
+  echo "   May cause errors or create local .venv/. To avoid: cd $ROOT && uv run ruff" >&2
+fi
+
+# Remove .direnv/bin from PATH to prevent recursion
+PATH=$(echo "$PATH" | tr ':' '\n' | grep -v '.direnv/bin' | tr '\n' ':' | sed 's/:$//')
+exec uv run ruff "$@"
+RUFF_EOF
+
+# mypy interceptor
+cat > .direnv/bin/mypy <<'MYPY_EOF'
+#!/bin/bash
+# Intercept bare mypy calls and redirect to uv
+ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo ".")
+CURRENT=$(pwd)
+
+if [ -f "pyproject.toml" ] && [ "$CURRENT" != "$ROOT" ]; then
+  echo "Warning: Running mypy from subdirectory with pyproject.toml ($CURRENT)" >&2
+  echo "   May cause errors or create local .venv/. To avoid: cd $ROOT && uv run mypy" >&2
+fi
+
+# Remove .direnv/bin from PATH to prevent recursion
+PATH=$(echo "$PATH" | tr ':' '\n' | grep -v '.direnv/bin' | tr '\n' ':' | sed 's/:$//')
+exec uv run mypy "$@"
+MYPY_EOF
+
 # Make executables
 chmod +x .direnv/bin/python
 chmod +x .direnv/bin/python3
 chmod +x .direnv/bin/pip
+chmod +x .direnv/bin/pytest
+chmod +x .direnv/bin/ruff
+chmod +x .direnv/bin/mypy
 
 # Add to PATH (highest priority)
 PATH_add .direnv/bin
@@ -54,4 +137,4 @@ if [ -f .nvmrc ]; then
     fi
 fi
 
-echo "✓ direnv loaded: Python commands intercepted, Node version managed"
+echo "✓ direnv loaded: Python tools intercepted (python, pip, pytest, ruff, mypy), Node version managed"


### PR DESCRIPTION
## Summary

Extends direnv interceptor pattern to pytest, ruff, and mypy. All Python tool interceptors now detect when running from subdirectories with pyproject.toml and warn about potential issues (local .venv creation, import errors).

## Changes

- Add pytest interceptor: bare `pytest` → `uv run pytest`
- Add ruff interceptor: bare `ruff` → `uv run ruff`
- Add mypy interceptor: bare `mypy` → `uv run mypy`
- Update python/python3/pip interceptors with subdirectory detection
- Add PATH filtering to prevent infinite recursion in all interceptors
- Update success message to list all intercepted tools

## Interceptor Pattern

All interceptors use consistent pattern:
1. Detect project root via `git rev-parse --show-toplevel`
2. Warn if running from subdirectory with pyproject.toml
3. Remove .direnv/bin from PATH before exec to prevent recursion
4. Redirect to `uv run <tool>`

## Warning Example

When running from `analyzer/` subdirectory:
```
Warning: Running pytest from subdirectory with pyproject.toml (/path/to/analyzer)
   May cause errors or create local .venv/. To avoid: cd /path/to/root && uv run pytest
```

## Testing

- Tested all 5 interceptors (python, python3, pip, pytest, ruff, mypy) from project root
- Tested all interceptors from analyzer/ subdirectory with pyproject.toml
- Verified no infinite recursion (PATH filtering works correctly)
- Verified warnings display correctly and execution continues
- Created fresh worktree from feature branch and re-tested

## Test Plan

- [ ] CI/CD passes (Python 3.13, Node 24)
- [ ] Interceptors work in both locations (root and subdirectories)
- [ ] No regressions in existing python/pip interceptors

Generated with [Claude Code](https://claude.com/claude-code)