### PR TITLE
chore: Sync all version numbers to 1.1.0-beta.1

### DIFF
--- a/analyzer/src/__init__.py
+++ b/analyzer/src/__init__.py
@@ -7,4 +7,4 @@ This package provides the core analysis engine for DocImp, including:
 - Claude AI integration for documentation generation
 """
 
-__version__ = "1.0.6-α"
+__version__ = "1.1.0b1"

--- a/analyzer/src/main.py
+++ b/analyzer/src/main.py
@@ -1722,7 +1722,7 @@ def main(argv: list | None = None) -> int:
         ),
     )
 
-    parser.add_argument("--version", action="version", version="%(prog)s 1.0.6-α")
+    parser.add_argument("--version", action="version", version="%(prog)s 1.1.0b1")
 
     subparsers = parser.add_subparsers(dest="command", help="Available commands")
 

--- a/analyzer/tests/test_cli.py
+++ b/analyzer/tests/test_cli.py
@@ -50,7 +50,7 @@ class TestCLI:
         assert exc.value.code == 0
         captured = capsys.readouterr()
         assert "analyzer" in captured.out
-        assert "1.0.6-α" in captured.out
+        assert "1.1.0b1" in captured.out
 
     def test_analyze_json_format(self, examples_dir, capsys):
         """Test analyze command with JSON output."""

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docimp-cli",
-  "version": "1.0.6-α",
+  "version": "1.1.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "docimp-cli",
-      "version": "1.0.6-α",
+      "version": "1.1.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@types/prompts": "^2.4.9",

--- a/uv.lock
+++ b/uv.lock
@@ -133,7 +133,7 @@ wheels = [
 
 [[package]]
 name = "docimp-analyzer"
-version = "0.2.0"
+version = "1.1.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

Syncs all version declarations across the codebase to match the official `1.1.0-beta.1` release. The version was bumped in `package.json` and `pyproject.toml` but several files were missed.

### Files Updated
- `analyzer/src/__init__.py`: `1.0.6-α` → `1.1.0b1`
- `analyzer/src/main.py`: `1.0.6-α` → `1.1.0b1`
- `analyzer/tests/test_cli.py`: Update test assertion
- `cli/package-lock.json`: Regenerated via `npm install`
- `uv.lock`: Synced via `uv`

## Test plan
- [x] `pytest analyzer/tests/test_cli.py -v -k version` passes
- [x] Full test suite passes in CI

Generated with [Claude Code](https://claude.com/claude-code)
Steered and validated by @nikblanchet (rubber duck consultant)